### PR TITLE
Create `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Change clang-format and clang-tidy config for the whole codebase (#61)
+85fcfd01ef996f7fb126906786b49b1eb12c6926


### PR DESCRIPTION
This allows completely ignoring the large formatting changes in `git blame`