### PR TITLE
[ci] Increase ccache size for sanitizer builds

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -113,7 +113,7 @@ runs:
         if ('${{inputs.sanitizers}}') {
           "size=100M" >> $Env:GITHUB_OUTPUT
         } else {
-          "size=30M" >> $Env:GITHUB_OUTPUT
+          "size=50M" >> $Env:GITHUB_OUTPUT
         }
 
     - name: Install CCache

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -111,7 +111,11 @@ runs:
       id: calculate-cache-size
       run: |
         if ('${{inputs.sanitizers}}') {
-          "size=100M" >> $Env:GITHUB_OUTPUT
+          if ($IsWindows) {
+            "size=120M" >> $Env:GITHUB_OUTPUT
+          } else {
+            "size=100M" >> $Env:GITHUB_OUTPUT
+          }
         } else {
           "size=50M" >> $Env:GITHUB_OUTPUT
         }

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -105,12 +105,23 @@ runs:
         $hash = (Get-FileHash -InputStream $stream -Algorithm SHA256).Hash
         "key=${{steps.ccache-key.outputs.key}}-$hash" >> $Env:GITHUB_OUTPUT
 
+    - name: Calculate ccache size
+      if: ${{ inputs.llvm-build-only != 'ON' }}
+      shell: pwsh
+      id: calculate-cache-size
+      run: |
+        if ('${{inputs.sanitizers}}') {
+          "size=100M" >> $Env:GITHUB_OUTPUT
+        } else {
+          "size=30M" >> $Env:GITHUB_OUTPUT
+        }
+
     - name: Install CCache
       if: ${{ inputs.llvm-build-only != 'ON' }}
       uses: Chocobo1/setup-ccache-action@v1
       with:
         ccache_options: |
-          max_size=50M
+          max_size=${{steps.calculate-cache-size.outputs.size}}
           compiler_check=none
         override_cache_key: ${{steps.compiler-hash.outputs.key}}
         windows_compile_environment: msvc


### PR DESCRIPTION
https://github.com/zero9178/Pylir/actions/runs/6132265451/job/16642991389 showed that a lot of cleanups are being performed in a build that should have been almost fully cached. This indicates that the cache is too small.

Increase the ccache size to 100M for sanitizer builds.