### PR TITLE
[PylirToLLVM][NFC] Cleanup CodeGenState.cpp a bit

### DIFF
--- a/src/pylir/Optimizer/Conversion/PylirToLLVMIR/CodeGenState.cpp
+++ b/src/pylir/Optimizer/Conversion/PylirToLLVMIR/CodeGenState.cpp
@@ -12,29 +12,29 @@
 #include <pylir/Optimizer/PylirPy/IR/Value.hpp>
 
 using namespace mlir;
+using namespace pylir;
 using namespace pylir::Py;
 
-void pylir::CodeGenState::appendToGlobalInit(
-    mlir::OpBuilder& builder, llvm::function_ref<void()> section) {
-  mlir::OpBuilder::InsertionGuard guard{builder};
+void CodeGenState::appendToGlobalInit(OpBuilder& builder,
+                                      llvm::function_ref<void()> section) {
+  OpBuilder::InsertionGuard guard{builder};
   if (!m_globalInit) {
     builder.setInsertionPointToEnd(
-        mlir::cast<mlir::ModuleOp>(m_symbolTable.getOp()).getBody());
-    m_globalInit = builder.create<mlir::LLVM::LLVMFuncOp>(
+        cast<ModuleOp>(m_symbolTable.getOp()).getBody());
+    m_globalInit = builder.create<LLVM::LLVMFuncOp>(
         builder.getUnknownLoc(), "$__GLOBAL_INIT__",
-        mlir::LLVM::LLVMFunctionType::get(
-            builder.getType<mlir::LLVM::LLVMVoidType>(), {}),
-        mlir::LLVM::Linkage::Internal, true);
+        LLVM::LLVMFunctionType::get(builder.getType<LLVM::LLVMVoidType>(), {}),
+        LLVM::Linkage::Internal, true);
     m_globalInit.addEntryBlock();
   }
   builder.setInsertionPointToEnd(&m_globalInit.back());
   section();
 }
 
