### PR TITLE
[ci] Use `CMAKE_MSVC_RUNTIME_LIBRARY` in LLVM build

### DIFF
--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -122,23 +122,8 @@ jobs:
             }
           }
           $runtime_lib = ''
-          switch ('${{inputs.runtime_lib}}') {
-            "MultiThreaded" {
-              $runtime_lib = '-DLLVM_USE_CRT_RELEASE=MT'
-            }
-            "MultiThreadedDebug" {
-              $runtime_lib = '-DLLVM_USE_CRT_RELEASE=MTd'
-            }
-            "MultiThreadedDLL" {
-              $runtime_lib = '-DLLVM_USE_CRT_RELEASE=MD'
-            }
-            "MultiThreadedDebugDLL" {
-              $runtime_lib = '-DLLVM_USE_CRT_RELEASE=MDd'
-            }
-            "" {}
-            Default {
-              throw 'Unknown runtime library ${{inputs.runtime_lib}}'
-            }
+          if ('${{inputs.runtime_lib}}') {
+            $runtime_lib = '-DCMAKE_MSVC_RUNTIME_LIBRARY=${{inputs.runtime_lib}}'
           }
 
           $exe_suffix = ''


### PR DESCRIPTION
LLVM used to have a mechanism for choosing the MSVC runtime library prior to CMake supporting it natively but is now moving away from this mechanism in https://github.com/llvm/llvm-project/commit/9f4dfcb795bb0ecf9944553f49371164801cd83f