### PR TITLE
Bump MLIR version

### DIFF
--- a/.pinned-llvm-revision
+++ b/.pinned-llvm-revision
@@ -1,1 +1,1 @@
-0f052a972ebe9bdf2c1eb56bddf6abb04eec50d6
+be59265bbde77bba40599f114a6bedfe91da5c07


### PR DESCRIPTION
Includes fixes for `extraClassOf` of attribute and type interfaces + fixing the implicit conversion operator for null interfaces