### PR TITLE
[Py] Add attribute verifier to verify structural properties

### DIFF
--- a/src/pylir/Optimizer/Interfaces/AttrVerifyInterface.cpp
+++ b/src/pylir/Optimizer/Interfaces/AttrVerifyInterface.cpp
@@ -1,0 +1,42 @@
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "AttrVerifyInterface.hpp"
+
+#include "pylir/Optimizer/Interfaces/AttrVerifyInterface.cpp.inc"
+
+using namespace mlir;
+using namespace pylir;
+
+LogicalResult AttrVerifyInterface::verify(Operation* operation,
+                                          SymbolTableCollection& table) {
+  AttrTypeWalker walker;
+
+  // Current sub-operation set by the operation walker from which the attribute
+  // is reachable.
+  Operation* currentOperation;
+
+  walker.addWalk([&](AttrVerifyInterface verifyInterface) {
+    if (failed(verifyInterface.verifyStructure(currentOperation, table)))
+      return WalkResult::interrupt();
+    return WalkResult::advance();
+  });
+
+  // Use a post-order walk to first verify any sub-attributes and sub-operations
+  // prior to verifying the attribute and operation itself.
+  constexpr WalkOrder walkOrder = WalkOrder::PostOrder;
+
+  // Walk all operations including itself. This includes both inherent and
+  // discard-able attributes. The walk result from the attribute type walker
+  // is forwarded to the operation walker.
+  WalkResult result = operation->walk<walkOrder>([&](Operation* subOperation) {
+    // Set the current operation for the `AttrTypeWalker` instance above.
+    currentOperation = subOperation;
+    return walker.walk<walkOrder>(currentOperation->getAttrDictionary());
+  });
+
+  // The walking was interrupted if any verification failed. Propagate the
+  // failure.
+  return failure(/*isFailure=*/result.wasInterrupted());
+}

--- a/src/pylir/Optimizer/Interfaces/AttrVerifyInterface.hpp
+++ b/src/pylir/Optimizer/Interfaces/AttrVerifyInterface.hpp
@@ -8,4 +8,3 @@
 #include <mlir/IR/SymbolTable.h>
 
 #include "pylir/Optimizer/Interfaces/AttrVerifyInterface.h.inc"
-

--- a/src/pylir/Optimizer/Interfaces/AttrVerifyInterface.hpp
+++ b/src/pylir/Optimizer/Interfaces/AttrVerifyInterface.hpp
@@ -1,0 +1,11 @@
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <mlir/IR/Attributes.h>
+#include <mlir/IR/SymbolTable.h>
+
+#include "pylir/Optimizer/Interfaces/AttrVerifyInterface.h.inc"
+

--- a/src/pylir/Optimizer/Interfaces/AttrVerifyInterface.td
+++ b/src/pylir/Optimizer/Interfaces/AttrVerifyInterface.td
@@ -1,0 +1,54 @@
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef PYLIR_INTERFACES_ATTR_VERIFY_INTERFACE
+#define PYLIR_INTERFACES_ATTR_VERIFY_INTERFACE
+
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/OpBase.td"
+include "mlir/IR/SymbolInterfaces.td"
+include "pylir/Optimizer/Util/TablegenUtil.td"
+
+def AttrVerifyInterface : AttrInterface<"AttrVerifyInterface"> {
+  let cppNamespace = "::pylir";
+
+  let description = [{
+    This attribute interface allows verifying the structural properties of
+    an attribute.
+    Common use cases include attributes referencing symbols and
+    checking that the referred to operation is of a specific shape and kind and
+    attributes using mutable attributes and requiring the cycle, and therefore
+    creation and parsing, to be complete prior to verification.
+  }];
+
+  let methods = [
+    InterfaceMethod<[{
+      Called to verify the structural properties of the attribute.
+      `operation` is an operation that this attribute is transitively reachable
+      from and can be used to emit errors using the `emitError` method.
+    }], "mlir::LogicalResult", "verifyStructure",
+      (ins "::mlir::Operation*":$operation,
+           "::mlir::SymbolTableCollection&":$collection)>
+  ];
+
+  let extraClassDeclaration = [{
+    /// Entry point to verify all attributes reachable from `operation` or any
+    /// of its sub-operations.
+    static mlir::LogicalResult
+    verify(mlir::Operation* operation, mlir::SymbolTableCollection& table);
+  }];
+}
+
+/// Trait that can be attached to any operation to automatically verify all
+/// attributes reachable from it or any of its sub-operations. The mechanism
+/// works by automatically implementing the `SymbolUserOpInterface` to receive
+/// a `SymbolTableCollection`.
+def VerifyAttributesOpTrait : OpInterfaceImplementation<SymbolUserOpInterface,
+  [{
+    mlir::LogicalResult verifySymbolUses(mlir::SymbolTableCollection& table) {
+      return ::pylir::AttrVerifyInterface::verify(*this, table);
+    }
+  }]>;
+
+#endif

