### PR TITLE
[CMake] Remove `NO_CACHE`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,20 +61,17 @@ if (PYLIR_INCLUDE_LLVM_BUILD)
   # Purposefully enable console output as LLVM takes a long time to clone and
   # users would not get feedback otherwise.
   set(FETCHCONTENT_QUIET FALSE)
+  # These variables have to be unset if updating the LLVM version or similar
+  # as they may still point to the previous directory otherwise.
+  unset(LLVM_EXTERNAL_LLD_SOURCE_DIR CACHE)
+  unset(LLVM_EXTERNAL_MLIR_SOURCE_DIR CACHE)
   CPMAddPackage(
     NAME llvm_project
     GITHUB_REPOSITORY llvm/llvm-project
     GIT_TAG ${PYLIR_REQUIRED_LLVM_REVISION}
-    EXCLUDE_FROM_ALL
-    SYSTEM
+    EXCLUDE_FROM_ALL TRUE
+    SYSTEM TRUE
     SOURCE_SUBDIR llvm
-    # Putting it into cache leads to the cache being populated for a copy for
-    # every LLVM tag ever used. These take a very long time to download due to
-    # the repo size. When not using the cache, cmake will actually just use a
-    # `git fetch` and checkout when updating which is a lot faster. Keep LLVM
-    # out of the cache until https://github.com/cpm-cmake/CPM.cmake/issues/492
-    # is implemented.
-    NO_CACHE TRUE
     GIT_PROGRESS TRUE
     # Required for ninja:
     # https://gitlab.kitware.com/cmake/cmake/-/issues/18238#note_440475.


### PR DESCRIPTION
While the original reasons why it was added remain valid, not using a cache for LLVM has the disadvantages of having one clone per cmake configuration. This quite heavily impacts IDE performance and prevents `ccache` from sharing object files between cmake configurations. Using a cache fixes these while also saving on disk space. The single issue with the cache is that bumping the LLVM version requires redownloading the whole repo instead of just fetching the new changes. Given `n` cmake configurations, `n` LLVM bumps need to occur before the disk usage is as large as the disk usage of the cache directory.

Also fix some trivial bugs in syntax and updating.