### PR TITLE
[Optimizer] Remove redundant includes

### DIFF
--- a/src/pylir/Optimizer/Conversion/PylirToLLVMIR/PylirToLLVMIR.cpp
+++ b/src/pylir/Optimizer/Conversion/PylirToLLVMIR/PylirToLLVMIR.cpp
@@ -7,7 +7,6 @@
 #include <mlir/Conversion/LLVMCommon/Pattern.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlowOps.h>
-#include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/LLVMIR/LLVMDialect.h>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Transforms/DialectConversion.h>

--- a/src/pylir/Optimizer/ExternalModels/ExternalModels.cpp
+++ b/src/pylir/Optimizer/ExternalModels/ExternalModels.cpp
@@ -6,7 +6,6 @@
 
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlowOps.h>
-#include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/IR/Matchers.h>
 
 #include <llvm/ADT/TypeSwitch.h>

--- a/src/pylir/Optimizer/Optimizer.cpp
+++ b/src/pylir/Optimizer/Optimizer.cpp
@@ -6,7 +6,6 @@
 
 #include <mlir/Conversion/ArithToLLVM/ArithToLLVM.h>
 #include <mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h>
-#include <mlir/Dialect/Arith/Transforms/Passes.h>
 #include <mlir/Dialect/LLVMIR/Transforms/LegalizeForExport.h>
 #include <mlir/Dialect/LLVMIR/Transforms/Passes.h>
 #include <mlir/Pass/PassManager.h>

--- a/src/pylir/Optimizer/PylirPy/Transforms/ExpandPyDialect.cpp
+++ b/src/pylir/Optimizer/PylirPy/Transforms/ExpandPyDialect.cpp
@@ -4,7 +4,6 @@
 
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlowOps.h>
-#include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Transforms/DialectConversion.h>
 


### PR DESCRIPTION
These were potentially causing flaky builds by the library (correctly) not having a dependency on these dialects, but their headers being used eitherway. TableGen may then not yet have generated them when compiling lead to build errors.