### PR TITLE
[Py] Add `TupleAttrInterface`

### DIFF
--- a/src/pylir/Optimizer/Conversion/PylirToLLVMIR/CodeGenState.cpp
+++ b/src/pylir/Optimizer/Conversion/PylirToLLVMIR/CodeGenState.cpp
@@ -313,7 +313,7 @@ void pylir::CodeGenState::initializeGlobal(
       .Case([&](Py::ListAttr attr) {
         auto sizeConstant = builder.create<mlir::LLVM::ConstantOp>(
             global.getLoc(), m_typeConverter.getIndexType(),
-            builder.getI64IntegerAttr(attr.getValue().size()));
+            builder.getI64IntegerAttr(attr.getElements().size()));
         undef = builder.create<mlir::LLVM::InsertValueOp>(
             global.getLoc(), undef, sizeConstant, 1);
         auto tupleObject = m_globalBuffers.lookup(attr);
@@ -323,12 +323,12 @@ void pylir::CodeGenState::initializeGlobal(
               mlir::cast<mlir::ModuleOp>(m_symbolTable.getOp()).getBody());
           tupleObject = builder.create<mlir::LLVM::GlobalOp>(
               global.getLoc(),
-              m_typeConverter.getPyTupleType(attr.getValue().size()), true,
+              m_typeConverter.getPyTupleType(attr.getElements().size()), true,
               mlir::LLVM::Linkage::Private, "tuple$", nullptr, 0,
               REF_ADDRESS_SPACE, true);
           initializeGlobal(
               tupleObject, builder,
-              Py::TupleAttr::get(attr.getContext(), attr.getValue()));
+              Py::TupleAttr::get(attr.getContext(), attr.getElements()));
           tupleObject.setUnnamedAddrAttr(mlir::LLVM::UnnamedAddrAttr::get(
               builder.getContext(), mlir::LLVM::UnnamedAddr::Global));
           m_symbolTable.insert(tupleObject);

--- a/src/pylir/Optimizer/PylirMem/IR/Value.cpp
+++ b/src/pylir/Optimizer/PylirMem/IR/Value.cpp
@@ -8,6 +8,8 @@
 
 #include "pylir/Optimizer/PylirPy/IR/Value.hpp"
 
+using namespace mlir;
+
 std::optional<pylir::Mem::LayoutType>
 pylir::Mem::getLayoutType(mlir::Value value,
                           llvm::DenseMap<mlir::Attribute, LayoutType>* cache) {
@@ -49,11 +51,11 @@ std::optional<pylir::Mem::LayoutType> getLayoutTypeImpl(mlir::Attribute attr) {
   if (auto result = mapLayoutType(attr))
     return result;
 
-  auto type = ref_cast<TypeAttr>(attr);
+  auto type = ref_cast<Py::TypeAttr>(attr);
   if (!type)
     return std::nullopt;
 
-  auto mro = ref_cast<TupleAttr>(type.getMroTuple());
+  auto mro = dyn_cast<TupleAttrInterface>(type.getMroTuple());
   for (mlir::Attribute iter : mro)
     if (auto result = mapLayoutType(iter))
       return result;

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrInterfaces.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrInterfaces.td
@@ -145,4 +145,49 @@ def BoolAttrInterface : RefAttrImplementable<"BoolAttrInterface",
   let convertFromStorage = "$_self.getBoolean()";
 }
 
+def TupleAttrInterface : RefAttrImplementable<"TupleAttrInterface",
+  [ObjectAttrInterface]> {
+  let cppNamespace = "::pylir::Py";
+
+  let description = [{
+    Interface implemented by any attribute that subclasses `builtins.tuple`.
+
+    Implies an implementation of `ObjectAttrInterface`.
+  }];
+
+  let methods = [
+    InterfaceMethod<[{
+      Returns the boolean value of this attribute.
+    }],
+    "llvm::ArrayRef<mlir::Attribute>", "getElements", (ins)>,
+    canImplementMethod
+  ];
+
+  let extraSharedClassDeclaration = [{
+    [[nodiscard]] mlir::Attribute operator[](std::size_t index) const {
+      return $_attr.getElements()[index];
+    }
+
+    /// Returns true if the tuple contains no elements.
+    [[nodiscard]] bool empty() const {
+      return $_attr.getElements().empty();
+    }
+
+    /// Returns the amount of elements within the tuple.
+    [[nodiscard]] std::size_t size() const {
+      return $_attr.getElements().size();
+    }
+
+    /// Returns the begin iterator to the first element in the tuple.
+    [[nodiscard]] auto begin() const {
+      return $_attr.getElements().begin();
+    }
+
+    /// Returns the end iterator past the last element in the tuple.
+    [[nodiscard]] auto end() const {
+      return $_attr.getElements().end();
+    }
+  }];
+}
+
 #endif

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.td
@@ -222,55 +222,31 @@ def PylirPy_StrAttr : PylirPy_PyObjAttr<"Str", [ImmutableAttr]> {
 }
 
 def PylirPy_TupleAttr : PylirPy_PyObjAttr<"Tuple", [ImmutableAttr],
-  /*base=*/ObjectAttrInterface,/*hasSlots=*/0> {
+  /*base=*/TupleAttrInterface, /*hasSlots=*/0> {
 	let mnemonic = "tuple";
 	let summary = "python tuple";
 
   let parameters = !con((ins
-    OptionalArrayRefParameter<"mlir::Attribute">:$value),
+    OptionalArrayRefParameter<"mlir::Attribute">:$elements),
   extraIns);
 
 	let assemblyFormat = [{
-	  `<` `(` (`)`) : ($value^ `)`)? ( `,` struct($type_object)^)? `>`
+	  `<` `(` (`)`) : ($elements^ `)`)? ( `,` struct($type_object)^)? `>`
 	}];
 
   let builders = [
-    AttrBuilder<!con((ins CArg<"llvm::ArrayRef<mlir::Attribute>", "{}">:$value),
+    AttrBuilder<!con((ins CArg<"llvm::ArrayRef<mlir::Attribute>", "{}">:$elements),
       extraBuilderArgs),
       extraBuilderPrologue # [{
-      return $_get($_ctxt, value, typeObject);
+      return $_get($_ctxt, elements, typeObject);
     }]>
   ];
 
 	let extraClassDeclaration = [{
 
-    [[nodiscard]] mlir::Attribute operator[](std::size_t index) const {
-      return getValue()[index];
-    }
-
     /// Returns all slots of the tuple in a dictionary, which is always empty.
-	  ::mlir::DictionaryAttr getSlots() const {
-      return ::mlir::DictionaryAttr::getWithSorted(getContext(), {});
-    }
-
-	  /// Returns true if the tuple contains no elements.
-	  [[nodiscard]] bool empty() const {
-      return getValue().empty();
-	  }
-
-    /// Returns the amount of elements within the tuple.
-	  [[nodiscard]] std::size_t size() const {
-      return getValue().size();
-	  }
-
-    /// Returns the begin iterator to the first element in the tuple.
-    [[nodiscard]] auto begin() const {
-      return getValue().begin();
-    }
-
-    /// Returns the end iterator past the last element in the tuple.
-    [[nodiscard]] auto end() const {
-      return getValue().end();
+	  mlir::DictionaryAttr getSlots() const {
+      return mlir::DictionaryAttr::getWithSorted(getContext(), {});
     }
 	}];
 }
@@ -279,18 +255,18 @@ def PylirPy_ListAttr : PylirPy_PyObjAttr<"List"> {
 	let mnemonic = "list";
 
   let parameters = !con((ins
-    OptionalArrayRefParameter<"mlir::Attribute">:$value),
+    OptionalArrayRefParameter<"mlir::Attribute">:$elements),
   extraIns);
 
 	let assemblyFormat = [{
-	  `<` `[` (`]`) : ( $value^ `]`)? ( `,` struct($type_object, $slots)^)? `>`
+	  `<` `[` (`]`) : ( $elements^ `]`)? ( `,` struct($type_object, $slots)^)? `>`
 	}];
 
 	let builders = [
-    AttrBuilder<!con((ins CArg<"llvm::ArrayRef<mlir::Attribute>", "{}">:$value),
+    AttrBuilder<!con((ins CArg<"llvm::ArrayRef<mlir::Attribute>", "{}">:$elements),
       extraBuilderArgs),
       extraBuilderPrologue # [{
-      return $_get($_ctxt, value, typeObject, slots);
+      return $_get($_ctxt, elements, typeObject, slots);
     }]>
   ];
 }

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyOpSROA.cpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyOpSROA.cpp
@@ -378,8 +378,8 @@ void pylir::Py::ListAttr::destructureAggregate(
   destructureSlots(*this, write);
   auto indexType = mlir::IndexType::get(getContext());
   write(nullptr, ListResource::get(), indexType,
-        mlir::IntegerAttr::get(indexType, getValue().size()));
-  for (auto [index, iter] : llvm::enumerate(getValue()))
+        mlir::IntegerAttr::get(indexType, getElements().size()));
+  for (auto [index, iter] : llvm::enumerate(getElements()))
     write(mlir::IntegerAttr::get(indexType, index), ListResource::get(),
           DynamicType::get(getContext()), iter);
 }

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyPatterns.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyPatterns.td
@@ -9,8 +9,6 @@ include "mlir/IR/PatternBase.td"
 include "mlir/Dialect/Arith/IR/ArithOps.td"
 include "pylir/Optimizer/PylirPy/IR/PylirPyOps.td"
 
