### PR TITLE
[Py] Introduce `ObjectBaseAttribute` and `ConcreteObjectAttribute` ba…

### DIFF
--- a/src/pylir/CodeGen/CompilerBuiltins.cpp
+++ b/src/pylir/CodeGen/CompilerBuiltins.cpp
@@ -380,13 +380,11 @@ void pylir::CodeGen::createCompilerBuiltinsImpl() {
   // This function is called at the end of compiling the `builtins` module.
   // At that point in time, it is safe to cast the types to `TypeAttrInterface`.
   m_builder.createGlobalValue(Builtins::None.name, /*constant=*/true,
-                              m_builder.getObjectAttr(cast<TypeAttrInterface>(
-                                  m_builder.getNoneTypeBuiltin())),
-                              /*external=*/true);
+      m_builder.getObjectAttr(m_builder.getNoneTypeBuiltin()),
+      /*external=*/true);
   m_builder.createGlobalValue(Builtins::NotImplemented.name, /*constant=*/true,
-                              m_builder.getObjectAttr(cast<TypeAttrInterface>(
-                                  m_builder.getNotImplementedTypeBuiltin())),
-                              /*external=*/true);
+      m_builder.getObjectAttr(m_builder.getNotImplementedTypeBuiltin()),
+      /*external=*/true);
 
 #define COMPILER_BUILTIN_REV_BIN_OP(name, slotName, revSlotName)            \
   buildRevBinOpCompilerBuiltin(m_builder,                                   \

--- a/src/pylir/CodeGen/CompilerBuiltins.cpp
+++ b/src/pylir/CodeGen/CompilerBuiltins.cpp
@@ -379,10 +379,12 @@ void buildGetAttributeOpCompilerBuiltin(pylir::PyBuilder& builder,
 void pylir::CodeGen::createCompilerBuiltinsImpl() {
   // This function is called at the end of compiling the `builtins` module.
   // At that point in time, it is safe to cast the types to `TypeAttrInterface`.
-  m_builder.createGlobalValue(Builtins::None.name, /*constant=*/true,
+  m_builder.createGlobalValue(
+      Builtins::None.name, /*constant=*/true,
       m_builder.getObjectAttr(m_builder.getNoneTypeBuiltin()),
       /*external=*/true);
-  m_builder.createGlobalValue(Builtins::NotImplemented.name, /*constant=*/true,
+  m_builder.createGlobalValue(
+      Builtins::NotImplemented.name, /*constant=*/true,
       m_builder.getObjectAttr(m_builder.getNotImplementedTypeBuiltin()),
       /*external=*/true);
 

--- a/src/pylir/CodeGen/PyBuilder.hpp
+++ b/src/pylir/CodeGen/PyBuilder.hpp
@@ -43,7 +43,7 @@ public:
     return Py::UnboundAttr::get(getContext());
   }
 
-  Py::ObjectAttr getObjectAttr(Py::TypeAttrInterface type,
+  Py::ObjectAttr getObjectAttr(Py::ObjectBaseAttribute type,
                                mlir::DictionaryAttr slots = {}) {
     return Py::ObjectAttr::get(context, type, slots);
   }
@@ -467,14 +467,14 @@ public:
 
   Py::GlobalValueAttr
   createGlobalValue(llvm::StringRef symbolName, bool constant = false,
-                    Py::ConcreteObjectAttrInterface initializer = {},
+                    Py::ConcreteObjectAttribute initializer = {},
                     bool external = false) {
     auto result = getAttr<Py::GlobalValueAttr>(symbolName);
     result.setInitializer(initializer);
     result.setConstant(constant);
-    if (external) {
+    if (external)
       create<Py::ExternalOp>(symbolName, result);
-    }
+
     return result;
   }
 

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrInterfaces.cpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrInterfaces.cpp
@@ -4,4 +4,13 @@
 
 #include "PylirPyAttrInterfaces.hpp"
 
+#include "PylirPyAttributes.hpp"
+
 #include "pylir/Optimizer/PylirPy/IR/PylirPyAttrInterfaces.cpp.inc"
+
+using namespace pylir::Py;
+
+bool ObjectBaseAttribute::classof(mlir::Attribute attribute) {
+  return llvm::isa<GlobalValueAttr>(attribute) ||
+         ConcreteObjectAttribute::classof(attribute);
+}

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrInterfaces.hpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrInterfaces.hpp
@@ -11,6 +11,15 @@
 
 namespace pylir::Py {
 class TypeAttrInterface;
+
+/// Base class of all attributes that represent python objects.
+class ObjectBaseAttribute : public mlir::Attribute {
+public:
+  using mlir::Attribute::Attribute;
+
+  static bool classof(mlir::Attribute attribute);
+};
+
 } // namespace pylir::Py
 
 #include "pylir/Optimizer/PylirPy/IR/PylirPyAttrInterfaces.h.inc"

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrInterfaces.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttrInterfaces.td
@@ -8,25 +8,26 @@
 include "mlir/IR/OpBase.td"
 
 /// Base class for all attribute interfaces that should also be able to be
-/// implementable by `RefAttr`. Any `RefAttr` that refers to a symbol that
-/// implements a given interface automatically implements that interface as
-/// well. If the attribute is a "sub-interface" of `ConstObjectAttrInterface`,
-/// then the symbol referred to by the `RefAttr` must additionally be constant.
-class RefAttrImplementable<string name, list<Interface> baseInterfaces = []>
-  : AttrInterface<name, baseInterfaces> {
+/// implementable by `GlobalValueAttr`. Any `GlobalValueAttr` that refers to a
+/// symbol that implements a given interface automatically implements that
+/// interface as well. If the attribute is a "sub-interface" of
+/// `ConstObjectAttrInterface`, then the symbol referred to by the
+/// `GlobalValueAttr` must additionally be constant.
+class GlobalValueAttrImplementable<string name,
+  list<Interface> baseInterfaces = []> : AttrInterface<name, baseInterfaces> {
 
   /// Interface method that should be appended to the methods array of any
-  /// subclass of `RefAttrImplementable`. It automatically adds the necessary
-  /// hooks to allow `RefAttr` to implement the interface.
+  /// subclass of `GlobalValueAttrImplementable`. It automatically adds the
+  /// necessary hooks to allow `GlobalValueAttr` to implement the interface.
   InterfaceMethod canImplementMethod = InterfaceMethod<[{
-    This method is used by the `classof` mechanism of the given interface
-    implementation to allow an implementation to dynamically determine whether
-    it implements the given interface.
-    The implementation has a parameter containing the interface type to avoid
-    clashing with the corresponding method of any other interface implemented.
+    This method is used by the `classof` mechanism of `}] # name # [{` to allow
+    an implementation to dynamically determine whether it implements the
+    interface.
+    The implementation has a parameter containing `}] # name # [{` to avoid
+    clashing with corresponding methods of any other interfaces implemented.
 
-    Returns true for attributes where the interface is directly attached to in
-    ODS.
+    Returns true for attributes `}] # name # [{` is directly attached to
+    in ODS.
   }], "bool", "canImplement",
     (ins "std::in_place_type_t<" # cppNamespace # "::" # name # ">":$tagType),
      [{
@@ -39,7 +40,7 @@ class RefAttrImplementable<string name, list<Interface> baseInterfaces = []>
   }];
 }
 
-def ObjectAttrInterface : RefAttrImplementable<"ObjectAttrInterface"> {
+def ObjectAttrInterface : GlobalValueAttrImplementable<"ObjectAttrInterface"> {
   let cppNamespace = "::pylir::Py";
 
   let description = [{
@@ -59,8 +60,9 @@ def ObjectAttrInterface : RefAttrImplementable<"ObjectAttrInterface"> {
   ];
 }
 
-def ConstObjectAttrInterface : RefAttrImplementable<"ConstObjectAttrInterface",
-  [ObjectAttrInterface]> {
+def ConstObjectAttrInterface
+  : GlobalValueAttrImplementable<"ConstObjectAttrInterface",
+      [ObjectAttrInterface]> {
   let cppNamespace = "::pylir::Py";
 
   let description = [{
@@ -90,21 +92,7 @@ def ConstObjectAttrInterface : RefAttrImplementable<"ConstObjectAttrInterface",
   ];
 }
 
-def ConcreteObjectAttrInterface : AttrInterface<"ConcreteObjectAttrInterface",
-  [ConstObjectAttrInterface]> {
-  let cppNamespace = "pylir::Py";
-
-  let description = [{
-    This interface is implemented by all attributes that represent concrete
-    python objects. It is most notably not implemented by `RefAttr`.
-
-    This interface doesn't have any methods but is rather used as a marker
-    or trait that additionally also implies an implementation of
-    `ConstObjectAttrInterface`.
-  }];
-}
-
-def IntAttrInterface : RefAttrImplementable<"IntAttrInterface",
+def IntAttrInterface : GlobalValueAttrImplementable<"IntAttrInterface",
   [ObjectAttrInterface]> {
   let cppNamespace = "::pylir::Py";
 
@@ -125,7 +113,7 @@ def IntAttrInterface : RefAttrImplementable<"IntAttrInterface",
   let convertFromStorage = "$_self.getInteger()";
 }
 
-def BoolAttrInterface : RefAttrImplementable<"BoolAttrInterface",
+def BoolAttrInterface : GlobalValueAttrImplementable<"BoolAttrInterface",
   [IntAttrInterface]> {
   let cppNamespace = "::pylir::Py";
 
@@ -147,7 +135,7 @@ def BoolAttrInterface : RefAttrImplementable<"BoolAttrInterface",
   let convertFromStorage = "$_self.getBoolean()";
 }
 
-def TupleAttrInterface : RefAttrImplementable<"TupleAttrInterface",
+def TupleAttrInterface : GlobalValueAttrImplementable<"TupleAttrInterface",
   [ObjectAttrInterface]> {
   let cppNamespace = "::pylir::Py";
 
@@ -192,7 +180,7 @@ def TupleAttrInterface : RefAttrImplementable<"TupleAttrInterface",
   }];
 }
 
-def TypeAttrInterface : RefAttrImplementable<"TypeAttrInterface",
+def TypeAttrInterface : GlobalValueAttrImplementable<"TypeAttrInterface",
   [ObjectAttrInterface]> {
   let cppNamespace = "::pylir::Py";
 
@@ -216,7 +204,7 @@ def TypeAttrInterface : RefAttrImplementable<"TypeAttrInterface",
   ];
 }
 
-def DictAttrInterface : RefAttrImplementable<"DictAttrInterface",
+def DictAttrInterface : GlobalValueAttrImplementable<"DictAttrInterface",
   [ConstObjectAttrInterface]> {
   let cppNamespace = "::pylir::Py";
 
@@ -242,8 +230,9 @@ def DictAttrInterface : RefAttrImplementable<"DictAttrInterface",
   ];
 }
 
-def FunctionAttrInterface : RefAttrImplementable<"FunctionAttrInterface",
-  [ObjectAttrInterface]> {
+def FunctionAttrInterface
+  : GlobalValueAttrImplementable<"FunctionAttrInterface",
+    [ObjectAttrInterface]> {
   let cppNamespace = "::pylir::Py";
 
   let description = [{
@@ -262,7 +251,7 @@ def FunctionAttrInterface : RefAttrImplementable<"FunctionAttrInterface",
   ];
 }
 
-def FloatAttrInterface : RefAttrImplementable<"FloatAttrInterface",
+def FloatAttrInterface : GlobalValueAttrImplementable<"FloatAttrInterface",
   [ObjectAttrInterface]> {
   let cppNamespace = "::pylir::Py";
 
@@ -281,7 +270,7 @@ def FloatAttrInterface : RefAttrImplementable<"FloatAttrInterface",
   ];
 }
 
-def StrAttrInterface : RefAttrImplementable<"StrAttrInterface",
+def StrAttrInterface : GlobalValueAttrImplementable<"StrAttrInterface",
   [ObjectAttrInterface]> {
   let cppNamespace = "::pylir::Py";
 

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.hpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.hpp
@@ -17,9 +17,35 @@
 #include "PylirPyAttrInterfaces.hpp"
 #include "PylirPyTraits.hpp"
 
-namespace pylir::Py::detail {
+namespace pylir::Py {
+namespace detail {
 struct GlobalValueAttrStorage;
-} // namespace pylir::Py::detail
+} // namespace detail
+
+/// Base class of all attributes that represent concrete python objects.
+/// It is most notably not the base class of `GlobalValueAttr`.
+class ConcreteObjectAttribute : public ObjectBaseAttribute {
+public:
+  using ObjectBaseAttribute::ObjectBaseAttribute;
+
+  /// All concrete object attributes implement `ObjectAttrInterface` and
+  /// `ConstObjectAttrInterface`.
+  operator ObjectAttrInterface() const {
+    if (!*this)
+      return nullptr;
+    return cast<ObjectAttrInterface>();
+  }
+
+  operator ConstObjectAttrInterface() const {
+    if (!*this)
+      return nullptr;
+    return cast<ConstObjectAttrInterface>();
+  }
+
+  static bool classof(mlir::Attribute attribute);
+};
+
+} // namespace pylir::Py
 
 #define GET_ATTRDEF_CLASSES
 #include "pylir/Optimizer/PylirPy/IR/PylirPyAttributes.h.inc"

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.td
@@ -48,22 +48,22 @@ def EmptySlotsAttr
 /// Convenient base class for Python object attributes adding common methods and
 /// parameters.
 class PylirPy_PyObjAttr<string name,
-  list<Trait> traits = []>
-  : PylirPy_Attr<name, !listconcat([ConcreteObjectAttrInterface,
+  list<Trait> traits = [], string baseCppClass = "ConcreteObjectAttribute">
+  : PylirPy_Attr<name, !listconcat([ConstObjectAttrInterface,
    KnownTypeAttr<name>, DeclareAttrInterfaceMethods<SROAAttrInterface>],
-   traits)>;
+   traits), baseCppClass>;
 
-def PylirPy_ObjectAttr : PylirPy_Attr<"Object", [ConcreteObjectAttrInterface,
-  DeclareAttrInterfaceMethods<SROAAttrInterface>]> {
+def PylirPy_ObjectAttr : PylirPy_Attr<"Object", [ConstObjectAttrInterface,
+  DeclareAttrInterfaceMethods<SROAAttrInterface>], "ConcreteObjectAttribute"> {
 	let mnemonic = "obj";
 	let summary = "python object";
 
-	let parameters = (ins "TypeAttrInterface":$type_object, SlotsMap:$slots);
+	let parameters = (ins "ObjectBaseAttribute":$type_object, SlotsMap:$slots);
 
 	let skipDefaultBuilders = 1;
 
 	let builders = [
-    AttrBuilder<(ins "TypeAttrInterface":$typeObject,
+    AttrBuilder<(ins "ObjectBaseAttribute":$typeObject,
       CArg<"mlir::DictionaryAttr", "{}">:$slots), [{
       slots = slots ? slots : DictionaryAttr::get($_ctxt);
   	  return $_get($_ctxt, typeObject, slots);
@@ -440,8 +440,8 @@ def PylirPy_FractionalAttr : PylirPy_Attr<"Fractional"> {
   let assemblyFormat = "`<` $nominator `,` $denominator `>`";
 }
 
-def PylirPy_GlobalValueAttr : AttrDef<PylirPy_Dialect, "GlobalValue",
-    [NativeAttrTrait<"IsMutable">]> {
+def PylirPy_GlobalValueAttr : PylirPy_Attr<"GlobalValue",
+    [NativeAttrTrait<"IsMutable">], "ObjectBaseAttribute"> {
   let mnemonic = "globalValue";
 
   let description = [{
@@ -477,7 +477,7 @@ def PylirPy_GlobalValueAttr : AttrDef<PylirPy_Dialect, "GlobalValue",
 
   let parameters = (ins StringRefParameter<>:$name,
               DefaultValuedParameter<"bool", "false">:$constant,
-              OptionalParameter<"ConcreteObjectAttrInterface">:$initializer);
+              OptionalParameter<"ConcreteObjectAttribute">:$initializer);
 
   // Required to make it properly mutable.
   let genStorageClass = 0;
@@ -496,7 +496,7 @@ def PylirPy_GlobalValueAttr : AttrDef<PylirPy_Dialect, "GlobalValue",
     void setConstant(bool constant);
 
     /// Sets the initializer of this global value.
-    void setInitializer(ConcreteObjectAttrInterface initializer);
+    void setInitializer(ConcreteObjectAttribute initializer);
   }];
 
   let builders = [

--- a/src/pylir/Optimizer/PylirPy/Transforms/FoldGlobals.cpp
+++ b/src/pylir/Optimizer/PylirPy/Transforms/FoldGlobals.cpp
@@ -33,9 +33,10 @@ protected:
   void runOnOperation() override;
 
 private:
-  pylir::Py::GlobalValueAttr createGlobalValueFromGlobal(
-      pylir::Py::GlobalOp globalOp,
-      pylir::Py::ConcreteObjectAttrInterface initializer, bool constant) {
+  pylir::Py::GlobalValueAttr
+  createGlobalValueFromGlobal(pylir::Py::GlobalOp globalOp,
+                              pylir::Py::ConcreteObjectAttribute initializer,
+                              bool constant) {
     PYLIR_ASSERT(globalOp.getType().isa<pylir::Py::DynamicType>());
     auto globalValueAttr = pylir::Py::GlobalValueAttr::get(
         globalOp->getContext(), globalOp.getSymName());
@@ -82,11 +83,12 @@ private:
       if (!constantStorage)
         constantStorage = attr.dyn_cast<pylir::Py::UnboundAttr>();
 
-      if (!constantStorage)
+      if (!constantStorage) {
+        // Cast is safe as this is not a `GlobalValueAttr` nor `UnboundAttr`
+        // but must be a store of type `!py.dynamic`.
         constantStorage = createGlobalValueFromGlobal(
-            globalOp, mlir::cast<pylir::Py::ConcreteObjectAttrInterface>(attr),
-            true);
-
+            globalOp, cast<ConcreteObjectAttribute>(attr), true);
+      }
     } else {
       constantStorage = attr;
     }

--- a/tools/pylir-tblgen/WrapInterfaceGen.cpp
+++ b/tools/pylir-tblgen/WrapInterfaceGen.cpp
@@ -92,7 +92,7 @@ static bool emit(const llvm::RecordKeeper& records, llvm::raw_ostream& rawOs) {
   // monotonically, allowing us to get the list of records in lexical order,
   // as they are defined in the TableGen file.
   std::vector<llvm::Record*> sortedDefs(
-      records.getAllDerivedDefinitions("RefAttrImplementable"));
+      records.getAllDerivedDefinitions("GlobalValueAttrImplementable"));
   llvm::sort(sortedDefs, [](llvm::Record* lhs, llvm::Record* rhs) {
     return lhs->getID() < rhs->getID();
   });


### PR DESCRIPTION
…se classes

Previously, interfaces such as `ObjectAttrInterface` or `ConcreteObjectInterface` were being used as "constraints" in methods and even as parameters of attributes despite their interface methods never to rarely being used. As interfaces are twice as large as plain attributes and converting to the interface requires a hashmap lookup in the context, using the interface as constraint in many of these scenarios cost us both in time, space and arguably comprehension. Furthermore, `ObjectAttrInterface` is only conditionally implemented by `GlobalValueAttr` and therefore not suitable in almost all scenarios currently used.

This commit therefore introduces base classes implemented by the attributes in `PylirPyAttributes.td` that act as a more constrained version of `mlir::Attribute`.