### PR TITLE
[Py] Split `ConstObjectAttrInterface` from `ObjectAttrInterface`

### DIFF
--- a/src/pylir/CodeGen/PyBuilder.hpp
+++ b/src/pylir/CodeGen/PyBuilder.hpp
@@ -508,7 +508,7 @@ public:
     }
 
     Py::GlobalValueOp createGlobalValue(llvm::StringRef symbolName, bool constant = false,
-                                        Py::ObjectAttrInterface initializer = {}, bool external = false)
+                                        Py::ConstObjectAttrInterface initializer = {}, bool external = false)
     {
         return create<Py::GlobalValueOp>(symbolName, external ? mlir::StringAttr{} : getStringAttr("private"), constant,
                                          initializer);

--- a/src/pylir/Optimizer/Conversion/PylirToLLVMIR/CodeGenState.cpp
+++ b/src/pylir/Optimizer/Conversion/PylirToLLVMIR/CodeGenState.cpp
@@ -213,7 +213,7 @@ mlir::Value pylir::CodeGenState::createRuntimeCall(mlir::Location loc, mlir::OpB
 }
 
 void pylir::CodeGenState::initializeGlobal(mlir::LLVM::GlobalOp global, mlir::OpBuilder& builder,
-                                           Py::ObjectAttrInterface objectAttr)
+                                           Py::ConstObjectAttrInterface objectAttr)
 {
     builder.setInsertionPointToStart(&global.getInitializerRegion().emplaceBlock());
     mlir::Value undef = builder.create<mlir::LLVM::UndefOp>(global.getLoc(), global.getType());
@@ -492,11 +492,11 @@ mlir::Value pylir::CodeGenState::getConstant(mlir::Location loc, mlir::OpBuilder
 
     return builder.create<mlir::LLVM::AddressOfOp>(
         loc, m_objectPtrType,
-        mlir::FlatSymbolRefAttr::get(createGlobalConstant(builder, attribute.cast<Py::ObjectAttrInterface>())));
+        mlir::FlatSymbolRefAttr::get(createGlobalConstant(builder, attribute.cast<Py::ConstObjectAttrInterface>())));
 }
 
 mlir::LLVM::GlobalOp pylir::CodeGenState::createGlobalConstant(mlir::OpBuilder& builder,
-                                                               Py::ObjectAttrInterface objectAttr)
+                                                               Py::ConstObjectAttrInterface objectAttr)
 {
     if (auto globalOp = m_globalConstants.lookup(objectAttr))
     {

--- a/src/pylir/Optimizer/Conversion/PylirToLLVMIR/CodeGenState.hpp
+++ b/src/pylir/Optimizer/Conversion/PylirToLLVMIR/CodeGenState.hpp
@@ -59,7 +59,7 @@ class CodeGenState
 
     void appendToGlobalInit(mlir::OpBuilder& builder, llvm::function_ref<void()> section);
 
-    mlir::LLVM::GlobalOp createGlobalConstant(mlir::OpBuilder& builder, pylir::Py::ObjectAttrInterface objectAttr);
+    mlir::LLVM::GlobalOp createGlobalConstant(mlir::OpBuilder& builder, pylir::Py::ConstObjectAttrInterface objectAttr);
 
 public:
     CodeGenState(PylirTypeConverter& typeConverter, mlir::ModuleOp module)
@@ -113,7 +113,7 @@ public:
 
     /// Generates code to create the initializer region for 'global' with the compile time constant 'objectAttr'.
     void initializeGlobal(mlir::LLVM::GlobalOp global, mlir::OpBuilder& builder,
-                          pylir::Py::ObjectAttrInterface objectAttr);
+                          pylir::Py::ConstObjectAttrInterface objectAttr);
 
     /// Generates code to translate the compile time constant 'attribute' to an PyObject pointer in LLVM and returns it.
     /// Attribute may be any kind of attribute from the 'py' dialect.

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrBase.hpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrBase.hpp
@@ -9,7 +9,7 @@
 
 namespace pylir::Py
 {
-class ObjectAttrInterface;
+class ConstObjectAttrInterface;
 class GlobalValueOp;
 namespace detail
 {

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrBase.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrBase.td
@@ -121,7 +121,7 @@ def PylirPy_GlobalValueAttr : AttrDef<PylirPy_Dialect, "GlobalValue", [NativeAtt
 
     let parameters = (ins StringRefParameter<>:$name,
                           DefaultValuedParameter<"bool", "false">:$constant,
-                          OptionalParameter<"pylir::Py::ObjectAttrInterface">:$initializer);
+                          OptionalParameter<"ConstObjectAttrInterface">:$initializer);
 
     // Required to make it properly mutable.
     let genStorageClass = 0;
@@ -138,7 +138,7 @@ def PylirPy_GlobalValueAttr : AttrDef<PylirPy_Dialect, "GlobalValue", [NativeAtt
         void setConstant(bool constant);
 
         /// Sets the initializer of this global value.
-        void setInitializer(ObjectAttrInterface initializer);
+        void setInitializer(ConstObjectAttrInterface initializer);
     }];
 
     let builders = [

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrInterfaces.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrInterfaces.td
@@ -10,9 +10,40 @@ include "mlir/IR/OpBase.td"
 def ObjectAttrInterface : AttrInterface<"ObjectAttrInterface"> {
     let cppNamespace = "::pylir::Py";
 
+    let description = [{
+        This interface is the base interface used by all object attributes and interfaces.
+        It represents the immutable properties of all python object attributes.
+    }];
+
     let methods = [
-        InterfaceMethod<[{}], "::pylir::Py::RefAttr", "getTypeObject", (ins)>,
-        InterfaceMethod<[{}], "::mlir::DictionaryAttr", "getSlots", (ins)>
+        InterfaceMethod<[{
+            Returns the `#py.ref` referring to the type object of this attribute.
+            Mustn't be null.
+        }], "::pylir::Py::RefAttr", "getTypeObject", (ins)>
+    ];
+}
+
+def ConstObjectAttrInterface : AttrInterface<"ConstObjectAttrInterface", [ObjectAttrInterface]> {
+    let cppNamespace = "::pylir::Py";
+
+    let description = [{
+        This interface is a specialization of `ObjectAttrInterface`, representing instances of constant python objects.
+        Note that "constant" here refers to constant in the IR and compiler sense, as in, a known value that cannot
+        change, not immutable in the Python sense (e.g. a tuple). This interface is therefore implemented by all
+        concrete object attributes including attributes used to represent otherwise mutable objects as attributes
+        such as `#py.dict`.
+
+        The methods on this interface are intended to return data that would only be valid on a constant as its
+        value may change throughout the program otherwise. Immutable data is accessible via the `ObjectAttrInterface`.
+
+        Implies an implementation of `ObjectAttrInterface`.
+    }];
+
+    let methods = [
+        InterfaceMethod<[{
+            Returns a dictionary containing all slots of the attribute.
+            Mustn't be null.
+        }], "::mlir::DictionaryAttr", "getSlots", (ins)>
     ];
 }
 

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.cpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.cpp
@@ -131,7 +131,7 @@ struct GlobalValueAttrStorage : mlir::AttributeStorage
         return mlir::success();
     }
 
-    mlir::LogicalResult mutate(mlir::AttributeStorageAllocator&, ObjectAttrInterface attribute)
+    mlir::LogicalResult mutate(mlir::AttributeStorageAllocator&, ConstObjectAttrInterface attribute)
     {
         initializer = attribute;
         return mlir::success();
@@ -139,7 +139,7 @@ struct GlobalValueAttrStorage : mlir::AttributeStorage
 
     llvm::StringRef name;
     bool constant;
-    mlir::Attribute initializer;
+    ConstObjectAttrInterface initializer;
 };
 
 } // namespace pylir::Py::detail
@@ -183,7 +183,7 @@ mlir::Attribute pylir::Py::GlobalValueAttr::parse(::mlir::AsmParser& parser, ::m
 
     // Default values.
     bool constant = false;
-    ObjectAttrInterface initializer = {};
+    ConstObjectAttrInterface initializer = {};
 
     while (mlir::succeeded(parser.parseOptionalComma()))
     {
@@ -268,12 +268,12 @@ void pylir::Py::GlobalValueAttr::setConstant(bool constant)
     (void)Base::mutate(constant);
 }
 
-pylir::Py::ObjectAttrInterface pylir::Py::GlobalValueAttr::getInitializer() const
+pylir::Py::ConstObjectAttrInterface pylir::Py::GlobalValueAttr::getInitializer() const
 {
-    return mlir::cast_or_null<ObjectAttrInterface>(getImpl()->initializer);
+    return getImpl()->initializer;
 }
 
-void pylir::Py::GlobalValueAttr::setInitializer(pylir::Py::ObjectAttrInterface initializer)
+void pylir::Py::GlobalValueAttr::setInitializer(ConstObjectAttrInterface initializer)
 {
     (void)Base::mutate(initializer);
 }

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.td
@@ -29,7 +29,8 @@ class PylirPy_PyObjAttr<string name,
     list<Trait> traits = [],
     AttrInterface base = ObjectAttrInterface,
     bit hasSlots = 1>
-    : PylirPy_Attr<name, !listconcat(traits, [base, DeclareAttrInterfaceMethods<SROAAttrInterface>])>
+    : PylirPy_Attr<name, !listconcat(traits, [base, ConstObjectAttrInterface,
+     DeclareAttrInterfaceMethods<SROAAttrInterface>])>
 {
     /// The default builder usually has the same parameter types as the ones declared with default arguments.
     /// This leads to build errors due to being a redeclaration of a method. Turn it off for the vast majority of
@@ -273,7 +274,7 @@ def PylirPy_ListAttr : PylirPy_PyObjAttr<"List"> {
     ];
 }
 
-def PylirPy_DictAttr : PylirPy_Attr<"Dict", [ObjectAttrInterface,
+def PylirPy_DictAttr : PylirPy_Attr<"Dict", [ConstObjectAttrInterface,
     DeclareAttrInterfaceMethods<SROAAttrInterface>]> {
 
     let mnemonic = "dict";
@@ -368,7 +369,8 @@ def PylirPy_DictAttr : PylirPy_Attr<"Dict", [ObjectAttrInterface,
 }
 
 def PylirPy_FunctionAttr : PylirPy_Attr<"Function", [ImmutableAttr,
-    DeclareAttrInterfaceMethods<ObjectAttrInterface>, DeclareAttrInterfaceMethods<SROAAttrInterface>]>
+    DeclareAttrInterfaceMethods<ObjectAttrInterface>, DeclareAttrInterfaceMethods<ConstObjectAttrInterface>,
+    DeclareAttrInterfaceMethods<SROAAttrInterface>]>
 {
 	let mnemonic = "function";
 	let summary = "python function";

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyOpFold.cpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyOpFold.cpp
@@ -162,7 +162,7 @@ mlir::Attribute foldGetSlot(mlir::MLIRContext* context, mlir::Attribute objectOp
     }
     auto index = intAttr.getValue();
 
-    auto object = ref_cast_or_null<ObjectAttrInterface>(objectOp);
+    auto object = ref_cast_or_null<ConstObjectAttrInterface>(objectOp);
     if (!object)
     {
         return nullptr;

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyOpSROA.cpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyOpSROA.cpp
@@ -68,7 +68,7 @@ void replaceDictAggregate(T op, mlir::OpBuilder& builder,
 }
 
 void destructureSlots(
-    pylir::Py::ObjectAttrInterface attr,
+    pylir::Py::ConstObjectAttrInterface attr,
     llvm::function_ref<void(mlir::Attribute, mlir::SideEffects::Resource*, mlir::Type, mlir::Attribute)> write)
 {
     for (const auto& iter : attr.getSlots())

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyOps.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyOps.td
@@ -1129,7 +1129,7 @@ def PylirPy_GlobalValueOp : PylirPy_Op<"globalValue", [DeclareOpInterfaceMethods
             SymbolNameAttr:$sym_name,
             OptionalAttr<StrAttr>:$sym_visibility,
             UnitAttr:$constant,
-            OptionalAttr<ObjectAttrInterface>:$initializer);
+            OptionalAttr<ConstObjectAttrInterface>:$initializer);
 
     let results = (outs);
 

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyOpsVerifier.cpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyOpsVerifier.cpp
@@ -53,11 +53,14 @@ mlir::LogicalResult verify(mlir::Operation* op, mlir::Attribute attribute, mlir:
     {
         return mlir::failure();
     }
-    for (auto iter : object.getSlots())
+    if (auto constantObjectAttr = mlir::dyn_cast<pylir::Py::ConstObjectAttrInterface>(attribute))
     {
-        if (mlir::failed(verify(op, iter.getValue(), collection)))
+        for (auto iter : constantObjectAttr.getSlots())
         {
-            return mlir::failure();
+            if (mlir::failed(verify(op, iter.getValue(), collection)))
+            {
+                return mlir::failure();
+            }
         }
     }
     return llvm::TypeSwitch<mlir::Attribute, mlir::LogicalResult>(object)

--- a/src/pylir/Optimizer/PylirPy/Transforms/FoldGlobals.cpp
+++ b/src/pylir/Optimizer/PylirPy/Transforms/FoldGlobals.cpp
@@ -33,7 +33,7 @@ protected:
 
 private:
     pylir::Py::GlobalValueOp createGlobalValueFromGlobal(pylir::Py::GlobalOp globalOp,
-                                                         pylir::Py::ObjectAttrInterface initializer, bool constant)
+                                                         pylir::Py::ConstObjectAttrInterface initializer, bool constant)
     {
         PYLIR_ASSERT(globalOp.getType().isa<pylir::Py::DynamicType>());
         mlir::OpBuilder builder(globalOp);
@@ -86,7 +86,7 @@ private:
         singleStore->erase();
 
         // Create the global value if the constant was not a reference but a constant object.
-        if (auto initializer = attr.dyn_cast<pylir::Py::ObjectAttrInterface>())
+        if (auto initializer = attr.dyn_cast<pylir::Py::ConstObjectAttrInterface>())
         {
             // Link the RefAttr created above as well.
             pylir::Py::RefAttr::get(createGlobalValueFromGlobal(globalOp, initializer, true));


### PR DESCRIPTION
The primary motivation for this change is that `getSlots` is only valid if we know that the python object being represented by the attribute is a constant. This is most notably not the case for `#py.globalValue` or `#py.ref` that isn't marked `const` or is not initialized with a constant object.