### PR TITLE
[test] Add cmake option for execution test compile flags

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+set(PYLIR_TEST_EXEC_FLAGS "" CACHE STRING
+  "pylir flags to use when compiling the E2E execution tests")
+
 set(PYLIR_TEST_DEPENDS
   FileCheck count not split-file
   pylir-opt

--- a/test/Execution/Dataflow.py
+++ b/test/Execution/Dataflow.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 def foo(x):

--- a/test/Execution/HelloWorld.py
+++ b/test/Execution/HelloWorld.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s
 print("Hello World!")
 # CHECK: Hello World!

--- a/test/Execution/NameError.py
+++ b/test/Execution/NameError.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: not %t 2>&1 | FileCheck %s
 
 a

--- a/test/Execution/SSA-Bug.py
+++ b/test/Execution/SSA-Bug.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 def random():

--- a/test/Execution/attributes.py
+++ b/test/Execution/attributes.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 obj = object()

--- a/test/Execution/aug_ops.py
+++ b/test/Execution/aug_ops.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 i = 5

--- a/test/Execution/bool.py
+++ b/test/Execution/bool.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 print(True)

--- a/test/Execution/catch.py
+++ b/test/Execution/catch.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s
 
 def foo():

--- a/test/Execution/comparison.py
+++ b/test/Execution/comparison.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 print(object() == object())

--- a/test/Execution/contains.py
+++ b/test/Execution/contains.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 d = {"one": 1, "two": 2, "five": 5}

--- a/test/Execution/for.py
+++ b/test/Execution/for.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 for i in (3, 5, 6):

--- a/test/Execution/hash.py
+++ b/test/Execution/hash.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 print(hash(5) == hash(5))

--- a/test/Execution/if.py
+++ b/test/Execution/if.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 if True:

--- a/test/Execution/int.py
+++ b/test/Execution/int.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 print(420)
 # CHECK: 420

--- a/test/Execution/isinstance.py
+++ b/test/Execution/isinstance.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 print(isinstance(5, int))

--- a/test/Execution/iter.py
+++ b/test/Execution/iter.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 it = iter((3, 5, 6))

--- a/test/Execution/lambda.py
+++ b/test/Execution/lambda.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 

--- a/test/Execution/len.py
+++ b/test/Execution/len.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 print(len(()))

--- a/test/Execution/lit.local.cfg
+++ b/test/Execution/lit.local.cfg
@@ -1,0 +1,14 @@
+added_flags = [config.pylir_test_exec_flags]
+# When the runtime is built with sanitizers it is required to link in the
+# sanitizers when linking with pylir as well.
+if config.pylir_sanitizers:
+    added_flags.append("-Xsanitize=" + config.pylir_sanitizers)
+
+config.substitutions = list(
+    map(
+        lambda p: p
+        if p[0] != "%{PYLIR_ADDITIONAL_FLAGS}"
+        else (p[0], p[1] + " " + " ".join(added_flags)),
+        config.substitutions,
+    )
+)

--- a/test/Execution/nested.py
+++ b/test/Execution/nested.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 

--- a/test/Execution/print.py
+++ b/test/Execution/print.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 print("text")
 # CHECK: text

--- a/test/Execution/raise.py
+++ b/test/Execution/raise.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 try:

--- a/test/Execution/repr.py
+++ b/test/Execution/repr.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 print(repr(420) == "420")

--- a/test/Execution/str.py
+++ b/test/Execution/str.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 print("Hello" + " " + "World")

--- a/test/Execution/tuple.py
+++ b/test/Execution/tuple.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 print((3, 353))

--- a/test/Execution/type.py
+++ b/test/Execution/type.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 print(type(0) == int)

--- a/test/Execution/unpack-assign.py
+++ b/test/Execution/unpack-assign.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 a = 3

--- a/test/Execution/while.py
+++ b/test/Execution/while.py
@@ -1,4 +1,4 @@
-# RUN: pylir %rt_link_flags %s -o %t
+# RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s --match-full-lines
 
 while False:

--- a/test/Main/roundtrip.py
+++ b/test/Main/roundtrip.py
@@ -1,31 +1,31 @@
 # RUN: rm -f %t1.mlir %t2.mlir
 # RUN: pylir %s -S -emit-pylir -o %t1.mlir
 # RUN: pylir %t1.mlir -S -emit-pylir -o %t2.mlir
-# RUN: pylir %rt_link_flags %t1.mlir -o /dev/null
+# RUN: pylir -c %t1.mlir -o /dev/null
 # RUN: pylir-opt %t1.mlir -o /dev/null
 
 # RUN: rm -f %t1.mlirbc %t2.mlirbc
 # RUN: pylir %s -c -emit-pylir -o %t1.mlirbc
 # RUN: pylir %t1.mlirbc -c -emit-pylir -o %t2.mlirbc
-# RUN: pylir %rt_link_flags %t1.mlirbc -o /dev/null
+# RUN: pylir -c %t1.mlirbc -o /dev/null
 # RUN: pylir-opt %t1.mlirbc -o /dev/null
 
 # RUN: rm -f %t1.mlir %t2.mlir
 # RUN: pylir %s -S -emit-mlir -o %t1.mlir
 # RUN: pylir %t1.mlir -S -emit-mlir -o %t2.mlir
-# RUN: pylir %rt_link_flags %t1.mlir -o /dev/null
+# RUN: pylir -c %t1.mlir -o /dev/null
 
 # RUN: rm -f %t1.mlirbc %t2.mlirbc
 # RUN: pylir %s -c -emit-mlir -o %t1.mlirbc
 # RUN: pylir %t1.mlirbc -c -emit-mlir -o %t2.mlirbc
-# RUN: pylir %rt_link_flags %t1.mlirbc -o /dev/null
+# RUN: pylir -c %t1.mlirbc -o /dev/null
 
 # RUN: rm -f %t1.ll %t2.ll
 # RUN: pylir %s -S -emit-llvm -o %t1.ll
 # RUN: pylir %t1.ll -S -emit-llvm -o %t2.ll
-# RUN: pylir %rt_link_flags %t1.ll -o /dev/null
+# RUN: pylir -c %t1.ll -o /dev/null
 
 # RUN: rm -f %t1.bc %t2.bc
 # RUN: pylir %s -c -emit-llvm -o %t1.bc
 # RUN: pylir %t1.bc -c -emit-llvm -o %t2.bc
-# RUN: pylir %rt_link_flags %t1.bc -o /dev/null
+# RUN: pylir -c %t1.bc -o /dev/null

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -19,67 +19,64 @@ from lit.llvm.subst import FindTool
 # Configuration file for the 'lit' test runner.
 
 # name: The name of this test suite.
-config.name = 'Pylir'
+config.name = "Pylir"
 
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files.
-config.suffixes = ['.mlir', '.ll', '.py', '.td']
+config.suffixes = [".mlir", ".ll", ".py", ".td"]
 
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)
 
 # test_exec_root: The root path where tests should be run.
