### PR TITLE
[Py] Change `getTypeObject` to return `TypeAttrInterface`

### DIFF
--- a/src/pylir/Optimizer/Conversion/PylirToLLVMIR/CodeGenState.cpp
+++ b/src/pylir/Optimizer/Conversion/PylirToLLVMIR/CodeGenState.cpp
@@ -254,12 +254,9 @@ void pylir::CodeGenState::initializeGlobal(
   mlir::Value undef =
       builder.create<mlir::LLVM::UndefOp>(global.getLoc(), global.getType());
   auto typeObject = objectAttr.getTypeObject();
-  PYLIR_ASSERT(typeObject);
-  PYLIR_ASSERT(typeObject.getSymbol().getInitializerAttr() &&
-               "Type objects can't be a declaration");
 
-  auto typeObj = builder.create<mlir::LLVM::AddressOfOp>(
-      global.getLoc(), m_objectPtrType, objectAttr.getTypeObject().getRef());
+  auto typeObj =
+      getConstant(global.getLoc(), builder, objectAttr.getTypeObject());
   undef = builder.create<mlir::LLVM::InsertValueOp>(global.getLoc(), undef,
                                                     typeObj, 0);
   llvm::TypeSwitch<Py::ObjectAttrInterface>(objectAttr)

--- a/src/pylir/Optimizer/Conversion/PylirToLLVMIR/PylirToLLVMIR.cpp
+++ b/src/pylir/Optimizer/Conversion/PylirToLLVMIR/PylirToLLVMIR.cpp
@@ -155,13 +155,9 @@ struct GlobalValueOpConversion
         Builtins::Str.name,
     };
     bool constant = op.getConstant();
-    if (!op.isDeclaration()) {
-      constant =
-          (constant ||
-           immutable.contains(
-               op.getInitializer()->getTypeObject().getRef().getValue())) &&
-          !needToBeRuntimeInit(*op.getInitializer());
-    }
+    if (!op.isDeclaration())
+      constant = constant && !needToBeRuntimeInit(*op.getInitializer());
+
     auto global = rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalOp>(
         op, type, constant, linkage, op.getName(), mlir::Attribute{}, 0,
         REF_ADDRESS_SPACE, true);

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrInterfaces.hpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrInterfaces.hpp
@@ -11,4 +11,8 @@
 
 #include "PylirPyAttrBase.hpp"
 
+namespace pylir::Py {
+class TypeAttrInterface;
+} // namespace pylir::Py
+
 #include "pylir/Optimizer/PylirPy/IR/PylirPyAttrInterfaces.h.inc"

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrInterfaces.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrInterfaces.td
@@ -53,7 +53,7 @@ def ObjectAttrInterface : RefAttrImplementable<"ObjectAttrInterface"> {
       Returns the `#py.ref` referring to the type object of this attribute.
       Mustn't be null.
     }], "::pylir::Py::TypeAttrInterface", "getTypeObject", (ins), [{
-      return cast<TypeAttrInterface>($_attr.getTypeObject());
+      return llvm::cast<pylir::Py::TypeAttrInterface>($_attr.getTypeObject());
     }]>,
     canImplementMethod
   ];

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrInterfaces.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrInterfaces.td
@@ -52,7 +52,9 @@ def ObjectAttrInterface : RefAttrImplementable<"ObjectAttrInterface"> {
     InterfaceMethod<[{
       Returns the `#py.ref` referring to the type object of this attribute.
       Mustn't be null.
-    }], "::pylir::Py::RefAttr", "getTypeObject", (ins)>,
+    }], "::pylir::Py::TypeAttrInterface", "getTypeObject", (ins), [{
+      return cast<TypeAttrInterface>($_attr.getTypeObject());
+    }]>,
     canImplementMethod
   ];
 }

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.cpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.cpp
@@ -453,8 +453,9 @@ void printKVPair(
 
 } // namespace
 
-pylir::Py::RefAttr pylir::Py::FunctionAttr::getTypeObject() const {
-  return RefAttr::get(getContext(), Builtins::Function.name);
+TypeAttrInterface pylir::Py::FunctionAttr::getTypeObject() const {
+  return llvm::cast<TypeAttrInterface>(
+      RefAttr::get(getContext(), Builtins::Function.name));
 }
 
 mlir::DictionaryAttr pylir::Py::FunctionAttr::getSlots() const {

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.td
@@ -418,6 +418,11 @@ def PylirPy_FunctionAttr : PylirPy_Attr<"Function", [ FunctionAttrInterface,
       return $_get(context, value, qualName, defaults, kwDefaults, dict);
     }]>
   ];
+
+
+  let extraClassDeclaration = [{
+    TypeAttrInterface getTypeObject() const;
+  }];
 }
 
 def PylirPy_TypeAttr : PylirPy_PyObjAttr<"Type", [TypeAttrInterface]> {


### PR DESCRIPTION
There is no reason as to why it must be a `RefAttr` specifically, and with the new casting ability of `RefAttr`, it is possible to use `TypeAttrInterface` instead. The only disadvantage is the explicit cast required which may possibly defer an error to use, rather than construction, which is less ergonomic. This can be mitigated by future implementations of attribute verifiers and `GlobalValueAttr`.