### PR TITLE
[CMake] Add and default to unified Pylir and LLVM build

### DIFF
--- a/.github/workflows/build-and-lint.yml
+++ b/.github/workflows/build-and-lint.yml
@@ -124,6 +124,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache `
             $use_lld `
             -DPYLIR_ENABLE_ASSERTIONS=ON `
+            -DPYLIR_INCLUDE_LLVM_BUILD=OFF `
             -DLLVM_DIR="${{steps.llvm-fetch.outputs.install-dir}}/lib/cmake/llvm/" `
             -DMLIR_DIR="${{steps.llvm-fetch.outputs.install-dir}}/lib/cmake/mlir/" `
             -DLLD_DIR="${{steps.llvm-fetch.outputs.install-dir}}/lib/cmake/lld/" `
@@ -190,6 +191,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" \
             -DPYLIR_ENABLE_ASSERTIONS=ON \
+            -DPYLIR_INCLUDE_LLVM_BUILD=OFF \
             -DLLVM_DIR="${{steps.llvm-fetch.outputs.install-dir}}/lib/cmake/llvm/" \
             -DMLIR_DIR="${{steps.llvm-fetch.outputs.install-dir}}/lib/cmake/mlir/" \
             -DLLD_DIR="${{steps.llvm-fetch.outputs.install-dir}}/lib/cmake/lld/" \
@@ -305,6 +307,7 @@ jobs:
             -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" `
             -DPYLIR_ENABLE_ASSERTIONS=ON `
             -DPYLIR_BUILD_DOCS=ON `
+            -DPYLIR_INCLUDE_LLVM_BUILD=OFF `
             -DLLVM_DIR="${{steps.llvm-fetch.outputs.install-dir}}/lib/cmake/llvm/" `
             -DMLIR_DIR="${{steps.llvm-fetch.outputs.install-dir}}/lib/cmake/mlir/" `
             -DLLD_DIR="${{steps.llvm-fetch.outputs.install-dir}}/lib/cmake/lld/" `

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ option(PYLIR_BUILD_TESTS "Build tests" ON)
 option(PYLIR_BUILD_DOCS "Build documentation" OFF)
 option(PYLIR_FUZZER "Build fuzzers" OFF)
 option(PYLIR_COVERAGE "Compile with coverage" OFF)
+option(PYLIR_INCLUDE_LLVM_BUILD
+  "Whether to download and build LLVM as part of Pylir" ON)
 set(PYLIR_SANITIZERS "" CACHE STRING "Compile with given sanitizers")
 
 if (NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
@@ -31,32 +33,125 @@ include(CMakePolicies NO_POLICY_SCOPE)
 
 add_subdirectory(3rdParty)
 
-find_package(Threads REQUIRED)
-link_libraries(Threads::Threads)
-find_package(MLIR REQUIRED CONFIG)
-find_package(LLD REQUIRED)
-
-message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
-message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
-
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/.pinned-llvm-revision PYLIR_REQUIRED_LLVM_REVISION)
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+  ${CMAKE_CURRENT_SOURCE_DIR}/.pinned-llvm-revision)
 string(STRIP ${PYLIR_REQUIRED_LLVM_REVISION} PYLIR_REQUIRED_LLVM_REVISION)
 