-config.test_exec_root = os.path.join(config.pylir_obj_root, 'test')
+config.test_exec_root = os.path.join(config.pylir_obj_root, "test")
 
-config.substitutions.append(('%PATH%', config.environment['PATH']))
-
-# Flags required to successfully link executables in our current build config.
-# Currently mostly used to add linking of sanitizers when the runtime library was built with them.
-rt_link_flags = []
-if config.pylir_sanitizers:
-    rt_link_flags.append('-Xsanitize=' + config.pylir_sanitizers)
-
-config.substitutions.append(('%rt_link_flags', ''.join(rt_link_flags)))
+config.substitutions.append(("%PATH%", config.environment["PATH"]))
 
 llvm_config.with_system_environment(
-    ['HOME', 'INCLUDE', 'LIB', 'TMP', 'TEMP', 'TSAN_OPTIONS', 'ASAN_OPTIONS',
-     'UBSAN_OPTIONS'])
+    [
+        "HOME",
+        "INCLUDE",
+        "LIB",
+        "TMP",
+        "TEMP",
+        "TSAN_OPTIONS",
+        "ASAN_OPTIONS",
+        "UBSAN_OPTIONS",
+    ]
+)
 
 llvm_config.use_default_substitutions()
 
-for arch in config.llvm_targets_to_build.split(';'):
-    config.available_features.add(arch.lower() + '-registered-target')
+for arch in config.llvm_targets_to_build.split(";"):
+    config.available_features.add(arch.lower() + "-registered-target")
 
 # excludes: A list of directories to exclude from the testsuite. The 'Inputs'
 # subdirectories contain auxiliary inputs for various tests in their parent
 # directories.