--- a/src/pylir/Optimizer/Interfaces/CMakeLists.txt
+++ b/src/pylir/Optimizer/Interfaces/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+add_pylir_interface(Attr AttrVerifyInterface LIBRARY LIB_PREFIX Pylir)
 add_pylir_interface(OP CaptureInterface LIBRARY LIB_PREFIX Pylir)
 add_pylir_interface(OP ConditionalBranchInterface LIBRARY LIB_PREFIX Pylir)
 add_pylir_interface(OP MemoryFoldInterface LIBRARY LIB_PREFIX Pylir)

--- a/src/pylir/Optimizer/PylirPy/IR/CMakeLists.txt
+++ b/src/pylir/Optimizer/PylirPy/IR/CMakeLists.txt
@@ -35,7 +35,7 @@ add_library(PylirPyDialect
   PylirPyOps.cpp
   PylirPyOpFold.cpp
   PylirPyOpSROA.cpp
-  PylirPyOpsVerifier.cpp
+  PylirPyVerifiers.cpp
   PylirPyTraits.cpp
   PylirPyTypes.cpp
   Value.cpp
@@ -48,6 +48,7 @@ add_dependencies(PylirPyDialect
 )
 target_link_libraries(PylirPyDialect
   PUBLIC
+  PylirAttrVerifyInterface
   PylirCaptureInterface
   PylirMemoryFoldInterface
   PylirPyCopyObjectInterface

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.hpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.hpp
@@ -8,6 +8,7 @@
 #include <mlir/IR/BuiltinAttributes.h>
 
 #include <pylir/Interfaces/Builtins.hpp>
+#include <pylir/Optimizer/Interfaces/AttrVerifyInterface.hpp>
 #include <pylir/Optimizer/Interfaces/SROAInterfaces.hpp>
 #include <pylir/Support/BigInt.hpp>
 

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.td
@@ -9,6 +9,7 @@ include "pylir/Optimizer/PylirPy/IR/PylirPyAttrInterfaces.td"
 include "pylir/Optimizer/PylirPy/IR/PylirPyBase.td"
 include "pylir/Optimizer/PylirPy/IR/PylirPyTraits.td"
 include "pylir/Optimizer/Interfaces/SROAInterfaces.td"
+include "pylir/Optimizer/Interfaces/AttrVerifyInterface.td"
 include "pylir/Optimizer/Util/TablegenUtil.td"
 include "mlir/IR/OpBase.td"
 
@@ -219,7 +220,7 @@ def PylirPy_ListAttr : PylirPy_PyObjAttr<"List", [EmptySlotsAttr]> {
 }
 
 def PylirPy_DictAttr : PylirPy_PyObjAttr<"Dict", [DictAttrInterface,
-  EmptySlotsAttr]> {
+  EmptySlotsAttr, DeclareAttrInterfaceMethods<AttrVerifyInterface>]> {
 
   let mnemonic = "dict";
   let summary = "python dictionary";
@@ -323,7 +324,7 @@ def PylirPy_DictAttr : PylirPy_PyObjAttr<"Dict", [DictAttrInterface,
 }
 
 def PylirPy_FunctionAttr : PylirPy_PyObjAttr<"Function",
-  [FunctionAttrInterface]> {
+  [FunctionAttrInterface, DeclareAttrInterfaceMethods<AttrVerifyInterface>]> {
 	let mnemonic = "function";
 	let summary = "python function";
 
@@ -364,7 +365,8 @@ def PylirPy_FunctionAttr : PylirPy_PyObjAttr<"Function",
   }];
 }
 
-def PylirPy_TypeAttr : PylirPy_PyObjAttr<"Type", [TypeAttrInterface]> {
+def PylirPy_TypeAttr : PylirPy_PyObjAttr<"Type", [TypeAttrInterface,
+  DeclareAttrInterfaceMethods<AttrVerifyInterface>]> {
 	let mnemonic = "type";
 	let summary = "python type";
 

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyOps.hpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyOps.hpp
@@ -16,6 +16,7 @@
 
 #include <llvm/ADT/iterator.h>
 
+#include <pylir/Optimizer/Interfaces/AttrVerifyInterface.hpp>
 #include <pylir/Optimizer/Interfaces/CaptureInterface.hpp>
 #include <pylir/Optimizer/Interfaces/MemoryFoldInterface.hpp>
 #include <pylir/Optimizer/Interfaces/SROAInterfaces.hpp>

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyOps.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyOps.td
@@ -12,6 +12,7 @@ include "pylir/Optimizer/PylirPy/IR/PylirPyTraits.td"
 include "pylir/Optimizer/PylirPy/Interfaces/ExceptionHandlingInterface.td"
 include "pylir/Optimizer/PylirPy/Interfaces/CopyObjectInterface.td"
 include "pylir/Optimizer/PylirPy/Interfaces/OnlyReadsValueInterface.td"
+include "pylir/Optimizer/Interfaces/AttrVerifyInterface.td"
 include "pylir/Optimizer/Interfaces/MemoryFoldInterface.td"
 include "pylir/Optimizer/Interfaces/CaptureInterface.td"
 include "pylir/Optimizer/Interfaces/SROAInterfaces.td"
@@ -98,7 +99,7 @@ def DictResource : Resource<"::pylir::Py::DictResource">;
 //===----------------------------------------------------------------------===//
 
 def PylirPy_ConstantOp : PylirPy_Op<"constant", [ConstantLike, NoMemoryEffect,
-  KnownType<"Tuple">, DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+  KnownType<"Tuple">]> {
   let arguments = (ins AnyAttrOf<[PylirPy_UnboundAttr, ObjectAttrInterface,
     PylirPy_GlobalValueAttr]>:$constant);
   let results = (outs DynamicType:$result);
@@ -1235,8 +1236,7 @@ defvar GlobalOpSupportedTypes = AnyTypeOf<[DynamicType, Index, F64]>;
 defvar GlobalOpSupportedAttrs = AnyAttrOf<[ObjectAttrInterface, IndexAttr,
   F64Attr, PylirPy_GlobalValueAttr]>;
 
-def PylirPy_GlobalOp : PylirPy_Op<"global", [Symbol,
-  DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+def PylirPy_GlobalOp : PylirPy_Op<"global", [Symbol, VerifyAttributesOpTrait]> {
 
   let arguments = (ins
       SymbolNameAttr:$sym_name,
@@ -1259,6 +1259,8 @@ def PylirPy_GlobalOp : PylirPy_Op<"global", [Symbol,
     If the global does not have an initializer loading from it before a value
     has ever been stored in it is undefined behaviour.
   }];
+
+  let hasVerifier = 1;
 }
 
 def PylirPy_LoadOp : PylirPy_Op<"load", [
@@ -1348,7 +1350,8 @@ def PylirPy_InvokeOp
 }
 
 def PylirPy_FuncOp : PylirPy_Op<"func", [FunctionOpInterface, IsolatedFromAbove,
-  OpAsmOpInterface, AutomaticAllocationScope, CallableOpInterface]> {
+  OpAsmOpInterface, AutomaticAllocationScope, CallableOpInterface,
+  VerifyAttributesOpTrait]> {
   let arguments = (ins StrAttr:$sym_name,
            TypeAttrOf<FunctionType>:$function_type,
            OptionalAttr<StrAttr>:$sym_visibility,

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyVerifiers.cpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyVerifiers.cpp
@@ -2,11 +2,10 @@
 //  See https://llvm.org/LICENSE.txt for license information.
 //  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "PylirPyOps.hpp"
-
 #include <llvm/ADT/TypeSwitch.h>
 
 #include "PylirPyAttributes.hpp"
+#include "PylirPyOps.hpp"
 #include "Value.hpp"
 
 using namespace mlir;


### PR DESCRIPTION
Few of our attributes tend to require verifying structural traits that cannot be verified on construction. Previously, verification of these were hardcoded parts of the op verification which was not nicely constructed and made use of a large `TypeSwitch`.

The new implementation makes use of an attribute interface and an external driver that can be attached to operations via a trait. The former allows attributes to opt into verification and delegates the verification behaviour to the attribute itself rather than the large central `TypeSwitch` from before. The external driver also takes care of the recursive traversal of attributes which had previously been implemented manually in the op verifiers.