### PR TITLE
[Py] Add implementations of object attribute interfaces to `RefAttr`

### DIFF
--- a/src/pylir/CodeGen/PyBuilder.hpp
+++ b/src/pylir/CodeGen/PyBuilder.hpp
@@ -468,7 +468,7 @@ public:
 
   Py::GlobalValueOp
   createGlobalValue(llvm::StringRef symbolName, bool constant = false,
-                    Py::ConstObjectAttrInterface initializer = {},
+                    Py::ConcreteObjectAttrInterface initializer = {},
                     bool external = false) {
     return create<Py::GlobalValueOp>(
         symbolName, external ? mlir::StringAttr{} : getStringAttr("private"),

--- a/src/pylir/Optimizer/PylirPy/IR/CMakeLists.txt
+++ b/src/pylir/Optimizer/PylirPy/IR/CMakeLists.txt
@@ -27,6 +27,10 @@ add_pylir_doc(PylirPyOps.td PylirPyDialect Dialect/ -gen-dialect-doc
 add_pylir_interface(ATTR PylirPyAttrInterfaces)
 add_pylir_rewriter(PylirPyPatterns)
 
+set(LLVM_TARGET_DEFINITIONS PylirPyAttrInterfaces.td)
+pylir_tablegen(PylirPyWrapInterfaces.h.inc -gen-wrap-interfaces)
+add_public_tablegen_target(PylirPyWrapInterfacesIncGen)
+
 add_library(PylirPyDialect
   PylirPyAttrInterfaces.cpp
   PylirPyAttributes.cpp
@@ -43,6 +47,7 @@ add_dependencies(PylirPyDialect
   PylirPyIncGen
   PylirPyPatternsIncGen
   PylirPyAttrInterfacesIncGen
+  PylirPyWrapInterfacesIncGen
 )
 target_link_libraries(PylirPyDialect
   PUBLIC

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrBase.hpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrBase.hpp
@@ -8,7 +8,7 @@
 #include <mlir/IR/BuiltinAttributes.h>
 
 namespace pylir::Py {
-class ConstObjectAttrInterface;
+class ConcreteObjectAttrInterface;
 class GlobalValueOp;
 namespace detail {
 struct GlobalValueAttrStorage;

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrBase.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrBase.td
@@ -139,7 +139,7 @@ def PylirPy_GlobalValueAttr : AttrDef<PylirPy_Dialect, "GlobalValue",
 
   let parameters = (ins StringRefParameter<>:$name,
               DefaultValuedParameter<"bool", "false">:$constant,
-              OptionalParameter<"ConstObjectAttrInterface">:$initializer);
+              OptionalParameter<"ConcreteObjectAttrInterface">:$initializer);
 
   // Required to make it properly mutable.
   let genStorageClass = 0;
@@ -158,7 +158,7 @@ def PylirPy_GlobalValueAttr : AttrDef<PylirPy_Dialect, "GlobalValue",
     void setConstant(bool constant);
 
     /// Sets the initializer of this global value.
-    void setInitializer(ConstObjectAttrInterface initializer);
+    void setInitializer(ConcreteObjectAttrInterface initializer);
   }];
 
   let builders = [

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrInterfaces.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrInterfaces.td
@@ -7,7 +7,39 @@
 
 include "mlir/IR/OpBase.td"
 
-def ObjectAttrInterface : AttrInterface<"ObjectAttrInterface"> {
+/// Base class for all attribute interfaces that should also be able to be
+/// implementable by `RefAttr`. Any `RefAttr` that refers to a symbol that
+/// implements a given interface automatically implements that interface as
+/// well. If the attribute is a "sub-interface" of `ConstObjectAttrInterface`,
+/// then the symbol referred to by the `RefAttr` must additionally be constant.
+class RefAttrImplementable<string name, list<Interface> baseInterfaces = []>
+  : AttrInterface<name, baseInterfaces> {
+
+  /// Interface method that should be appended to the methods array of any
+  /// subclass of `RefAttrImplementable`. It automatically adds the necessary
+  /// hooks to allow `RefAttr` to implement the interface.
+  InterfaceMethod canImplementMethod = InterfaceMethod<[{
+    This method is used by the `classof` mechanism of the given interface
+    implementation to allow an implementation to dynamically determine whether
+    it implements the given interface.
+    The implementation has a parameter containing the interface type to avoid
+    clashing with the corresponding method of any other interface implemented.
+
+    Returns true for attributes where the interface is directly attached to in
+    ODS.
+  }], "bool", "canImplement",
+    (ins "std::in_place_type_t<" # cppNamespace # "::" # name # ">":$tagType),
+     [{
+    return true;
+  }]>;
+
+  let extraClassOf = [{
+    return $_attr.canImplement(std::in_place_type<}]
+      # cppNamespace # "::" # name # [{>);
+  }];
+}
+
+def ObjectAttrInterface : RefAttrImplementable<"ObjectAttrInterface"> {
   let cppNamespace = "::pylir::Py";
 
   let description = [{
@@ -20,11 +52,13 @@ def ObjectAttrInterface : AttrInterface<"ObjectAttrInterface"> {
     InterfaceMethod<[{
       Returns the `#py.ref` referring to the type object of this attribute.
       Mustn't be null.
-    }], "::pylir::Py::RefAttr", "getTypeObject", (ins)>
+    }], "::pylir::Py::RefAttr", "getTypeObject", (ins)>,
+    canImplementMethod
   ];
 }
 
-def ConstObjectAttrInterface : AttrInterface<"ConstObjectAttrInterface", [ObjectAttrInterface]> {
+def ConstObjectAttrInterface : RefAttrImplementable<"ConstObjectAttrInterface",
+  [ObjectAttrInterface]> {
   let cppNamespace = "::pylir::Py";
 
   let description = [{
@@ -49,11 +83,26 @@ def ConstObjectAttrInterface : AttrInterface<"ConstObjectAttrInterface", [Object
     InterfaceMethod<[{
       Returns a dictionary containing all slots of the attribute.
       Mustn't be null.
-    }], "::mlir::DictionaryAttr", "getSlots", (ins)>
+    }], "::mlir::DictionaryAttr", "getSlots", (ins)>,
+    canImplementMethod
   ];
 }
 
-def IntAttrInterface : AttrInterface<"IntAttrInterface",
+def ConcreteObjectAttrInterface : AttrInterface<"ConcreteObjectAttrInterface",
+  [ConstObjectAttrInterface]> {
+  let cppNamespace = "pylir::Py";
+
+  let description = [{
+    This interface is implemented by all attributes that represent concrete
+    python objects. It is most notably not implemented by `RefAttr`.
+
+    This interface doesn't have any methods but is rather used as a marker
+    or trait that additionally also implies an implementation of
+    `ConstObjectAttrInterface`.
+  }];
+}
+
+def IntAttrInterface : RefAttrImplementable<"IntAttrInterface",
   [ObjectAttrInterface]> {
   let cppNamespace = "::pylir::Py";
 
@@ -66,14 +115,16 @@ def IntAttrInterface : AttrInterface<"IntAttrInterface",
     InterfaceMethod<[{
       Returns the big integer value of this attribute.
     }],
-    "pylir::BigInt", "getInteger", (ins)>
+    "pylir::BigInt", "getInteger", (ins)>,
+    canImplementMethod
   ];
 
   let returnType = "pylir::BigInt";
   let convertFromStorage = "$_self.getInteger()";
 }
 
-def BoolAttrInterface : AttrInterface<"BoolAttrInterface", [IntAttrInterface]> {
+def BoolAttrInterface : RefAttrImplementable<"BoolAttrInterface",
+  [IntAttrInterface]> {
   let cppNamespace = "::pylir::Py";
 
   let description = [{
@@ -86,7 +137,8 @@ def BoolAttrInterface : AttrInterface<"BoolAttrInterface", [IntAttrInterface]> {
     InterfaceMethod<[{
       Returns the boolean value of this attribute.
     }],
-    "bool", "getBoolean", (ins)>
+    "bool", "getBoolean", (ins)>,
+    canImplementMethod
   ];
 
   let returnType = "bool";

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.td
@@ -35,7 +35,7 @@ class PylirPy_PyObjAttr<string name,
   list<Trait> traits = [],
   AttrInterface base = ObjectAttrInterface,
   bit hasSlots = 1>
-  : PylirPy_Attr<name, !listconcat(traits, [base, ConstObjectAttrInterface,
+  : PylirPy_Attr<name, !listconcat(traits, [base, ConcreteObjectAttrInterface,
    DeclareAttrInterfaceMethods<SROAAttrInterface>])>
 {
   /// The default builder usually has the same parameter types as the ones
@@ -295,7 +295,7 @@ def PylirPy_ListAttr : PylirPy_PyObjAttr<"List"> {
   ];
 }
 
-def PylirPy_DictAttr : PylirPy_Attr<"Dict", [ConstObjectAttrInterface,
+def PylirPy_DictAttr : PylirPy_Attr<"Dict", [ConcreteObjectAttrInterface,
   DeclareAttrInterfaceMethods<SROAAttrInterface>]> {
 
   let mnemonic = "dict";
@@ -406,7 +406,7 @@ def PylirPy_DictAttr : PylirPy_Attr<"Dict", [ConstObjectAttrInterface,
 }
 
 def PylirPy_FunctionAttr : PylirPy_Attr<"Function", [ImmutableAttr,
-  DeclareAttrInterfaceMethods<ObjectAttrInterface>,
+  ConcreteObjectAttrInterface, DeclareAttrInterfaceMethods<ObjectAttrInterface>,
   DeclareAttrInterfaceMethods<ConstObjectAttrInterface>,
   DeclareAttrInterfaceMethods<SROAAttrInterface>]>
 {

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyOps.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyOps.td
@@ -101,7 +101,7 @@ def DictResource : Resource<"::pylir::Py::DictResource">;
 def PylirPy_ConstantOp : PylirPy_Op<"constant", [ConstantLike, NoMemoryEffect,
   KnownType<"Tuple">, DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let arguments = (ins AnyAttrOf<[PylirPy_UnboundAttr, ObjectAttrInterface,
-                  PylirPy_RefAttr, PylirPy_GlobalValueAttr]>:$constant);
+    PylirPy_RefAttr, PylirPy_GlobalValueAttr]>:$constant);
   let results = (outs DynamicType:$result);
 
   let assemblyFormat = [{
@@ -1240,7 +1240,7 @@ def PylirPy_GlobalValueOp : PylirPy_Op<"globalValue", [
       SymbolNameAttr:$sym_name,
       OptionalAttr<StrAttr>:$sym_visibility,
       UnitAttr:$constant,
-      OptionalAttr<ConstObjectAttrInterface>:$initializer);
+      OptionalAttr<ConcreteObjectAttrInterface>:$initializer);
 
   let results = (outs);
 

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyOpsVerifier.cpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyOpsVerifier.cpp
@@ -30,15 +30,16 @@ verifySymbolUse(mlir::Operation* op, mlir::SymbolRefAttr name,
 
 mlir::LogicalResult verify(mlir::Operation* op, mlir::Attribute attribute,
                            mlir::SymbolTableCollection& collection) {
+  if (auto ref = attribute.dyn_cast<pylir::Py::RefAttr>()) {
+    if (!ref.getSymbol())
+      return op->emitOpError("RefAttr '")
+             << ref.getRef() << "' does not refer to a 'py.globalValue'";
+
+    return mlir::success();
+  }
+
   auto object = attribute.dyn_cast<pylir::Py::ObjectAttrInterface>();
   if (!object) {
-    if (auto ref = attribute.dyn_cast<pylir::Py::RefAttr>()) {
-      if (!ref.getSymbol())
-        return op->emitOpError("RefAttr '")
-               << ref.getRef() << "' does not refer to a 'py.globalValue'";
-
-      return mlir::success();
-    }
     if (!attribute.isa<pylir::Py::UnboundAttr, pylir::Py::GlobalValueAttr>())
       return op->emitOpError("Not allowed attribute '")
              << attribute << "' found\n";

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyPatterns.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyPatterns.td
@@ -9,9 +9,7 @@ include "mlir/IR/PatternBase.td"
 include "mlir/Dialect/Arith/IR/ArithOps.td"
 include "pylir/Optimizer/PylirPy/IR/PylirPyOps.td"
 
-class ResolvesTo<int constOnly = 1>
-	: NativeCodeCall<"::resolvesToPattern($_self, $0, "
-	    # !if(constOnly, "true", "false") # ")">;
+def ResolvesTo : NativeCodeCall<"::resolvesToPattern($_self, $0)">;
 
 def prependTupleConst
   : NativeCodeCall<"prependTupleConst($_builder, $_loc, $0, $1)">;
@@ -27,7 +25,7 @@ def : Pat<(PylirPy_TuplePrependOp $input,
        }() }]> $input, $args), ConstantAttr<DenseI32ArrayAttr, "{}">)>;
 
 def : Pat<(PylirPy_TuplePrependOp $input,
-            (ResolvesTo<0> PylirPy_TupleAttr:$args)),
+            (ResolvesTo PylirPy_TupleAttr:$args)),
               (prependTupleConst $input, $args)>;
 
 def : Pat<(PylirPy_TupleDropFrontOp (ConstantLikeMatcher IndexAttr:$count),
@@ -117,7 +115,7 @@ foreach lhs = [PylirPy_IntFromUnsignedOp, PylirPy_IntFromSignedOp] in {
 // Index -> Arith_CmpIOp $kind, $lhs, (index)$rhs
 foreach lhs = [PylirPy_IntFromUnsignedOp, PylirPy_IntFromSignedOp] in {
   def : Pat<(PylirPy_IntCmpOp:$op $kind, (lhs $lhs),
-    (ResolvesTo<0> IntAttrInterface:$rhs)),
+    (ConstantLikeMatcher IntAttrInterface:$rhs)),
        (Arith_CmpIOp (NativeCodeCall<"toArithPredicate($0)"> $kind), $lhs,
          (Arith_ConstantOp
           (NativeCodeCall<"toBuiltinInt($0.getOwner(), $1, $2.getType())">
@@ -157,13 +155,13 @@ def : Pat<(PylirPy_IsUnboundValueOp (SelectOp $cond, $lhs, $rhs)),
       }]>> $lhs, $rhs)]>;
 
 multiclass IntCommAndAssocPattern<Op op, string operator> {
-	def : Pat<(op (op $op, (ResolvesTo<0> IntAttrInterface:$first)), (
-	  ResolvesTo<0> IntAttrInterface:$second)), (op $op,
+	def : Pat<(op (op $op, (ConstantLikeMatcher IntAttrInterface:$first)), (
+	  ConstantLikeMatcher IntAttrInterface:$second)), (op $op,
 			(PylirPy_ConstantOp (BinOpAttrs<operator, IntAttrInterface,
 			  PylirPy_IntAttr> $first, $second)))>;
 
-	def : Pat<(op (op $x, (ResolvesTo<0> IntAttrInterface:$first)), (op $y,
-	  (ResolvesTo<0> IntAttrInterface:$second))), (op (op $x, $y),
+	def : Pat<(op (op $x, (ConstantLikeMatcher IntAttrInterface:$first)), (op $y,
+	  (ConstantLikeMatcher IntAttrInterface:$second))), (op (op $x, $y),
 			(PylirPy_ConstantOp
 			  (BinOpAttrs<operator, IntAttrInterface, PylirPy_IntAttr>
 			    $first, $second)))>;

--- a/src/pylir/Optimizer/PylirPy/IR/Value.cpp
+++ b/src/pylir/Optimizer/PylirPy/IR/Value.cpp
@@ -12,6 +12,8 @@
 #include "PylirPyAttributes.hpp"
 #include "PylirPyTraits.hpp"
 
+using namespace mlir;
+
 mlir::OpFoldResult pylir::Py::getTypeOf(mlir::Value value) {
   if (auto op = value.getDefiningOp<pylir::Py::KnownTypeObjectInterface>())
     return op.getKnownTypeObject();
@@ -118,8 +120,7 @@ mlir::Attribute pylir::Py::getCanonicalEqualsForm(mlir::Attribute attribute) {
                                  ref_cast<StrAttr>(attribute).getValue());
   case BuiltinMethodKind::Int:
     return FractionalAttr::get(attribute.getContext(),
-                               ref_cast<IntAttr>(attribute).getValue(),
-                               BigInt(1));
+        dyn_cast<IntAttrInterface>(attribute).getInteger(), BigInt(1));
   case BuiltinMethodKind::Float:
     auto [nom, denom] =
         toRatio(ref_cast<FloatAttr>(attribute).getDoubleValue());

--- a/src/pylir/Optimizer/PylirPy/IR/Value.cpp
+++ b/src/pylir/Optimizer/PylirPy/IR/Value.cpp
@@ -119,7 +119,8 @@ mlir::Attribute pylir::Py::getCanonicalEqualsForm(mlir::Attribute attribute) {
     return mlir::StringAttr::get(attribute.getContext(),
                                  ref_cast<StrAttr>(attribute).getValue());
   case BuiltinMethodKind::Int:
-    return FractionalAttr::get(attribute.getContext(),
+    return FractionalAttr::get(
+        attribute.getContext(),
         dyn_cast<IntAttrInterface>(attribute).getInteger(), BigInt(1));
   case BuiltinMethodKind::Float:
     auto [nom, denom] =

--- a/src/pylir/Optimizer/PylirPy/Transforms/FoldGlobals.cpp
+++ b/src/pylir/Optimizer/PylirPy/Transforms/FoldGlobals.cpp
@@ -33,8 +33,8 @@ protected:
   void runOnOperation() override;
 
 private:
-  pylir::Py::GlobalValueOp
-  createGlobalValueFromGlobal(pylir::Py::GlobalOp globalOp,
+  pylir::Py::GlobalValueOp createGlobalValueFromGlobal(
+      pylir::Py::GlobalOp globalOp,
       pylir::Py::ConcreteObjectAttrInterface initializer, bool constant) {
     PYLIR_ASSERT(globalOp.getType().isa<pylir::Py::DynamicType>());
     mlir::OpBuilder builder(globalOp);

--- a/src/pylir/Optimizer/PylirPy/Transforms/FoldGlobals.cpp
+++ b/src/pylir/Optimizer/PylirPy/Transforms/FoldGlobals.cpp
@@ -16,6 +16,9 @@
 
 #include "Passes.hpp"
 
+using namespace mlir;
+using namespace pylir::Py;
+
 namespace pylir::Py {
 #define GEN_PASS_DEF_FOLDGLOBALSPASS
 #include "pylir/Optimizer/PylirPy/Transforms/Passes.h.inc"
@@ -32,8 +35,7 @@ protected:
 private:
   pylir::Py::GlobalValueOp
   createGlobalValueFromGlobal(pylir::Py::GlobalOp globalOp,
-                              pylir::Py::ConstObjectAttrInterface initializer,
-                              bool constant) {
+      pylir::Py::ConcreteObjectAttrInterface initializer, bool constant) {
     PYLIR_ASSERT(globalOp.getType().isa<pylir::Py::DynamicType>());
     mlir::OpBuilder builder(globalOp);
     return builder.create<pylir::Py::GlobalValueOp>(
@@ -86,8 +88,7 @@ private:
 
     // Create the global value if the constant was not a reference but a
     // constant object.
-    if (auto initializer =
-            attr.dyn_cast<pylir::Py::ConstObjectAttrInterface>()) {
+    if (auto initializer = dyn_cast<ConcreteObjectAttrInterface>(attr)) {
       // Link the RefAttr created above as well.
       pylir::Py::RefAttr::get(
           createGlobalValueFromGlobal(globalOp, initializer, true));

--- a/tools/pylir-tblgen/CMakeLists.txt
+++ b/tools/pylir-tblgen/CMakeLists.txt
@@ -4,8 +4,9 @@
 
 add_tablegen(pylir-tblgen PYLIR
   IntrinsicGen.cpp
-  main.cpp
   OpVariableDecoratorGen.cpp
+  WrapInterfaceGen.cpp
+  main.cpp
 )
 target_link_libraries(pylir-tblgen
   PRIVATE

--- a/tools/pylir-tblgen/WrapInterfaceGen.cpp
+++ b/tools/pylir-tblgen/WrapInterfaceGen.cpp
@@ -1,0 +1,120 @@
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <mlir/Support/IndentedOstream.h>
+#include <mlir/TableGen/Class.h>
+#include <mlir/TableGen/GenInfo.h>
+#include <mlir/TableGen/Interfaces.h>
+
+#include <llvm/TableGen/Error.h>
+#include <llvm/TableGen/Record.h>
+#include <llvm/TableGen/TableGenBackend.h>
+
+using namespace mlir;
+using namespace mlir::tblgen;
+
+/// This method generates specializations of `WrapInterface`, which allows
+/// an attribute to implement a `FallbackModel` of a given interface through
+/// metaprogramming techniques. The default implementation calls
+/// `getUnderlying` on the model implementation, which must return an attribute
+/// implementing the given interface that the method call is forwarded to.
+///
+/// It is also possible to override the implementation of a method through by
+/// simply declaring and defining the method as with the usual mechanism.
+///
+/// template <class Self>
+/// struct WrapInterface<Self, {0}>
+///     : {0}::FallbackModel<Self> {
+///
+///   ret name(Attribute thisAttr, args...) const {
+///     return static_cast<const Self*>(this)->getUnderlying(thisAttr)
+///       .name(args...);
+///   }
+///   ...
+/// };
+static void generateWrapStructures(ArrayRef<llvm::Record*> defs,
+                                   llvm::raw_ostream& rawOs) {
+  IfDefScope scope("GEN_WRAP_CLASSES", rawOs);
+
+  // Declaration of the primary template.
+  rawOs << "template <class Self, class Interface> struct WrapInterface;\n\n";
+
+  for (llvm::Record* iter : defs) {
+    AttrInterface interface(iter);
+
+    // Self refers to the actual model that inherits from a `WrapInterface`.
+    Class clazz(llvm::formatv("WrapInterface<Self, {0}>",
+                              interface.getFullyQualifiedName()),
+                /*isStruct=*/true);
+    clazz.addTemplateParam("Self");
+    clazz.addParent(llvm::formatv("{0}::FallbackModel<Self>",
+                                  interface.getFullyQualifiedName()));
+
+    // For every method, generate a default implementation forwarding to the
+    // attribute returned by `getUnderlying`.
+    for (const InterfaceMethod& method : interface.getMethods()) {
+      SmallVector<MethodParameter> methodParameters;
+      methodParameters.emplace_back("Attribute", "odsThisAttr");
+      for (const InterfaceMethod::Argument& argument : method.getArguments())
+        methodParameters.emplace_back(argument.type, argument.name);
+
+      // Attribute interface methods are always const.
+      Method* methodImpl = clazz.addConstMethod(
+          method.getReturnType(), method.getName(), methodParameters);
+      methodImpl->body().indent() << llvm::formatv(
+          R"(
+return static_cast<const Self*>(this)->getUnderlying(odsThisAttr).{0}({1});
+)",
+          method.getName(),
+          llvm::map_range(method.getArguments(),
+                          [](const InterfaceMethod::Argument& argument) {
+                            return llvm::formatv(
+                                "std::forward<decltype({0})>({0})",
+                                argument.name);
+                          }));
+    }
+
+    clazz.finalize();
+    // Since the class has a template parameter, `writeDeclTo`, will write the
+    // complete class definition with inline methods. There is no need to call
+    // `writeDefTo`.
+    clazz.writeDeclTo(rawOs);
+    rawOs << "\n\n";
+  }
+}
+
+static bool emit(const llvm::RecordKeeper& records, llvm::raw_ostream& rawOs) {
+  raw_indented_ostream os(rawOs);
+  llvm::emitSourceFileHeader("WrapInterface implementations", os);
+
+  // Sort the definitions by their ID. The IDs are given by lexical order
+  // monotonically, allowing us to get the list of records in lexical order,
+  // as they are defined in the TableGen file.
+  std::vector<llvm::Record*> sortedDefs(
+      records.getAllDerivedDefinitions("RefAttrImplementable"));
+  llvm::sort(sortedDefs, [](llvm::Record* lhs, llvm::Record* rhs) {
+    return lhs->getID() < rhs->getID();
+  });
+
+  // First generate the list guarded by the `GEN_WRAP_LIST` macro. This allows
+  // any new implementation of `RefAttrImplementable` to automatically be
+  // implemented by `RefAttr` without a need to change any C++ code.
+  {
+    IfDefScope scope("GEN_WRAP_LIST", rawOs);
+    llvm::interleave(
+        sortedDefs, rawOs,
+        [&](llvm::Record* record) {
+          rawOs << Interface(record).getFullyQualifiedName();
+        },
+        ",\n");
+  }
+
+  generateWrapStructures(sortedDefs, rawOs);
+
+  return false;
+}
+
+static mlir::GenRegistration
+    genIntrinsics("gen-wrap-interfaces",
+                  "Generated wrapper interface for RefAttrImplementable", emit);


### PR DESCRIPTION
This is the first in a series of commits aimed at removing `ref_cast` and `ref_cast_or_null` by replacing casts to python attributes, with casts to python attribute interfaces instead. `RefAttr` then conditionally implements these interfaces as external model, making any uses `ref_cast` redundant.

The mechanism for `RefAttr` to implement these interfaces makes use TableGen to automatically create wrapper implementations of `FallbackModel` of a given interface.

As implemented now, adding a new python attribute interface, adding, removing or changing methods requires no additionally changes as `RefAttr` will automatically implement these as well.