### PR TITLE
[ci] add missing permissions to cron job

### DIFF
--- a/.github/workflows/llvm-cron.yml
+++ b/.github/workflows/llvm-cron.yml
@@ -1,5 +1,8 @@
 name: LLVM Cron
 
+permissions:
+  actions: write
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
The cron job calls the llvm-build workflow which requires `actions: write` permissions. As the cron job did not have such permissions, calling it lead to an error.

Update the permissions to fix the error. Note that the write action is used by the `ccache` action to remove stale caches.