-def ResolvesTo : NativeCodeCall<"::resolvesToPattern($_self, $0)">;
-
 def prependTupleConst
   : NativeCodeCall<"prependTupleConst($_builder, $_loc, $0, $1)">;
 
@@ -25,7 +23,7 @@ def : Pat<(PylirPy_TuplePrependOp $input,
        }() }]> $input, $args), ConstantAttr<DenseI32ArrayAttr, "{}">)>;
 
 def : Pat<(PylirPy_TuplePrependOp $input,
-            (ResolvesTo PylirPy_TupleAttr:$args)),
+            (ConstantLikeMatcher TupleAttrInterface:$args)),
               (prependTupleConst $input, $args)>;
 
 def : Pat<(PylirPy_TupleDropFrontOp (ConstantLikeMatcher IndexAttr:$count),

--- a/src/pylir/Optimizer/PylirPy/IR/Value.cpp
+++ b/src/pylir/Optimizer/PylirPy/IR/Value.cpp
@@ -13,6 +13,7 @@
 #include "PylirPyTraits.hpp"
 
 using namespace mlir;
+using namespace pylir::Py;
 
 mlir::OpFoldResult pylir::Py::getTypeOf(mlir::Value value) {
   if (auto op = value.getDefiningOp<pylir::Py::KnownTypeObjectInterface>())
@@ -65,7 +66,7 @@ pylir::Py::BuiltinMethodKind getBuiltinMethod(mlir::Attribute attribute,
   if (auto opt = getBuiltinMethod(typeObject))
     return *opt;
 
-  auto mro = pylir::Py::ref_cast_or_null<pylir::Py::TupleAttr>(
+  auto mro = dyn_cast_or_null<TupleAttrInterface>(
       pylir::Py::ref_cast<pylir::Py::TypeAttr>(typeObject).getMroTuple());
   if (!mro)
     return pylir::Py::BuiltinMethodKind::Unknown;


### PR DESCRIPTION
This PR adds `TupleAttrInterface` as a replacement for most casts to `TupleAttr`. This defines the interface making a `TupleAttr` a `TupleAttr` and automatically makes `RefAttr` implement the interface if its initializer is a tuple.