### PR TITLE
[ci] make sure `clang-format` errors properly on changes

### DIFF
--- a/.github/workflows/build-and-lint.yml
+++ b/.github/workflows/build-and-lint.yml
@@ -249,6 +249,11 @@ jobs:
           git diff -U0 HEAD^ :^3rdParty '***.c' '***.h' '***.hpp' '***.cpp' \
            | ${{github.workspace}}/util/clang-format-diff.py -p1 -binary $(which clang-format-$LLVM_LINT_VERSION) \
            | tee ${{github.workspace}}/clang-format.patch
+          
+          if [ -s ${{github.workspace}}/clang-format.patch ] 
+          then
+            exit 1
+          fi
 
       - name: Upload clang-format patch
         if: ${{ failure() }}


### PR DESCRIPTION
This is done with a similar approach as with `clang-tidy` where we check if an output is produced by the tool (in the case of `clang-format` a diff, in `clang-tidy` a `fixes.yml`), and if it is not empty, assume that a change is necessary.