-find_file(VCS_HEADER VCSRevision.h PATHS ${LLVM_INCLUDE_DIRS} PATH_SUFFIXES llvm/Support/ REQUIRED NO_DEFAULT_PATH)
-message(STATUS "Checking ${VCS_HEADER} for version mismatch")
-file(READ ${VCS_HEADER} VCS_FILE)
-string(REGEX MATCH "#define LLVM_REVISION \"([a-z0-9]+)\"" VCS_MATCH ${VCS_FILE})
-if (CMAKE_MATCH_COUNT EQUAL 0)
-  message(WARNING "Failed to determine revision of LLVM installed. Proceed with caution.
+if (PYLIR_INCLUDE_LLVM_BUILD)
+  include(CPM)
+  
+  # Default LLVM options to corresponding Pylir options.
+  set(PYLIR_LLVM_CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}"
+    CACHE STRING "Build type to use for LLVM compilation")
+  option(LLVM_ENABLE_ASSERTIONS "Whether to build LLVM with assertions"
+    ${PYLIR_ENABLE_ASSERTIONS})
+  
+  string(REPLACE "address" "Address" llvm_sanitizer_default
+    "${PYLIR_SANITIZERS}")
+  string(REPLACE "undefined" "Undefined" llvm_sanitizer_default
+    "${llvm_sanitizer_default}")
+  string(REPLACE "thread" "Thread" llvm_sanitizer_default
+    "${llvm_sanitizer_default}")
+  string(REPLACE "," ";" llvm_sanitizer_default "${llvm_sanitizer_default}")
+  
+  set(LLVM_USE_SANITIZER "${llvm_sanitizer_default}" CACHE
+    STRING "Sanitizers to use when building LLVM")
+  
+  CPMAddPackage(
+    NAME llvm_project
+    GITHUB_REPOSITORY llvm/llvm-project
+    GIT_TAG ${PYLIR_REQUIRED_LLVM_REVISION}
+    EXCLUDE_FROM_ALL
+    SYSTEM
+    SOURCE_SUBDIR llvm
+    # Putting it into cache leads to the cache being populated for a copy for
+    # every LLVM tag ever used. These take a very long time to download due to
+    # the repo size. When not using the cache, cmake will actually just use a
+    # `git fetch` and checkout when updating which is a lot faster. Keep LLVM
+    # out of the cache until https://github.com/cpm-cmake/CPM.cmake/issues/492
+    # is implemented.
+    NO_CACHE TRUE
+    OPTIONS "LLVM_ENABLE_PROJECTS mlir\\\\;lld"
+    # The interface given by an "In-tree" LLVM build is not identical to the one
+    # given by the LLVM Config when using `find_package`. To workaround this,
+    # add an external project to the LLVM build that is called from within LLVM
+    # via `add_subdirectory`. This gives us the chance to inspect and set the
+    # required variables to get both build types to parity.
+    "LLVM_EXTERNAL_PROJECTS Pylir"
+    "LLVM_EXTERNAL_PYLIR_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cmake/LLVM-Unified-Adaptor"
+    "LLVM_INCLUDE_TESTING OFF"
+    "LLVM_INCLUDE_BENCHMARKS OFF"
+    "LLVM_INCLUDE_DOCS OFF"
+    # Targets currently tested with Pylir
+    # TODO: Make this an option that is automatically quoted.
+    "LLVM_TARGETS_TO_BUILD X86\\\\;AArch64"
+    "CMAKE_BUILD_TYPE ${PYLIR_LLVM_CMAKE_BUILD_TYPE}"
+    "LLVM_USE_SANITIZER ${LLVM_USE_SANITIZER}"
+  )
+  
+  # LLVMs cmake file currently has a bug where it sets `EXCLUDE_FROM_ALL` to
+  # `OFF` within a macro(!), affecting all targets created afterwards.
+  # Workaround this by manually going over all targets and explicitly excluding
+  # them again.
+  macro(exclude_all_targets_recursive dir)
+    get_property(subdirectories DIRECTORY ${dir} PROPERTY SUBDIRECTORIES)
+    foreach (subdir ${subdirectories})
+      exclude_all_targets_recursive(${subdir})
+    endforeach ()
+    
+    get_property(current_targets DIRECTORY ${dir} PROPERTY BUILDSYSTEM_TARGETS)
+    foreach (target IN LISTS current_targets)
+      set_target_properties(${target} PROPERTIES EXCLUDE_FROM_ALL "ON")
+    endforeach ()
+  endmacro()
+
+  exclude_all_targets_recursive("${llvm_project_SOURCE_DIR}/llvm")
+  exclude_all_targets_recursive("${llvm_project_SOURCE_DIR}/mlir")
+  exclude_all_targets_recursive("${llvm_project_SOURCE_DIR}/lld")
+  
+  # Fetch the variables set by `LLVM-Unified-Adaptor` cmake from the global
+  # property and apply them to this scope as `find_package(LLVM)` would.
+  get_property(propagated_flags GLOBAL PROPERTY PYLIR_PROPAGATED_LLVM_FLAGS)
+  foreach (pair IN LISTS propagated_flags)
+    # A list element has the form "var=value" where `value` has all `;`
+    # replaced with `,`.
+    string(REGEX MATCH "^[^ =]+" var_key "${pair}")
+    string(LENGTH "${pair}" var_length)
+    string(LENGTH "${var_key}" var_key_length)
+    math(EXPR var_key_length "${var_key_length}+1")
+    string(SUBSTRING "${pair}" "${var_key_length}" "-1" var_value)
+    string(REPLACE "," ";" var_value "${var_value}")
+    set(${var_key} ${var_value})
+  endforeach ()
+
+else ()
+  find_package(Threads REQUIRED)
+  link_libraries(Threads::Threads)
+  find_package(MLIR REQUIRED CONFIG)
+  find_package(LLD REQUIRED)
+  
+  message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
+  message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+  
+  find_file(VCS_HEADER VCSRevision.h PATHS ${LLVM_INCLUDE_DIRS} PATH_SUFFIXES llvm/Support/ REQUIRED NO_DEFAULT_PATH)
+  message(STATUS "Checking ${VCS_HEADER} for version mismatch")
+  file(READ ${VCS_HEADER} VCS_FILE)
+  string(REGEX MATCH "#define LLVM_REVISION \"([a-z0-9]+)\"" VCS_MATCH ${VCS_FILE})
+  if (CMAKE_MATCH_COUNT EQUAL 0)
+    message(WARNING "Failed to determine revision of LLVM installed. Proceed with caution.
 Required revision: ${PYLIR_REQUIRED_LLVM_REVISION}
 Found LLVM installation: ${MLIR_DIR}")
-else ()
-  if (NOT ${CMAKE_MATCH_1} STREQUAL PYLIR_REQUIRED_LLVM_REVISION)
-    message(WARNING "Installed LLVM revision (${CMAKE_MATCH_1}) does not match required revision.\
+  else ()
+    if (NOT ${CMAKE_MATCH_1} STREQUAL PYLIR_REQUIRED_LLVM_REVISION)
+      message(WARNING "Installed LLVM revision (${CMAKE_MATCH_1}) does not match required revision.\
         Compilation is likely to fail.
 Required revision: ${PYLIR_REQUIRED_LLVM_REVISION}
 Found LLVM installation: ${MLIR_DIR}")
+    endif ()
   endif ()
+  
+  link_directories(${LLVM_BUILD_LIBRARY_DIR})
 endif ()
 
 set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
@@ -65,7 +160,6 @@ set(MLIR_BINARY_DIR ${CMAKE_BINARY_DIR})
 
 list(APPEND CMAKE_MODULE_PATH ${MLIR_CMAKE_DIR})
 list(APPEND CMAKE_MODULE_PATH ${LLVM_CMAKE_DIR})
-list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 include(HandlePylirOptions)
 include(TableGen)
 include(AddLLVM)
@@ -78,11 +172,11 @@ set(PYLIR_TABLEGEN_EXE "pylir-tblgen")
 include_directories(${PROJECT_SOURCE_DIR}/src)
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 include_directories(SYSTEM ${MLIR_INCLUDE_DIRS})
+include_directories(SYSTEM ${LLD_INCLUDE_DIRS})
 # Include directory where the various tablegen utilities place auto generated
 # sources and headers.
 include_directories(SYSTEM ${PROJECT_BINARY_DIR}/src)
 include_directories(SYSTEM 3rdParty)
-link_directories(${LLVM_BUILD_LIBRARY_DIR})
 add_definitions(${LLVM_DEFINITIONS})
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/cmake/AddPylir.cmake
+++ b/cmake/AddPylir.cmake
@@ -22,7 +22,7 @@ function(add_pylir_doc td_filename output_file output_directory command)
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${output_file}.md
     ${PYLIR_PREPROCESS_MLIR_MD})
   add_custom_target(${output_file}DocGen DEPENDS ${GEN_DOC_FILE})
-  add_dependencies(mlir-doc ${output_file}DocGen)
+  add_dependencies(pylir-doc ${output_file}DocGen)
 endfunction()
 
 #

--- a/cmake/LLVM-Unified-Adaptor/CMakeLists.txt
+++ b/cmake/LLVM-Unified-Adaptor/CMakeLists.txt
@@ -1,0 +1,54 @@
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This file is meant to be included as an external project when using a unified
+# Pylir + LLVM build. Its purpose is to gather variable values that would
+# normally be present in the LLVMConfig.cmake file of an installed LLVM and
+# escape them to the caller code through the use of a global property.
+
+set(MLIR_MAIN_SRC_DIR "${LLVM_EXTERNAL_MLIR_SOURCE_DIR}")
+set(LLD_SOURCE_DIR "${LLVM_EXTERNAL_LLD_SOURCE_DIR}")
+set(LLD_INCLUDE_DIRS "${LLD_SOURCE_DIR}/include;${LLVM_BINARY_DIR}/tools/lld/include")
+
+# Variables whose name in LLVMConfig and value correspond.
+set(forward_as_is
+  LLD_INCLUDE_DIRS
+  LLVM_ALL_TARGETS
+  LLVM_BINARY_DIR
+  LLVM_CMAKE_DIR
+  LLVM_DEFINITIONS
+  LLVM_ENABLE_RTTI
+  LLVM_HOST_TRIPLE
+  LLVM_NATIVE_ARCH
+  LLVM_LIBRARY_DIR
+  LLVM_TARGETS_TO_BUILD
+  LLVM_TARGET_TRIPLE
+  LLVM_TOOLS_BINARY_DIR
+  MLIR_MAIN_SRC_DIR
+)
+
+foreach (var IN LISTS forward_as_is)
+  # Make lists passable by replacing the semicolon with just a comma
+  string(FIND "${${var}}" "," comma_index)
+  if (NOT comma_index EQUAL -1)
+    message(FATAL "Variable values with commas not supported")
+  endif ()
+  string(REPLACE ";" "," var_value "${${var}}")
+  set_property(GLOBAL APPEND
+    PROPERTY PYLIR_PROPAGATED_LLVM_FLAGS
+    "${var}=${var_value}")
+endforeach ()
+
+set_property(GLOBAL APPEND
+  PROPERTY PYLIR_PROPAGATED_LLVM_FLAGS
+  "LLVM_INCLUDE_DIRS=${LLVM_MAIN_INCLUDE_DIR},${LLVM_INCLUDE_DIR}")
+
+set_property(GLOBAL APPEND
+  PROPERTY PYLIR_PROPAGATED_LLVM_FLAGS
+  "MLIR_CMAKE_DIR=${MLIR_MAIN_SRC_DIR}/cmake/modules")
+
+set(MLIR_GENERATED_INCLUDE_DIR ${LLVM_BINARY_DIR}/tools/mlir/include)
+set_property(GLOBAL APPEND
+  PROPERTY PYLIR_PROPAGATED_LLVM_FLAGS
+  "MLIR_INCLUDE_DIRS=${MLIR_MAIN_SRC_DIR}/include,${MLIR_GENERATED_INCLUDE_DIR}")

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -2,6 +2,9 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+# Create phony target used to collect build dependencies.
+add_custom_target(pylir-doc)
+
 find_program(SPHINX_EXECUTABLE NAMES sphinx-build REQUIRED)
 
 set(PYLIR_PREPROCESS_MLIR_MD "${CMAKE_CURRENT_SOURCE_DIR}/preprocess_mlir_md.py"
@@ -21,7 +24,7 @@ add_custom_target(create-build-dir
 set_target_properties(create-build-dir
   PROPERTIES ADDITIONAL_CLEAN_FILES "${CMAKE_CURRENT_BINARY_DIR}/source")
 
-add_dependencies(create-build-dir mlir-doc)
+add_dependencies(create-build-dir pylir-doc)
 
 add_custom_target(docs
   ${SPHINX_EXECUTABLE} -b html . ../build -W --keep-going -n

--- a/src/pylir/Main/CMakeLists.txt
+++ b/src/pylir/Main/CMakeLists.txt
@@ -54,11 +54,13 @@ target_link_libraries(PylirMain
   
   ${llvm_all}
   
+  MLIRArithDialect
   MLIRBuiltinToLLVMIRTranslation
   MLIRBytecodeReader
   MLIRBytecodeWriter
+  MLIRControlFlowDialect
   MLIRDLTIDialect
-  MLIRToLLVMIRTranslationRegistration
+  MLIRLLVMToLLVMIRTranslation
   
   ctre::ctre
 )

--- a/src/pylir/Optimizer/CMakeLists.txt
+++ b/src/pylir/Optimizer/CMakeLists.txt
@@ -24,7 +24,6 @@ target_link_libraries(PylirOptimizer
   PylirToLLVMIR
   
   MLIRArithToLLVM
-  MLIRArithTransforms
   MLIRLLVMIRTransforms
   MLIRPass
   MLIRReconcileUnrealizedCasts

--- a/src/pylir/Optimizer/Optimizer.cpp
+++ b/src/pylir/Optimizer/Optimizer.cpp
@@ -83,7 +83,6 @@ void pylir::registerOptimizationPipelines() {
       "to LLVM",
       [](mlir::OpPassManager& pm, const PylirLLVMOptions& options) {
         auto* nested = &pm.nestAny();
-        nested->addPass(mlir::arith::createArithExpandOpsPass());
         nested->addPass(mlir::createArithToLLVMConversionPass());
         pm.addPass(createConvertPylirToLLVMPass(ConvertPylirToLLVMPassOptions{
             options.targetTriple, options.dataLayout}));

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,6 @@
 set(PYLIR_TEST_DEPENDS
   FileCheck count not split-file
   pylir-opt
-  pylir-translate
   pylir
   pylir-tblgen
   pylir-stdlib
@@ -33,6 +32,8 @@ configure_file(
   ${PYLIR_TOOLS_DIR}/pylir-lit.py
   @ONLY
 )
+
+add_custom_target(pylir-test-depends ALL DEPENDS ${PYLIR_TEST_DEPENDS})
 
 add_test(NAME lit-tests COMMAND ${Python3_EXECUTABLE} ${PYLIR_TOOLS_DIR}/pylir-lit.py "${CMAKE_CURRENT_BINARY_DIR}" -v)
 set_tests_properties(lit-tests PROPERTIES TIMEOUT 3600)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -5,5 +5,4 @@
 add_subdirectory(pylir)
 add_subdirectory(pylir-opt)
 add_subdirectory(pylir-translate)
-add_subdirectory(pylir-reduce)
 add_subdirectory(pylir-tblgen)

--- a/tools/pylir-opt/CMakeLists.txt
+++ b/tools/pylir-opt/CMakeLists.txt
@@ -2,9 +2,6 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
-get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
-
 add_pylir_passes(Passes Test NO_DOC)
 add_pylir_dialect(Test test NO_DOC)
 
@@ -25,13 +22,23 @@ target_link_libraries(pylir-opt
   PRIVATE
   PylirAnalysis
   PylirExternalModels
+  PylirHIRDialect
+  PylirMemDialect
+  PylirMemTransforms
   PylirLinker
   PylirOptimizer
+  PylirPyToPylirMem
+  PylirPyTransforms
   PylirPyTransformsUtil
+  PylirToLLVMIR
+  PylirTransforms
   
-  MLIRMlirOptMain
-  ${dialect_libs}
-  ${conversion_libs}
+  MLIRArithToLLVM
+  MLIRDLTIDialect
+  MLIRSCFDialect
+  MLIROptLib
+  MLIRReconcileUnrealizedCasts
+  MLIRTransforms
 )
 target_include_directories(pylir-opt SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 add_dependencies(pylir-opt TestPassIncGen)

--- a/tools/pylir-opt/main.cpp
+++ b/tools/pylir-opt/main.cpp
@@ -3,18 +3,21 @@
 //  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <mlir/Bytecode/BytecodeWriter.h>
+#include <mlir/Conversion/Passes.h>
 #include <mlir/Debug/Counter.h>
+#include <mlir/Dialect/DLTI/DLTI.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/IR/AsmState.h>
 #include <mlir/IR/Dialect.h>
 #include <mlir/IR/MLIRContext.h>
-#include <mlir/InitAllDialects.h>
-#include <mlir/InitAllPasses.h>
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Support/FileUtilities.h>
 #include <mlir/Support/Timing.h>
 #include <mlir/Support/ToolUtilities.h>
 #include <mlir/Tools/ParseUtilities.h>
 #include <mlir/Tools/mlir-opt/MlirOptMain.h>
+#include <mlir/Transforms/Passes.h>
 
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/InitLLVM.h>
@@ -182,12 +185,16 @@ mlir::LogicalResult mlirOptMain(
 } // namespace
 
 int main(int argc, char** argv) {
-  mlir::registerAllPasses();
+  mlir::registerTransformsPasses();
+  mlir::registerReconcileUnrealizedCasts();
+  mlir::registerArithToLLVMConversionPass();
 
   mlir::DialectRegistry registry;
   registry.insert<pylir::Mem::PylirMemDialect, pylir::Py::PylirPyDialect,
-                  pylir::test::TestDialect, pylir::HIR::PylirHIRDialect>();
-  mlir::registerAllDialects(registry);
+                  pylir::test::TestDialect, pylir::HIR::PylirHIRDialect,
+                  mlir::DLTIDialect, mlir::scf::SCFDialect,
+                  mlir::arith::ArithDialect, mlir::LLVM::LLVMDialect,
+                  mlir::func::FuncDialect>();
 
   pylir::registerExternalModels(registry);
 

--- a/tools/pylir-reduce/CMakeLists.txt
+++ b/tools/pylir-reduce/CMakeLists.txt
@@ -5,7 +5,7 @@
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 
-add_executable(pylir-reduce
+add_executable(pylir-reduce EXCLUDE_FROM_ALL
   main.cpp
 )
 target_link_libraries(pylir-reduce

--- a/tools/pylir-translate/CMakeLists.txt
+++ b/tools/pylir-translate/CMakeLists.txt
@@ -5,7 +5,7 @@
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(translation_libs GLOBAL PROPERTY MLIR_TRANSLATION_LIBS)
 
-add_executable(pylir-translate main.cpp)
+add_executable(pylir-translate EXCLUDE_FROM_ALL main.cpp)
 target_link_libraries(pylir-translate
   PRIVATE
   ${dialect_libs}

--- a/tools/pylir-translate/main.cpp
+++ b/tools/pylir-translate/main.cpp
@@ -7,9 +7,8 @@
 #include <mlir/Tools/mlir-translate/MlirTranslateMain.h>
 
 int main(int argc, char** argv) {
-  mlir::registerAllTranslations();
-
-  // TODO: Register standalone translations here.
+  mlir::registerFromLLVMIRTranslation();
+  mlir::registerToLLVMIRTranslation();
 
   return failed(
       mlir::mlirTranslateMain(argc, argv, "MLIR Translation Testing Tool"));


### PR DESCRIPTION
The unified build makes it possible to build the required parts of LLVM with the exact revision required as part of the normal Pylir build. This now creates a better out of the box experience of compiling the project by only requiring a single build step instead of separately compiling LLVM.

Furthermore, this has the potential to greatly improve developer experience as bumping an LLVM version is now automatic, both performing it oneself and receiving a commit that bumped LLVM. Other advantages include the possibility to work on LLVM and Pylir at the same time and improved total build times due to finer grained target dependency tracking.

Note that the main CI builders will not be using this kind of build as it makes caching just the LLVM build probably more difficult and at the very least incompatible with the current mechanism.