### PR TITLE
[ci] Enable merge queue

### DIFF
--- a/.github/workflows/build-and-lint.yml
+++ b/.github/workflows/build-and-lint.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
+  merge_group:
 
 env:
   LLVM_LINT_VERSION: 15


### PR DESCRIPTION
Having a merge queue allows us to drop the requirement for a branch to be up-to-date to merge a PR. Rather, if it has no conflicts, it gets added to the queue and automatically tested on top of `main`. This automates things a lot as we can just push PRs to the queue and wait for it to get merged together with other PRs.