-mlir::ArrayAttr pylir::CodeGenState::getTBAAAccess(TbaaAccessType accessType) {
-  mlir::MLIRContext* context = &m_typeConverter.getContext();
+ArrayAttr CodeGenState::getTBAAAccess(TbaaAccessType accessType) {
+  MLIRContext* context = &m_typeConverter.getContext();
   if (accessType == TbaaAccessType::None)
-    return mlir::ArrayAttr::get(context, {});
+    return ArrayAttr::get(context, {});
 
   std::string tbaaAccessTypeString;
   switch (accessType) {
@@ -87,27 +87,26 @@ mlir::ArrayAttr pylir::CodeGenState::getTBAAAccess(TbaaAccessType accessType) {
     break;
   }
 
-  auto type = mlir::LLVM::TBAATypeDescriptorAttr::get(
+  auto type = LLVM::TBAATypeDescriptorAttr::get(
       context, /*identity=*/tbaaAccessTypeString,
-      mlir::LLVM::TBAAMemberAttr::get(m_tbaaRoot, 0));
+      LLVM::TBAAMemberAttr::get(m_tbaaRoot, 0));
 
   auto tag =
-      mlir::LLVM::TBAATagAttr::get(/*base_type=*/type, /*access_type=*/type, 0);
+      LLVM::TBAATagAttr::get(/*base_type=*/type, /*access_type=*/type, 0);
 
-  return mlir::ArrayAttr::get(context, tag);
+  return ArrayAttr::get(context, tag);
 }
 
-mlir::Value pylir::CodeGenState::createRuntimeCall(mlir::Location loc,
-                                                   mlir::OpBuilder& builder,
-                                                   CodeGenState::Runtime func,
-                                                   mlir::ValueRange args) {
+Value CodeGenState::createRuntimeCall(Location loc, OpBuilder& builder,
+                                      CodeGenState::Runtime func,
+                                      ValueRange args) {
   PlatformABI& abi = m_typeConverter.getPlatformABI();
-  mlir::MLIRContext* context = builder.getContext();
-  auto pointerType = builder.getType<mlir::LLVM::LLVMPointerType>();
+  MLIRContext* context = builder.getContext();
+  auto pointerType = builder.getType<LLVM::LLVMPointerType>();
 
-  mlir::Type returnType;
-  mlir::NamedAttrList resultAttrs;
-  llvm::SmallVector<mlir::Type> argumentTypes;
+  Type returnType;
+  NamedAttrList resultAttrs;
+  llvm::SmallVector<Type> argumentTypes;
   std::string functionName;
   llvm::SmallVector<llvm::StringRef> passThroughAttributes;
   switch (func) {
@@ -129,13 +128,13 @@ mlir::Value pylir::CodeGenState::createRuntimeCall(mlir::Location loc,
     // supported upstream.
     break;
   case Runtime::mp_init_u64:
-    returnType = mlir::LLVM::LLVMVoidType::get(context);
+    returnType = LLVM::LLVMVoidType::get(context);
     argumentTypes = {m_objectPtrType, builder.getI64Type()};
     functionName = "mp_init_u64";
     passThroughAttributes = {"gc-leaf-function", "nounwind"};
     break;
   case Runtime::mp_init_i64:
-    returnType = mlir::LLVM::LLVMVoidType::get(context);
+    returnType = LLVM::LLVMVoidType::get(context);
     argumentTypes = {m_objectPtrType, builder.getI64Type()};
     functionName = "mp_init_i64";
     passThroughAttributes = {"gc-leaf-function", "nounwind"};
@@ -153,25 +152,25 @@ mlir::Value pylir::CodeGenState::createRuntimeCall(mlir::Location loc,
     passThroughAttributes = {"nounwind"};
     break;
   case Runtime::pylir_print:
-    returnType = mlir::LLVM::LLVMVoidType::get(context);
+    returnType = LLVM::LLVMVoidType::get(context);
     argumentTypes = {m_objectPtrType};
     functionName = "pylir_print";
     passThroughAttributes = {"gc-leaf-function", "nounwind"};
     break;
   case Runtime::pylir_raise:
-    returnType = mlir::LLVM::LLVMVoidType::get(context);
+    returnType = LLVM::LLVMVoidType::get(context);
     argumentTypes = {m_objectPtrType};
     functionName = "pylir_raise";
     passThroughAttributes = {"noreturn"};
     break;
   case Runtime::mp_init:
-    returnType = mlir::LLVM::LLVMVoidType::get(context);
+    returnType = LLVM::LLVMVoidType::get(context);
     argumentTypes = {m_objectPtrType};
     functionName = "mp_init";
     passThroughAttributes = {"gc-leaf-function", "nounwind"};
     break;
   case Runtime::mp_unpack:
-    returnType = mlir::LLVM::LLVMVoidType::get(context);
+    returnType = LLVM::LLVMVoidType::get(context);
     argumentTypes = {m_objectPtrType,     m_typeConverter.getIndexType(),
                      abi.getInt(context), m_typeConverter.getIndexType(),
                      abi.getInt(context), m_typeConverter.getIndexType(),
@@ -180,13 +179,13 @@ mlir::Value pylir::CodeGenState::createRuntimeCall(mlir::Location loc,
     passThroughAttributes = {"gc-leaf-function", "nounwind"};
     break;
   case Runtime::mp_radix_size_overestimate:
-    returnType = mlir::LLVM::LLVMVoidType::get(context);
+    returnType = LLVM::LLVMVoidType::get(context);
     argumentTypes = {m_objectPtrType, abi.getInt(context), m_objectPtrType};
     functionName = "mp_radix_size_overestimate";
     passThroughAttributes = {"gc-leaf-function", "nounwind"};
     break;
   case Runtime::mp_to_radix:
-    returnType = mlir::LLVM::LLVMVoidType::get(context);
+    returnType = LLVM::LLVMVoidType::get(context);
     argumentTypes = {m_objectPtrType, pointerType,
                      m_typeConverter.getIndexType(), m_objectPtrType,
                      abi.getInt(context)};
@@ -200,7 +199,7 @@ mlir::Value pylir::CodeGenState::createRuntimeCall(mlir::Location loc,
     passThroughAttributes = {"gc-leaf-function", "nounwind"};
     break;
   case Runtime::mp_add:
-    returnType = mlir::LLVM::LLVMVoidType::get(context);
+    returnType = LLVM::LLVMVoidType::get(context);
     argumentTypes = {m_objectPtrType, m_objectPtrType, m_objectPtrType};
     functionName = "mp_add";
     passThroughAttributes = {"gc-leaf-function", "nounwind"};
@@ -211,28 +210,28 @@ mlir::Value pylir::CodeGenState::createRuntimeCall(mlir::Location loc,
     functionName = "pylir_dict_lookup";
     break;
   case Runtime::pylir_dict_erase:
-    returnType = mlir::LLVM::LLVMVoidType::get(context);
+    returnType = LLVM::LLVMVoidType::get(context);
     argumentTypes = {m_objectPtrType, m_objectPtrType, abi.getSizeT(context)};
     functionName = "pylir_dict_erase";
     break;
   case Runtime::pylir_dict_insert:
-    returnType = mlir::LLVM::LLVMVoidType::get(context);
+    returnType = LLVM::LLVMVoidType::get(context);
     argumentTypes = {m_objectPtrType, m_objectPtrType, abi.getSizeT(context),
                      m_objectPtrType};
     functionName = "pylir_dict_insert";
     break;
   case Runtime::pylir_dict_insert_unique:
-    returnType = mlir::LLVM::LLVMVoidType::get(context);
+    returnType = LLVM::LLVMVoidType::get(context);
     argumentTypes = {m_objectPtrType, m_objectPtrType, abi.getSizeT(context),
                      m_objectPtrType};
     functionName = "pylir_dict_insert_unique";
     break;
   }
 
-  auto module = mlir::cast<mlir::ModuleOp>(m_symbolTable.getOp());
-  auto llvmFunc = module.lookupSymbol<mlir::LLVM::LLVMFuncOp>(functionName);
+  auto module = cast<ModuleOp>(m_symbolTable.getOp());
+  auto llvmFunc = module.lookupSymbol<LLVM::LLVMFuncOp>(functionName);
   if (!llvmFunc) {
-    mlir::OpBuilder::InsertionGuard guard{builder};
+    OpBuilder::InsertionGuard guard{builder};
     builder.setInsertionPointToEnd(module.getBody());
     llvmFunc =
         abi.declareFunc(builder, loc, returnType, functionName, argumentTypes);
@@ -246,350 +245,341 @@ mlir::Value pylir::CodeGenState::createRuntimeCall(mlir::Location loc,
   return abi.callFunc(builder, loc, llvmFunc, args);
 }
 
-void pylir::CodeGenState::initializeGlobal(
-    mlir::LLVM::GlobalOp global, mlir::OpBuilder& builder,
-    Py::ConstObjectAttrInterface objectAttr) {
+void CodeGenState::initializeGlobal(LLVM::GlobalOp global, OpBuilder& builder,
+                                    ConcreteObjectAttribute objectAttr) {
   builder.setInsertionPointToStart(
       &global.getInitializerRegion().emplaceBlock());
-  mlir::Value undef =
-      builder.create<mlir::LLVM::UndefOp>(global.getLoc(), global.getType());
-  auto typeObject = objectAttr.getTypeObject();
+  Value undef =
+      builder.create<LLVM::UndefOp>(global.getLoc(), global.getType());
+  ConstObjectAttrInterface constObjectAttrInterface = objectAttr;
+  ObjectBaseAttribute typeObject = constObjectAttrInterface.getTypeObject();
 
-  auto typeObj =
-      getConstant(global.getLoc(), builder, objectAttr.getTypeObject());
-  undef = builder.create<mlir::LLVM::InsertValueOp>(global.getLoc(), undef,
-                                                    typeObj, 0);
-  llvm::TypeSwitch<Py::ObjectAttrInterface>(objectAttr)
-      .Case([&](Py::StrAttr attr) {
-        auto values = attr.getValue();
-        auto sizeConstant = builder.create<mlir::LLVM::ConstantOp>(
-            global.getLoc(), m_typeConverter.getIndexType(),
-            builder.getI64IntegerAttr(values.size()));
-        undef = builder.create<mlir::LLVM::InsertValueOp>(
-            global.getLoc(), undef, sizeConstant,
-            llvm::ArrayRef<std::int64_t>{1, 0});
-        undef = builder.create<mlir::LLVM::InsertValueOp>(
-            global.getLoc(), undef, sizeConstant,
-            llvm::ArrayRef<std::int64_t>{1, 1});
+  Value typeObj = getConstant(global.getLoc(), builder, typeObject);
+  undef =
+      builder.create<LLVM::InsertValueOp>(global.getLoc(), undef, typeObj, 0);
+  undef =
+      llvm::TypeSwitch<ConcreteObjectAttribute, Value>(objectAttr)
+          .Case<StrAttr, TupleAttr, ListAttr, Py::FloatAttr, IntAttrInterface,
+                DictAttr, Py::TypeAttr, FunctionAttr>([&](auto attr) {
+            return initialize(global.getLoc(), builder, attr, undef, global);
+          })
+          .Case([&](ObjectAttr) { return undef; });
 
-        auto elementType = builder.getI8Type();
-
-        auto strAttr = builder.getStringAttr(values);
-        auto bufferObject = m_globalBuffers.lookup(strAttr);
-        if (!bufferObject) {
-          mlir::OpBuilder::InsertionGuard bufferGuard{builder};
-          builder.setInsertionPointToStart(
-              mlir::cast<mlir::ModuleOp>(m_symbolTable.getOp()).getBody());
-          bufferObject = builder.create<mlir::LLVM::GlobalOp>(
-              global.getLoc(),
-              mlir::LLVM::LLVMArrayType::get(elementType, values.size()), true,
-              mlir::LLVM::Linkage::Private, "buffer$", strAttr, 0, 0, true);
-          bufferObject.setUnnamedAddrAttr(mlir::LLVM::UnnamedAddrAttr::get(
-              builder.getContext(), mlir::LLVM::UnnamedAddr::Global));
-          m_symbolTable.insert(bufferObject);
-          m_globalBuffers.insert({strAttr, bufferObject});
-        }
-        auto bufferAddress = builder.create<mlir::LLVM::AddressOfOp>(
-            global.getLoc(), builder.getType<mlir::LLVM::LLVMPointerType>(),
-            mlir::FlatSymbolRefAttr::get(bufferObject));
-        undef = builder.create<mlir::LLVM::InsertValueOp>(
-            global.getLoc(), undef, bufferAddress,
-            llvm::ArrayRef<std::int64_t>{1, 2});
-      })
-      .Case([&](Py::TupleAttr attr) {
-        auto sizeConstant = builder.create<mlir::LLVM::ConstantOp>(
-            global.getLoc(), m_typeConverter.getIndexType(),
-            builder.getI64IntegerAttr(attr.size()));
-        undef = builder.create<mlir::LLVM::InsertValueOp>(
-            global.getLoc(), undef, sizeConstant, 1);
-        for (const auto& iter : llvm::enumerate(attr)) {
-          auto constant = getConstant(global.getLoc(), builder, iter.value());
-          undef = builder.create<mlir::LLVM::InsertValueOp>(
-              global.getLoc(), undef, constant,
-              llvm::ArrayRef<std::int64_t>{
-                  2, static_cast<std::int32_t>(iter.index())});
-        }
-      })
-      .Case([&](Py::ListAttr attr) {
-        auto sizeConstant = builder.create<mlir::LLVM::ConstantOp>(
-            global.getLoc(), m_typeConverter.getIndexType(),
-            builder.getI64IntegerAttr(attr.getElements().size()));
-        undef = builder.create<mlir::LLVM::InsertValueOp>(
-            global.getLoc(), undef, sizeConstant, 1);
-        auto tupleObject = m_globalBuffers.lookup(attr);
-        if (!tupleObject) {
-          mlir::OpBuilder::InsertionGuard bufferGuard{builder};
-          builder.setInsertionPointToStart(
-              mlir::cast<mlir::ModuleOp>(m_symbolTable.getOp()).getBody());
-          tupleObject = builder.create<mlir::LLVM::GlobalOp>(
-              global.getLoc(),
-              m_typeConverter.getPyTupleType(attr.getElements().size()), true,
-              mlir::LLVM::Linkage::Private, "tuple$", nullptr, 0,
-              REF_ADDRESS_SPACE, true);
-          initializeGlobal(
-              tupleObject, builder,
-              Py::TupleAttr::get(attr.getContext(), attr.getElements()));
-          tupleObject.setUnnamedAddrAttr(mlir::LLVM::UnnamedAddrAttr::get(
-              builder.getContext(), mlir::LLVM::UnnamedAddr::Global));
-          m_symbolTable.insert(tupleObject);
-          m_globalBuffers.insert({attr, tupleObject});
-        }
-        auto address = builder.create<mlir::LLVM::AddressOfOp>(
-            global.getLoc(), m_objectPtrType,
-            mlir::FlatSymbolRefAttr::get(tupleObject));
-        undef = builder.create<mlir::LLVM::InsertValueOp>(global.getLoc(),
-                                                          undef, address, 2);
-      })
-      .Case([&](Py::FloatAttr floatAttr) {
-        auto constant = builder.create<mlir::LLVM::ConstantOp>(
-            global.getLoc(), builder.getF64Type(),
-            builder.getF64FloatAttr(floatAttr.getDoubleValue()));
-        undef = builder.create<mlir::LLVM::InsertValueOp>(global.getLoc(),
-                                                          undef, constant, 1);
-      })
-      .Case<Py::IntAttr, Py::BoolAttr>([&](auto integerLike) {
-        auto result = m_globalBuffers.lookup(integerLike);
-        if (!result) {
-          mlir::OpBuilder::InsertionGuard bufferGuard{builder};
-          builder.setInsertionPointToStart(
-              mlir::cast<mlir::ModuleOp>(m_symbolTable.getOp()).getBody());
-          BigInt bigInt = integerLike.getInteger();
-          auto targetSizeTBytes = m_typeConverter.getPlatformABI()
-                                      .getSizeT(builder.getContext())
-                                      .getIntOrFloatBitWidth() /
-                                  8;
-          auto size = mp_pack_count(&bigInt.getHandle(), 0, targetSizeTBytes);
-          llvm::SmallVector<std::size_t> data(size);
-          (void)mp_pack(data.data(), data.size(), nullptr,
-                        mp_order::MP_LSB_FIRST, targetSizeTBytes, MP_BIG_ENDIAN,
-                        0, &bigInt.getHandle());
-          auto elementType =
-              m_typeConverter.getPlatformABI().getSizeT(builder.getContext());
-          result = builder.create<mlir::LLVM::GlobalOp>(
-              global.getLoc(),
-              mlir::LLVM::LLVMArrayType::get(elementType, size), true,
-              mlir::LLVM::Linkage::Private, "buffer$", mlir::Attribute{}, 0, 0,
-              true);
-          result.setUnnamedAddrAttr(mlir::LLVM::UnnamedAddrAttr::get(
-              builder.getContext(), mlir::LLVM::UnnamedAddr::Global));
-          m_symbolTable.insert(result);
-          m_globalBuffers.insert({integerLike, result});
-          builder.setInsertionPointToStart(
-              &result.getInitializerRegion().emplaceBlock());
-          mlir::Value arrayUndef = builder.create<mlir::LLVM::UndefOp>(
-              global.getLoc(), result.getType());
-          for (const auto& element : llvm::enumerate(data)) {
-            auto constant = builder.create<mlir::LLVM::ConstantOp>(
-                global.getLoc(), elementType,
-                builder.getIntegerAttr(elementType, element.value()));
-            arrayUndef = builder.create<mlir::LLVM::InsertValueOp>(
-                global.getLoc(), arrayUndef, constant, element.index());
-          }
-          builder.create<mlir::LLVM::ReturnOp>(global.getLoc(), arrayUndef);
-        }
-        auto numElements = result.getType()
-                               .template cast<mlir::LLVM::LLVMArrayType>()
-                               .getNumElements();
-        appendToGlobalInit(builder, [&] {
-          mlir::Value mpIntPtr;
-          {
-            auto toInit = builder.create<mlir::LLVM::AddressOfOp>(
-                global.getLoc(), m_objectPtrType,
-                mlir::FlatSymbolRefAttr::get(global));
-            mpIntPtr = builder.create<mlir::LLVM::GEPOp>(
-                global.getLoc(), toInit.getType(), global.getType(), toInit,
-                llvm::ArrayRef<mlir::LLVM::GEPArg>{0, 1});
-          }
-
-          createRuntimeCall(global.getLoc(), builder, Runtime::mp_init,
-                            {mpIntPtr});
-          auto count = builder.create<mlir::LLVM::ConstantOp>(
-              global.getLoc(), m_typeConverter.getIndexType(),
-              builder.getIndexAttr(numElements));
-          auto intType =
-              m_typeConverter.getPlatformABI().getInt(builder.getContext());
-          auto order = builder.create<mlir::LLVM::ConstantOp>(
-              global.getLoc(), intType,
-              builder.getIntegerAttr(intType, mp_order::MP_LSB_FIRST));
-          auto size = builder.create<mlir::LLVM::ConstantOp>(
-              global.getLoc(), m_typeConverter.getIndexType(),
-              builder.getIndexAttr(m_typeConverter.getIndexTypeBitwidth() / 8));
-          auto endian = builder.create<mlir::LLVM::ConstantOp>(
-              global.getLoc(), intType,
-              builder.getIntegerAttr(intType, mp_endian::MP_BIG_ENDIAN));
-          auto zero = builder.create<mlir::LLVM::ConstantOp>(
-              global.getLoc(), m_typeConverter.getIndexType(),
-              builder.getIndexAttr(0));
-          auto buffer = builder.create<mlir::LLVM::AddressOfOp>(
-              global.getLoc(),
-              mlir::LLVM::LLVMPointerType::get(builder.getContext()),
-              mlir::FlatSymbolRefAttr::get(result));
-          createRuntimeCall(
-              global.getLoc(), builder, Runtime::mp_unpack,
-              {mpIntPtr, count, order, size, endian, zero, buffer});
-        });
-      })
-      .Case([&](Py::DictAttr dict) {
-        auto zeroI = builder.create<mlir::LLVM::ConstantOp>(
-            global.getLoc(), m_typeConverter.getIndexType(),
-            builder.getIndexAttr(0));
-        auto null = builder.create<mlir::LLVM::ZeroOp>(
-            global.getLoc(),
-            mlir::LLVM::LLVMPointerType::get(builder.getContext()));
-        undef = builder.create<mlir::LLVM::InsertValueOp>(
-            global.getLoc(), undef, zeroI, llvm::ArrayRef<std::int64_t>{1, 0});
-        undef = builder.create<mlir::LLVM::InsertValueOp>(
-            global.getLoc(), undef, zeroI, llvm::ArrayRef<std::int64_t>{1, 1});
-        undef = builder.create<mlir::LLVM::InsertValueOp>(
-            global.getLoc(), undef, null, llvm::ArrayRef<std::int64_t>{1, 2});
-        undef = builder.create<mlir::LLVM::InsertValueOp>(global.getLoc(),
-                                                          undef, zeroI, 2);
-        undef = builder.create<mlir::LLVM::InsertValueOp>(global.getLoc(),
-                                                          undef, null, 3);
-        if (dict.getKeyValuePairs().empty())
-          return;
-
-        appendToGlobalInit(builder, [&] {
-          auto dictionary = builder.create<mlir::LLVM::AddressOfOp>(
-              global.getLoc(), m_objectPtrType,
-              mlir::FlatSymbolRefAttr::get(global));
-          for (const auto& [key, value] : dict.getKeyValuePairs()) {
-            auto keyValue = getConstant(global.getLoc(), builder, key);
-            auto layoutType = m_typeConverter.getLayoutType(
-                dyn_cast<ObjectAttrInterface>(key).getTypeObject());
-            mlir::Value hash;
-            if (layoutType == Mem::LayoutType::String) {
-              hash = createRuntimeCall(global.getLoc(), builder,
-                                       Runtime::pylir_str_hash, {keyValue});
-            } else if (layoutType == Mem::LayoutType::Object) {
-              hash = builder.create<mlir::LLVM::PtrToIntOp>(
-                  global.getLoc(), m_typeConverter.getIndexType(), keyValue);
-            } else {
-              // TODO: Add more inline hash functions implementations.
-              PYLIR_UNREACHABLE;
-            }
-            auto valueValue = getConstant(global.getLoc(), builder, value);
-            createRuntimeCall(global.getLoc(), builder,
-                              Runtime::pylir_dict_insert_unique,
-                              {dictionary, keyValue, hash, valueValue});
-          }
-        });
-      })
-      .Case([&](Py::TypeAttr attr) {
-        auto layoutType = m_typeConverter.getLayoutType(attr);
-        PYLIR_ASSERT(layoutType);
-        {
-          auto instanceType = m_typeConverter.mapLayoutTypeToLLVM(*layoutType);
-          auto asCount = builder.create<mlir::LLVM::ConstantOp>(
-              global.getLoc(), m_typeConverter.getIndexType(),
-              builder.getI32IntegerAttr(
-                  m_typeConverter.getPlatformABI().getSizeOf(instanceType) /
-                  (m_typeConverter.getPointerBitwidth() / 8)));
-          undef = builder.create<mlir::LLVM::InsertValueOp>(global.getLoc(),
-                                                            undef, asCount, 1);
-        }
-
-        auto layoutRef = getConstant(
-            global.getLoc(), builder,
-            Mem::layoutTypeToTypeObject(attr.getContext(), *layoutType));
-        undef = builder.create<mlir::LLVM::InsertValueOp>(global.getLoc(),
-                                                          undef, layoutRef, 2);
-        auto mroConstant =
-            getConstant(global.getLoc(), builder, attr.getMroTuple());
-        undef = builder.create<mlir::LLVM::InsertValueOp>(
-            global.getLoc(), undef, mroConstant, 3);
-        auto instanceSlots =
-            getConstant(global.getLoc(), builder, attr.getInstanceSlots());
-        undef = builder.create<mlir::LLVM::InsertValueOp>(
-            global.getLoc(), undef, instanceSlots, 4);
-      })
-      .Case([&](Py::FunctionAttr function) {
-        auto address = builder.create<mlir::LLVM::AddressOfOp>(
-            global.getLoc(),
-            mlir::LLVM::LLVMPointerType::get(builder.getContext()),
-            function.getValue());
-        undef = builder.create<mlir::LLVM::InsertValueOp>(global.getLoc(),
-                                                          undef, address, 1);
-      });
-
-  auto initMap = objectAttr.getSlots();
+  DictionaryAttr initMap = constObjectAttrInterface.getSlots();
   for (auto [index, slotName] : llvm::enumerate(
            dyn_cast<TypeAttrInterface>(typeObject).getInstanceSlots())) {
-    mlir::Value value;
-    auto element = initMap.get(slotName.cast<Py::StrAttr>().getValue());
+    Value value;
+    Attribute element = initMap.get(slotName.cast<Py::StrAttr>().getValue());
     if (!element)
-      value =
-          builder.create<mlir::LLVM::ZeroOp>(global.getLoc(), m_objectPtrType);
+      value = builder.create<LLVM::ZeroOp>(global.getLoc(), m_objectPtrType);
     else
       value = getConstant(global.getLoc(), builder, element);
 
     auto indices = {
-        static_cast<std::int64_t>(global.getType()
-                                      .cast<mlir::LLVM::LLVMStructType>()
-                                      .getBody()
-                                      .size() -
-                                  1),
+        static_cast<std::int64_t>(
+            global.getType().cast<LLVM::LLVMStructType>().getBody().size() - 1),
         static_cast<std::int64_t>(index)};
-    undef = builder.create<mlir::LLVM::InsertValueOp>(global.getLoc(), undef,
-                                                      value, indices);
+    undef = builder.create<LLVM::InsertValueOp>(global.getLoc(), undef, value,
+                                                indices);
   }
 
-  builder.create<mlir::LLVM::ReturnOp>(global.getLoc(), undef);
+  builder.create<LLVM::ReturnOp>(global.getLoc(), undef);
 }
 
-mlir::Value pylir::CodeGenState::getConstant(mlir::Location loc,
-                                             mlir::OpBuilder& builder,
-                                             mlir::Attribute attribute) {
-  if (auto ref = attribute.dyn_cast<Py::GlobalValueAttr>())
-    return builder.create<mlir::LLVM::AddressOfOp>(
-        loc, m_objectPtrType,
-        mlir::FlatSymbolRefAttr::get(getGlobalValue(builder, ref)));
+Value CodeGenState::initialize(Location loc, OpBuilder& builder,
+                               Py::StrAttr attr, Value undef, LLVM::GlobalOp) {
+  StringRef values = attr.getValue();
+  auto sizeConstant = builder.create<LLVM::ConstantOp>(
+      loc, m_typeConverter.getIndexType(),
+      builder.getI64IntegerAttr(values.size()));
+  undef = builder.create<LLVM::InsertValueOp>(
+      loc, undef, sizeConstant, llvm::ArrayRef<std::int64_t>{1, 0});
+  undef = builder.create<LLVM::InsertValueOp>(
+      loc, undef, sizeConstant, llvm::ArrayRef<std::int64_t>{1, 1});
 
-  if (auto value = attribute.dyn_cast<Py::GlobalValueAttr>())
-    return builder.create<mlir::LLVM::AddressOfOp>(
+  IntegerType elementType = builder.getI8Type();
+
+  StringAttr strAttr = builder.getStringAttr(values);
+  LLVM::GlobalOp bufferObject = m_globalBuffers.lookup(strAttr);
+  if (!bufferObject) {
+    OpBuilder::InsertionGuard bufferGuard{builder};
+    builder.setInsertionPointToStart(
+        cast<ModuleOp>(m_symbolTable.getOp()).getBody());
+
+    bufferObject = builder.create<LLVM::GlobalOp>(
+        loc, LLVM::LLVMArrayType::get(elementType, values.size()),
+        /*isConstant=*/true, LLVM::Linkage::Private, "buffer$", strAttr,
+        /*alignment=*/0, /*addrSpace=*/0, /*dsoLocal=*/true);
+    bufferObject.setUnnamedAddrAttr(LLVM::UnnamedAddrAttr::get(
+        builder.getContext(), LLVM::UnnamedAddr::Global));
+
+    m_symbolTable.insert(bufferObject);
+    m_globalBuffers.insert({strAttr, bufferObject});
+  }
+  auto bufferAddress = builder.create<LLVM::AddressOfOp>(
+      loc, builder.getType<LLVM::LLVMPointerType>(),
+      FlatSymbolRefAttr::get(bufferObject));
+  return builder.create<LLVM::InsertValueOp>(
+      loc, undef, bufferAddress, llvm::ArrayRef<std::int64_t>{1, 2});
+}
+
+Value CodeGenState::initialize(Location loc, OpBuilder& builder, TupleAttr attr,
+                               Value undef, LLVM::GlobalOp) {
+  auto sizeConstant =
+      builder.create<LLVM::ConstantOp>(loc, m_typeConverter.getIndexType(),
+                                       builder.getI64IntegerAttr(attr.size()));
+  undef = builder.create<LLVM::InsertValueOp>(loc, undef, sizeConstant, 1);
+  for (auto&& [index, value] : llvm::enumerate(attr)) {
+    Value constant = getConstant(loc, builder, value);
+    undef = builder.create<LLVM::InsertValueOp>(
+        loc, undef, constant,
+        llvm::ArrayRef<std::int64_t>{2, static_cast<std::int32_t>(index)});
+  }
+  return undef;
+}
+
+Value CodeGenState::initialize(Location loc, OpBuilder& builder, ListAttr attr,
+                               Value undef, LLVM::GlobalOp) {
+  auto sizeConstant = builder.create<LLVM::ConstantOp>(
+      loc, m_typeConverter.getIndexType(),
+      builder.getI64IntegerAttr(attr.getElements().size()));
+  undef = builder.create<LLVM::InsertValueOp>(loc, undef, sizeConstant, 1);
+  LLVM::GlobalOp tupleObject = m_globalBuffers.lookup(attr);
+  if (!tupleObject) {
+    OpBuilder::InsertionGuard bufferGuard{builder};
+    builder.setInsertionPointToStart(
+        cast<ModuleOp>(m_symbolTable.getOp()).getBody());
+
+    tupleObject = builder.create<LLVM::GlobalOp>(
+        loc, m_typeConverter.getPyTupleType(attr.getElements().size()), true,
+        LLVM::Linkage::Private, "tuple$", /*initializer=*/nullptr,
+        /*alignment=*/0, REF_ADDRESS_SPACE, /*dsoLocal=*/true);
+
+    initializeGlobal(tupleObject, builder,
+                     Py::TupleAttr::get(attr.getContext(), attr.getElements()));
+    tupleObject.setUnnamedAddrAttr(LLVM::UnnamedAddrAttr::get(
+        builder.getContext(), LLVM::UnnamedAddr::Global));
+    m_symbolTable.insert(tupleObject);
+    m_globalBuffers.insert({attr, tupleObject});
+  }
+
+  auto address = builder.create<LLVM::AddressOfOp>(
+      loc, m_objectPtrType, FlatSymbolRefAttr::get(tupleObject));
+  return builder.create<LLVM::InsertValueOp>(loc, undef, address, 2);
+}
+
+Value CodeGenState::initialize(Location loc, OpBuilder& builder,
+                               Py::FloatAttr attr, Value undef,
+                               LLVM::GlobalOp) {
+  auto constant = builder.create<LLVM::ConstantOp>(
+      loc, builder.getF64Type(),
+      builder.getF64FloatAttr(attr.getDoubleValue()));
+  return builder.create<LLVM::InsertValueOp>(loc, undef, constant, 1);
+}
+
+Value CodeGenState::initialize(Location loc, OpBuilder& builder,
+                               IntAttrInterface attr, Value undef,
+                               LLVM::GlobalOp global) {
+  LLVM::GlobalOp result = m_globalBuffers.lookup(attr);
+  if (!result) {
+    OpBuilder::InsertionGuard bufferGuard{builder};
+    builder.setInsertionPointToStart(
+        cast<ModuleOp>(m_symbolTable.getOp()).getBody());
+
+    BigInt bigInt = attr.getInteger();
+    unsigned targetSizeTBytes = m_typeConverter.getPlatformABI()
+                                    .getSizeT(builder.getContext())
+                                    .getIntOrFloatBitWidth() /
+                                8;
+    std::size_t size = mp_pack_count(&bigInt.getHandle(), /*nails=*/0,
+                                     /*size=*/targetSizeTBytes);
+    llvm::SmallVector<std::size_t> data(size);
+    (void)mp_pack(data.data(), /*maxcount=*/data.size(), /*written=*/nullptr,
+                  mp_order::MP_LSB_FIRST, targetSizeTBytes, MP_BIG_ENDIAN,
+                  /*nails=*/0, &bigInt.getHandle());
+    Type elementType =
+        m_typeConverter.getPlatformABI().getSizeT(builder.getContext());
+    result = builder.create<LLVM::GlobalOp>(
+        loc, LLVM::LLVMArrayType::get(elementType, size), true,
+        LLVM::Linkage::Private, "buffer$", /*initializer=*/Attribute{},
+        /*alignment=*/0, /*addrSpace=*/0, /*dsoLocal=*/true);
+    result.setUnnamedAddrAttr(LLVM::UnnamedAddrAttr::get(
+        builder.getContext(), LLVM::UnnamedAddr::Global));
+    m_symbolTable.insert(result);
+    m_globalBuffers.insert({attr, result});
+    builder.setInsertionPointToStart(
+        &result.getInitializerRegion().emplaceBlock());
+    Value arrayUndef = builder.create<LLVM::UndefOp>(loc, result.getType());
+    for (auto&& [index, value] : llvm::enumerate(data)) {
+      auto constant = builder.create<LLVM::ConstantOp>(
+          loc, elementType, builder.getIntegerAttr(elementType, value));
+      arrayUndef =
+          builder.create<LLVM::InsertValueOp>(loc, arrayUndef, constant, index);
+    }
+    builder.create<LLVM::ReturnOp>(loc, arrayUndef);
+  }
+  unsigned numElements =
+      cast<LLVM::LLVMArrayType>(result.getType()).getNumElements();
+  appendToGlobalInit(builder, [&] {
+    Value mpIntPtr;
+    {
+      auto toInit = builder.create<LLVM::AddressOfOp>(
+          loc, m_objectPtrType, FlatSymbolRefAttr::get(global));
+      mpIntPtr = builder.create<LLVM::GEPOp>(
+          loc, toInit.getType(), global.getType(), toInit,
+          llvm::ArrayRef<LLVM::GEPArg>{0, 1});
+    }
+
+    createRuntimeCall(loc, builder, Runtime::mp_init, {mpIntPtr});
+    auto count = builder.create<LLVM::ConstantOp>(
+        loc, m_typeConverter.getIndexType(), builder.getIndexAttr(numElements));
+    Type intType =
+        m_typeConverter.getPlatformABI().getInt(builder.getContext());
+    auto order = builder.create<LLVM::ConstantOp>(
+        loc, intType, builder.getIntegerAttr(intType, mp_order::MP_LSB_FIRST));
+    auto size = builder.create<LLVM::ConstantOp>(
+        loc, m_typeConverter.getIndexType(),
+        builder.getIndexAttr(m_typeConverter.getIndexTypeBitwidth() / 8));
+    auto endian = builder.create<LLVM::ConstantOp>(
+        loc, intType,
+        builder.getIntegerAttr(intType, mp_endian::MP_BIG_ENDIAN));
+    auto zero = builder.create<LLVM::ConstantOp>(
+        loc, m_typeConverter.getIndexType(), builder.getIndexAttr(0));
+    auto buffer = builder.create<LLVM::AddressOfOp>(
+        loc, LLVM::LLVMPointerType::get(builder.getContext()),
+        FlatSymbolRefAttr::get(result));
+    createRuntimeCall(loc, builder, Runtime::mp_unpack,
+                      {mpIntPtr, count, order, size, endian, zero, buffer});
+  });
+  return undef;
+}
+
+Value CodeGenState::initialize(Location loc, OpBuilder& builder, DictAttr attr,
+                               Value undef, LLVM::GlobalOp global) {
+  auto zeroI = builder.create<LLVM::ConstantOp>(
+      loc, m_typeConverter.getIndexType(), builder.getIndexAttr(0));
+  auto null = builder.create<LLVM::ZeroOp>(
+      loc, LLVM::LLVMPointerType::get(builder.getContext()));
+  undef = builder.create<LLVM::InsertValueOp>(
+      loc, undef, zeroI, llvm::ArrayRef<std::int64_t>{1, 0});
+  undef = builder.create<LLVM::InsertValueOp>(
+      loc, undef, zeroI, llvm::ArrayRef<std::int64_t>{1, 1});
+  undef = builder.create<LLVM::InsertValueOp>(
+      loc, undef, null, llvm::ArrayRef<std::int64_t>{1, 2});
+  undef = builder.create<LLVM::InsertValueOp>(loc, undef, zeroI, 2);
+  undef = builder.create<LLVM::InsertValueOp>(loc, undef, null, 3);
+  if (attr.getKeyValuePairs().empty())
+    return undef;
+
+  appendToGlobalInit(builder, [&] {
+    auto dictionary = builder.create<LLVM::AddressOfOp>(
+        loc, m_objectPtrType, FlatSymbolRefAttr::get(global));
+    for (const auto& [key, value] : attr.getKeyValuePairs()) {
+      Value keyValue = getConstant(loc, builder, key);
+      std::optional<Mem::LayoutType> layoutType = m_typeConverter.getLayoutType(
+          dyn_cast<ObjectAttrInterface>(key).getTypeObject());
+      Value hash;
+      if (layoutType == Mem::LayoutType::String) {
+        hash = createRuntimeCall(loc, builder, Runtime::pylir_str_hash,
+                                 {keyValue});
+      } else if (layoutType == Mem::LayoutType::Object) {
+        hash = builder.create<LLVM::PtrToIntOp>(
+            loc, m_typeConverter.getIndexType(), keyValue);
+      } else {
+        // TODO: Add more inline hash functions implementations.
+        PYLIR_UNREACHABLE;
+      }
+
+      Value valueValue = getConstant(loc, builder, value);
+      createRuntimeCall(loc, builder, Runtime::pylir_dict_insert_unique,
+                        {dictionary, keyValue, hash, valueValue});
+    }
+  });
+
+  return undef;
+}
+
+Value CodeGenState::initialize(Location loc, OpBuilder& builder,
+                               Py::TypeAttr attr, Value undef, LLVM::GlobalOp) {
+  std::optional<Mem::LayoutType> layoutType =
+      m_typeConverter.getLayoutType(attr);
+  PYLIR_ASSERT(layoutType);
+  {
+    Type instanceType = m_typeConverter.mapLayoutTypeToLLVM(*layoutType);
+    auto asCount = builder.create<LLVM::ConstantOp>(
+        loc, m_typeConverter.getIndexType(),
+        builder.getI32IntegerAttr(
+            m_typeConverter.getPlatformABI().getSizeOf(instanceType) /
+            (m_typeConverter.getPointerBitwidth() / 8)));
+    undef = builder.create<LLVM::InsertValueOp>(loc, undef, asCount, 1);
+  }
+
+  Value layoutRef =
+      getConstant(loc, builder,
+                  Mem::layoutTypeToTypeObject(attr.getContext(), *layoutType));
+  undef = builder.create<LLVM::InsertValueOp>(loc, undef, layoutRef, 2);
+  Value mroConstant = getConstant(loc, builder, attr.getMroTuple());
+  undef = builder.create<LLVM::InsertValueOp>(loc, undef, mroConstant, 3);
+  Value instanceSlots = getConstant(loc, builder, attr.getInstanceSlots());
+  return builder.create<LLVM::InsertValueOp>(loc, undef, instanceSlots, 4);
+}
+
+Value CodeGenState::initialize(Location loc, OpBuilder& builder,
+                               FunctionAttr attr, Value undef, LLVM::GlobalOp) {
+  auto address = builder.create<LLVM::AddressOfOp>(
+      loc, LLVM::LLVMPointerType::get(builder.getContext()), attr.getValue());
+  return builder.create<LLVM::InsertValueOp>(loc, undef, address, 1);
+}
+
+Value CodeGenState::getConstant(Location loc, OpBuilder& builder,
+                                Attribute attribute) {
+  if (auto value = dyn_cast<Py::GlobalValueAttr>(attribute))
+    return builder.create<LLVM::AddressOfOp>(
         loc, m_objectPtrType,
-        mlir::FlatSymbolRefAttr::get(getGlobalValue(builder, value)));
+        FlatSymbolRefAttr::get(getGlobalValue(builder, value)));
 
   if (attribute.isa<Py::UnboundAttr>())
-    return builder.create<mlir::LLVM::ZeroOp>(loc, m_objectPtrType);
+    return builder.create<LLVM::ZeroOp>(loc, m_objectPtrType);
 
-  return builder.create<mlir::LLVM::AddressOfOp>(
+  return builder.create<LLVM::AddressOfOp>(
       loc, m_objectPtrType,
-      mlir::FlatSymbolRefAttr::get(createGlobalConstant(
-          builder, attribute.cast<Py::ConstObjectAttrInterface>())));
+      FlatSymbolRefAttr::get(getConstantObject(
+          builder, cast<ConcreteObjectAttribute>(attribute))));
 }
 
-mlir::LLVM::GlobalOp pylir::CodeGenState::createGlobalConstant(
-    mlir::OpBuilder& builder, Py::ConstObjectAttrInterface objectAttr) {
-  if (auto globalOp = m_globalConstants.lookup(objectAttr))
+LLVM::GlobalOp
+CodeGenState::getConstantObject(mlir::OpBuilder& builder,
+                                Py::ConcreteObjectAttribute objectAttr) {
+  if (auto globalOp = m_constantObjects.lookup(objectAttr))
     return globalOp;
 
-  mlir::OpBuilder::InsertionGuard guard{builder};
+  OpBuilder::InsertionGuard guard{builder};
   builder.setInsertionPointToStart(
-      mlir::cast<mlir::ModuleOp>(m_symbolTable.getOp()).getBody());
+      cast<ModuleOp>(m_symbolTable.getOp()).getBody());
   auto type = m_typeConverter.typeOf(objectAttr);
-  auto globalOp = builder.create<mlir::LLVM::GlobalOp>(
+  auto globalOp = builder.create<LLVM::GlobalOp>(
       builder.getUnknownLoc(), type, !needToBeRuntimeInit(objectAttr),
-      mlir::LLVM::Linkage::Private, "const$", mlir::Attribute{}, 0,
-      REF_ADDRESS_SPACE, true);
-  globalOp.setUnnamedAddrAttr(mlir::LLVM::UnnamedAddrAttr::get(
-      builder.getContext(), mlir::LLVM::UnnamedAddr::Global));
+      LLVM::Linkage::Private, "const$", Attribute{}, 0, REF_ADDRESS_SPACE,
+      true);
+  globalOp.setUnnamedAddrAttr(LLVM::UnnamedAddrAttr::get(
+      builder.getContext(), LLVM::UnnamedAddr::Global));
   globalOp.setSectionAttr(globalOp.getConstant()
                               ? m_typeConverter.getConstantSection()
                               : m_typeConverter.getCollectionSection());
   m_symbolTable.insert(globalOp);
-  m_globalConstants.insert({objectAttr, globalOp});
+  m_constantObjects.insert({objectAttr, globalOp});
   initializeGlobal(globalOp, builder, objectAttr);
   return globalOp;
 }
 
-mlir::LLVM::GlobalOp pylir::CodeGenState::getGlobalValue(
-    mlir::OpBuilder& builder, pylir::Py::GlobalValueAttr globalValueAttr) {
+LLVM::GlobalOp
+CodeGenState::getGlobalValue(OpBuilder& builder,
+                             Py::GlobalValueAttr globalValueAttr) {
   auto [iter, inserted] = m_globalValues.insert({globalValueAttr, nullptr});
   if (!inserted)
     return iter->second;
 
-  mlir::Type type;
+  Type type;
   if (!globalValueAttr.getInitializer()) {
     // If we don't have an initializer, we use the generic PyObject layout for
     // convenience. Semantically, the type given here has no meaning and LLVM
@@ -602,8 +592,7 @@ mlir::LLVM::GlobalOp pylir::CodeGenState::getGlobalValue(
   // Check if the global value appeared in an `py.external`.
   // Gives the symbol name that must be used or a null attribute if there was no
   // such occurrence.
-  mlir::StringAttr exportedName =
-      m_externalGlobalValues.lookup(globalValueAttr);
+  StringAttr exportedName = m_externalGlobalValues.lookup(globalValueAttr);
 
   bool constant = globalValueAttr.getConstant();
   if (globalValueAttr.getInitializer()) {
@@ -612,16 +601,16 @@ mlir::LLVM::GlobalOp pylir::CodeGenState::getGlobalValue(
     constant =
         constant && !needToBeRuntimeInit(globalValueAttr.getInitializer());
   }
-  mlir::OpBuilder::InsertionGuard guard{builder};
+  OpBuilder::InsertionGuard guard{builder};
   builder.setInsertionPointToEnd(
-      mlir::cast<mlir::ModuleOp>(m_symbolTable.getOp()).getBody());
-  auto globalOp = builder.create<mlir::LLVM::GlobalOp>(
+      cast<ModuleOp>(m_symbolTable.getOp()).getBody());
+  auto globalOp = builder.create<LLVM::GlobalOp>(
       builder.getUnknownLoc(), type, constant,
       /*linkage=*/
-      exportedName ? mlir::LLVM::linkage::Linkage::External
-                   : mlir::LLVM::linkage::Linkage::Internal,
+      exportedName ? LLVM::linkage::Linkage::External
+                   : LLVM::linkage::Linkage::Internal,
       /*name=*/exportedName ? exportedName : globalValueAttr.getName(),
-      /*value=*/mlir::Attribute{}, /*alignment=*/0, REF_ADDRESS_SPACE,
+      /*value=*/Attribute{}, /*alignment=*/0, REF_ADDRESS_SPACE,
       /*dsoLocal=*/true);
   if (!exportedName) {
     // If not meant to be exported, do an explicit insert into the symbol table.

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.hpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyAttributes.hpp
@@ -43,6 +43,10 @@ public:
   }
 
   static bool classof(mlir::Attribute attribute);
+
+  static ConcreteObjectAttribute getFromOpaquePointer(const void* ptr) {
+    return ConcreteObjectAttribute(reinterpret_cast<const ImplType*>(ptr));
+  }
 };
 
 } // namespace pylir::Py


### PR DESCRIPTION
A few pain points fixed by this PR:
* `initializeGlobal` was way too large and unwieldy. Replace its huge `TypeSwitch` with function overloading
* `createGlobalConstant` had a really confusing name in the context of all the other methods. Rename it and add doc comments.
* Adjust to new codestyle