-config.excludes = ['Inputs', 'CMakeLists.txt', 'pylir-lit.py', 'lit.cfg.py']
+config.excludes = ["Inputs", "CMakeLists.txt", "pylir-lit.py", "lit.cfg.py"]
 
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)
 
 # test_exec_root: The root path where tests should be run.
-config.test_exec_root = os.path.join(config.pylir_obj_root, 'test')
+config.test_exec_root = os.path.join(config.pylir_obj_root, "test")
 
 # Tweak the PATH to include the tools dir.
-llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
+llvm_config.with_environment("PATH", config.llvm_tools_dir, append_path=True)
 
-tool_dirs = [
-    config.pylir_tools_dir, config.mlir_tools_dir, config.llvm_tools_dir
-]
-
-pylir_extra_args = []
-if config.pylir_sanitizers:
-    pylir_extra_args.append("-Xsanitize=" + config.pylir_sanitizers)
+tool_dirs = [config.pylir_tools_dir, config.mlir_tools_dir, config.llvm_tools_dir]
 
 tools = [
-    'pylir', 'pylir-opt', 'pylir-translate',
-    ToolSubst('pylir-tblgen',
-              extra_args=["-I" + x for x in
-                          config.mlir_include_dirs.split(';')] + [
-                             "-I" + config.pylir_src_root + "/src"],
-              unresolved='fatal')
+    ToolSubst("pylir", extra_args=["%{PYLIR_ADDITIONAL_FLAGS}"]),
+    "pylir-opt",
+    ToolSubst(
+        "pylir-tblgen",
+        extra_args=["-I" + x for x in config.mlir_include_dirs.split(";")]
+        + ["-I" + config.pylir_src_root + "/src"],
+        unresolved="fatal",
+    ),
 ]
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)
@@ -87,4 +84,8 @@ llvm_config.add_tool_substitutions(tools, tool_dirs)
 # FileCheck -enable-var-scope is enabled by default in MLIR test
 # This option avoids to accidentally reuse variable across -LABEL match,
 # it can be explicitly opted-in by prefixing the variable name with $
-config.environment['FILECHECK_OPTS'] = "-enable-var-scope --allow-unused-prefixes=false"
+config.environment["FILECHECK_OPTS"] = "-enable-var-scope --allow-unused-prefixes=false"
+
+# Optional additional flags added to all pylir invocations. This can be
+# overwritten in subdirectories through their `lit.local.cfg`.
+config.substitutions.append(("%{PYLIR_ADDITIONAL_FLAGS}", ""))

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -18,6 +18,7 @@ config.pylir_src_root = "@PYLIR_SOURCE_DIR@"
 config.pylir_obj_root = "@PYLIR_BINARY_DIR@"
 config.pylir_tools_dir = "@PYLIR_TOOLS_DIR@"
 config.pylir_sanitizers = "@PYLIR_SANITIZERS@"
+config.pylir_test_exec_flags = "@PYLIR_TEST_EXEC_FLAGS@"
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.


### PR DESCRIPTION
The execution tests currently serve as 1) tests for the correct implementation of python builtins and 2) as e2e tests, acting as our last line of defense. For the purpose of 2) it is useful to run the tests with flags, such as higher optimization levels. This PR adds a mechanism to do so by adding the cmake flag `PYLIR_TEST_EXEC_FLAGS` which is added to any invocation of `pylir` in the `test/Execution` directory.