### PR TITLE
[ci] Add nightly recompressing ccache cache

### DIFF
--- a/.github/workflows/ccache-recompress-nightly.yml
+++ b/.github/workflows/ccache-recompress-nightly.yml
@@ -4,7 +4,6 @@ permissions:
   actions: write
 
 on:
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/ccache-recompress-nightly.yml
+++ b/.github/workflows/ccache-recompress-nightly.yml
@@ -39,11 +39,11 @@ jobs:
       - name: Install Dependencies
         uses: ./Pylir/.github/actions/dependencies
         with:
-          c-compiler: ${{inputs.c-compiler}}
-          cpp-compiler: ${{inputs.cpp-compiler}}
-          sanitizers: ${{inputs.sanitizers}}
-          runtime_lib: ${{inputs.runtime_lib}}
-          shared_libs: ${{inputs.shared_libs}}
+          c-compiler: ${{matrix.c-compiler}}
+          cpp-compiler: ${{matrix.cpp-compiler}}
+          sanitizers: ${{matrix.sanitizers}}
+          runtime_lib: ${{matrix.runtime_lib}}
+          shared_libs: ${{matrix.shared_libs}}
 
       - name: Compress ccache
         run: |

--- a/.github/workflows/ccache-recompress-nightly.yml
+++ b/.github/workflows/ccache-recompress-nightly.yml
@@ -1,0 +1,50 @@
+name: CCache Recompress Nightly
+
+permissions:
+  actions: write
+
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  ccache-recompress-nightly:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: windows-2022, cpp-compiler: clang-cl, c-compiler: clang-cl, runtime_lib: "MultiThreaded" }
+          - { os: windows-2022, cpp-compiler: clang-cl, c-compiler: clang-cl, runtime_lib: "MultiThreadedDebug" }
+          - { os: windows-2022, cpp-compiler: clang++, c-compiler: clang }
+          - { os: windows-2022, cpp-compiler: clang++, c-compiler: clang, sanitizers: "address,undefined" }
+          - { os: ubuntu-22.04, cpp-compiler: clang++, c-compiler: clang }
+          - { os: ubuntu-22.04, cpp-compiler: clang++, c-compiler: clang, shared_libs: "ON" }
+          - { os: ubuntu-22.04, cpp-compiler: clang++, c-compiler: clang, sanitizers: "thread" }
+          - { os: ubuntu-22.04, cpp-compiler: clang++, c-compiler: clang, sanitizers: "address,undefined" }
+          - { os: ubuntu-22.04, cpp-compiler: g++-10, c-compiler: gcc-10 }
+          - { os: macos-12, cpp-compiler: clang++, c-compiler: clang }
+    runs-on: ${{matrix.os}}
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - name: Checkout Repo for Actions
+        uses: actions/checkout@v3
+        with:
+          path: Pylir
+
+      - name: Install Dependencies
+        uses: ./Pylir/.github/actions/dependencies
+        with:
+          c-compiler: ${{inputs.c-compiler}}
+          cpp-compiler: ${{inputs.cpp-compiler}}
+          sanitizers: ${{inputs.sanitizers}}
+          runtime_lib: ${{inputs.runtime_lib}}
+          shared_libs: ${{inputs.shared_libs}}
+
+      - name: Compress ccache
+        run: |
+          ccache --recompress 20


### PR DESCRIPTION
CCache uses `zstd` for compression and decompression which has the nice property of having the same decompression speed regardless of compression level used. To save on cache space and therefore improve cache hit rate, it is potentially profitable to recompress the cache every night with the maximum compression level possible.