### PR TITLE
[cmake] Improve the mono-build experience with MSVC

### DIFF
--- a/3rdParty/CMakeLists.txt
+++ b/3rdParty/CMakeLists.txt
@@ -4,9 +4,6 @@
 
 include(CPM)
 
-# Required by FMT to detect whether clang-cl is using exceptions. Since we never
-# do, just hardcode it to 0.
-add_compile_definitions(_HAS_EXCEPTIONS=0)
 CPMAddPackage("gh:catchorg/Catch2@3.3.0")
 CPMAddPackage("gh:fmtlib/fmt#7.1.3")
 # Use the same C++ version everywhere.

--- a/3rdParty/CMakeLists.txt
+++ b/3rdParty/CMakeLists.txt
@@ -4,8 +4,13 @@
 
 include(CPM)
 
+# Required by FMT to detect whether clang-cl is using exceptions. Since we never
+# do, just hardcode it to 0.
+add_compile_definitions(_HAS_EXCEPTIONS=0)
 CPMAddPackage("gh:catchorg/Catch2@3.3.0")
 CPMAddPackage("gh:fmtlib/fmt#7.1.3")
+# Use the same C++ version everywhere.
+set(CTRE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
 CPMAddPackage("gh:hanickadot/compile-time-regular-expressions#v3.8")
 CPMAddPackage(
   NAME libtommath
@@ -24,17 +29,17 @@ CPMAddPackage(
   SYSTEM
 )
 
-#==============================================================================#
+#===------------------------------------------------------------------------===#
 # utf8proc
-#==============================================================================#
+#===------------------------------------------------------------------------===#
 
 add_library(utf8proc STATIC EXCLUDE_FROM_ALL ${utf8proc_SOURCE_DIR}/utf8proc.c)
 target_compile_definitions(utf8proc PUBLIC UTF8PROC_STATIC)
 target_include_directories(utf8proc SYSTEM PUBLIC ${utf8proc_SOURCE_DIR})
 
-#==============================================================================#
+#===------------------------------------------------------------------------===#
 # libtommath
-#==============================================================================#
+#===------------------------------------------------------------------------===#
 
 file(GLOB tommath_srcs "${libtommath_SOURCE_DIR}/*.c")
 add_library(tommath STATIC EXCLUDE_FROM_ALL ${tommath_srcs})
@@ -42,16 +47,16 @@ target_include_directories(tommath SYSTEM PUBLIC ${libtommath_SOURCE_DIR})
 target_compile_definitions(tommath
   PUBLIC MP_NO_ZERO_ON_FREE MP_NO_FILE MP_FIXED_CUTOFFS)
 
-#==============================================================================#
+#===------------------------------------------------------------------------===#
 # Catch2
-#==============================================================================#
+#===------------------------------------------------------------------------===#
 
 # Workaround for https://github.com/cpm-cmake/CPM.cmake/issues/475.
 list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
 
-#==============================================================================#
+#===------------------------------------------------------------------------===#
 # libunwind
-#==============================================================================#
+#===------------------------------------------------------------------------===#
 
 if (MSVC)
   # Workaround for cmake issue:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@ project(Pylir VERSION 0.0.1)
 
 set(CMAKE_CXX_STANDARD 17)
 
+#===------------------------------------------------------------------------===#
+# Project Build Options
+#===------------------------------------------------------------------------===#
+
 option(PYLIR_BUILD_TESTS "Build tests" ON)
 option(PYLIR_BUILD_DOCS "Build documentation" OFF)
 option(PYLIR_FUZZER "Build fuzzers" OFF)
@@ -15,21 +19,40 @@ option(PYLIR_INCLUDE_LLVM_BUILD
   "Whether to download and build LLVM as part of Pylir" ON)
 set(PYLIR_SANITIZERS "" CACHE STRING "Compile with given sanitizers")
 
-if (NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   option(PYLIR_ENABLE_ASSERTIONS "Enable assertions" OFF)
 else ()
   option(PYLIR_ENABLE_ASSERTIONS "Enable assertions" ON)
 endif ()
 
-## Set up dependencies and global include and link directories.
+option(PYLIR_ENABLE_RTTI "Enable generation of RTTI" OFF)
 
-# All platforms we currently care about default to PIC. This is also required
-# when linking a shared library (including a static into a shared).
-set(CMAKE_POSITION_INDEPENDENT_CODE ON CACHE "BOOL" "")
+if (NOT PYLIR_INCLUDE_LLVM_BUILD)
+  find_package(Threads REQUIRED)
+  link_libraries(Threads::Threads)
+  find_package(MLIR REQUIRED CONFIG)
+  find_package(LLD REQUIRED)
+
+  message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
+  message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+  if ((PYLIR_ENABLE_RTTI AND LLVM_ENABLE_RTTI)
+    OR (NOT LLVM_ENABLE_RTTI AND NOT PYLIR_ENABLE_RTTI))
+    message(WARNING "Value of PYLIR_ENABLE_RTTI overwritten by LLVM_ENABLE_RTTI")
+  endif ()
+  # Must match LLVMs RTTI setting as it causes linker issues otherwise.
+  set(PYLIR_ENABLE_RTTI ${LLVM_ENABLE_RTTI} CACHE BOOL "" FORCE)
+endif ()
+
+#===------------------------------------------------------------------------===#
+# Dependencies, global options, include and link directories setup.
+#===------------------------------------------------------------------------===#
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 # NO_POLICY_SCOPE makes policy changes done in the include affect the caller.
 include(CMakePolicies NO_POLICY_SCOPE)
+include(HandlePylirOptions)
+
+add_global_compile_options()
 
 add_subdirectory(3rdParty)
 
@@ -39,14 +62,12 @@ set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
 string(STRIP ${PYLIR_REQUIRED_LLVM_REVISION} PYLIR_REQUIRED_LLVM_REVISION)
 
 if (PYLIR_INCLUDE_LLVM_BUILD)
-  include(CPM)
-  
   # Default LLVM options to corresponding Pylir options.
   set(PYLIR_LLVM_CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}"
     CACHE STRING "Build type to use for LLVM compilation")
   option(LLVM_ENABLE_ASSERTIONS "Whether to build LLVM with assertions"
     ${PYLIR_ENABLE_ASSERTIONS})
-  
+
   string(REPLACE "address" "Address" llvm_sanitizer_default
     "${PYLIR_SANITIZERS}")
   string(REPLACE "undefined" "Undefined" llvm_sanitizer_default
@@ -54,91 +75,20 @@ if (PYLIR_INCLUDE_LLVM_BUILD)
   string(REPLACE "thread" "Thread" llvm_sanitizer_default
     "${llvm_sanitizer_default}")
   string(REPLACE "," ";" llvm_sanitizer_default "${llvm_sanitizer_default}")
-  
+
   set(LLVM_USE_SANITIZER "${llvm_sanitizer_default}" CACHE
     STRING "Sanitizers to use when building LLVM")
-  
-  # Purposefully enable console output as LLVM takes a long time to clone and
-  # users would not get feedback otherwise.
-  set(FETCHCONTENT_QUIET FALSE)
-  # These variables have to be unset if updating the LLVM version or similar
-  # as they may still point to the previous directory otherwise.
-  unset(LLVM_EXTERNAL_LLD_SOURCE_DIR CACHE)
-  unset(LLVM_EXTERNAL_MLIR_SOURCE_DIR CACHE)
-  CPMAddPackage(
-    NAME llvm_project
-    GITHUB_REPOSITORY llvm/llvm-project
-    GIT_TAG ${PYLIR_REQUIRED_LLVM_REVISION}
-    EXCLUDE_FROM_ALL TRUE
-    SYSTEM TRUE
-    SOURCE_SUBDIR llvm
-    GIT_PROGRESS TRUE
-    # Required for ninja:
-    # https://gitlab.kitware.com/cmake/cmake/-/issues/18238#note_440475.
-    USES_TERMINAL_DOWNLOAD TRUE
-    OPTIONS "LLVM_ENABLE_PROJECTS mlir\\\\;lld"
-    # The interface given by an "In-tree" LLVM build is not identical to the one
-    # given by the LLVM Config when using `find_package`. To workaround this,
-    # add an external project to the LLVM build that is called from within LLVM
-    # via `add_subdirectory`. This gives us the chance to inspect and set the
-    # required variables to get both build types to parity.
-    "LLVM_EXTERNAL_PROJECTS Pylir"
-    "LLVM_EXTERNAL_PYLIR_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cmake/LLVM-Unified-Adaptor"
-    "LLVM_INCLUDE_TESTING OFF"
-    "LLVM_INCLUDE_BENCHMARKS OFF"
-    "LLVM_INCLUDE_DOCS OFF"
-    # Targets currently tested with Pylir
-    # TODO: Make this an option that is automatically quoted.
-    "LLVM_TARGETS_TO_BUILD X86\\\\;AArch64"
-    "CMAKE_BUILD_TYPE ${PYLIR_LLVM_CMAKE_BUILD_TYPE}"
-    "LLVM_USE_SANITIZER ${LLVM_USE_SANITIZER}"
-  )
-  
-  # LLVMs cmake file currently has a bug where it sets `EXCLUDE_FROM_ALL` to
-  # `OFF` within a macro(!), affecting all targets created afterwards.
-  # Workaround this by manually going over all targets and explicitly excluding
-  # them again.
-  macro(exclude_all_targets_recursive dir)
-    get_property(subdirectories DIRECTORY ${dir} PROPERTY SUBDIRECTORIES)
-    foreach (subdir ${subdirectories})
-      exclude_all_targets_recursive(${subdir})
-    endforeach ()
-    
-    get_property(current_targets DIRECTORY ${dir} PROPERTY BUILDSYSTEM_TARGETS)
-    foreach (target IN LISTS current_targets)
-      set_target_properties(${target} PROPERTIES EXCLUDE_FROM_ALL "ON")
-    endforeach ()
-  endmacro()
 
-  exclude_all_targets_recursive("${llvm_project_SOURCE_DIR}/llvm")
-  exclude_all_targets_recursive("${llvm_project_SOURCE_DIR}/mlir")
-  exclude_all_targets_recursive("${llvm_project_SOURCE_DIR}/lld")
-  
-  # Fetch the variables set by `LLVM-Unified-Adaptor` cmake from the global
-  # property and apply them to this scope as `find_package(LLVM)` would.
-  get_property(propagated_flags GLOBAL PROPERTY PYLIR_PROPAGATED_LLVM_FLAGS)
-  foreach (pair IN LISTS propagated_flags)
-    # A list element has the form "var=value" where `value` has all `;`
-    # replaced with `,`.
-    string(REGEX MATCH "^[^ =]+" var_key "${pair}")
-    string(LENGTH "${pair}" var_length)
-    string(LENGTH "${var_key}" var_key_length)
-    math(EXPR var_key_length "${var_key_length}+1")
-    string(SUBSTRING "${pair}" "${var_key_length}" "-1" var_value)
-    string(REPLACE "," ";" var_value "${var_value}")
-    set(${var_key} ${var_value})
-  endforeach ()
+  include(PylirLLVMBuild)
 
+  add_required_llvm_build(${PYLIR_REQUIRED_LLVM_REVISION})
 else ()
-  find_package(Threads REQUIRED)
-  link_libraries(Threads::Threads)
-  find_package(MLIR REQUIRED CONFIG)
-  find_package(LLD REQUIRED)
-  
-  message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
-  message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
-  
-  find_file(VCS_HEADER VCSRevision.h PATHS ${LLVM_INCLUDE_DIRS} PATH_SUFFIXES llvm/Support/ REQUIRED NO_DEFAULT_PATH)
+  # Check the VCS Revision of the found LLVM and check that it matches the
+  # required. Warn otherwise.
+  find_file(VCS_HEADER VCSRevision.h
+    PATHS ${LLVM_INCLUDE_DIRS}
+    PATH_SUFFIXES llvm/Support/
+    REQUIRED NO_DEFAULT_PATH)
   message(STATUS "Checking ${VCS_HEADER} for version mismatch")
   file(READ ${VCS_HEADER} VCS_FILE)
   string(REGEX MATCH "#define LLVM_REVISION \"([a-z0-9]+)\"" VCS_MATCH ${VCS_FILE})
@@ -164,7 +114,7 @@ set(MLIR_BINARY_DIR ${CMAKE_BINARY_DIR})
 
 list(APPEND CMAKE_MODULE_PATH ${MLIR_CMAKE_DIR})
 list(APPEND CMAKE_MODULE_PATH ${LLVM_CMAKE_DIR})
-include(HandlePylirOptions)
+add_project_compile_options()
 include(TableGen)
 include(AddLLVM)
 include(AddMLIR)

--- a/cmake/HandlePylirOptions.cmake
+++ b/cmake/HandlePylirOptions.cmake
@@ -40,16 +40,9 @@ macro(add_global_compile_options)
   # when linking a shared library (including a static into a shared).
   set(CMAKE_POSITION_INDEPENDENT_CODE ON CACHE "BOOL" "")
 
-  # Turn off exceptions entirely within the compiler. They are simply not used
-  # and there is therefore no need to pay the size cost for them.
-  if (MSVC)
-    add_compile_options(/EHs-c-)
-  else ()
-    add_compile_options(-fno-exceptions)
-  endif ()
-
   # Workaround https://github.com/llvm/llvm-project/issues/65255
   if (MSVC)
+    add_compile_options(/EHsc)
     add_compile_definitions(_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING
       _CRT_SECURE_NO_WARNINGS)
   endif ()

--- a/cmake/HandlePylirOptions.cmake
+++ b/cmake/HandlePylirOptions.cmake
@@ -4,146 +4,176 @@
 
 include(CheckCXXCompilerFlag)
 
-if (NOT MSVC)
-  # GNU style flags.
-  add_compile_options(-pedantic -Wall -Wextra $<$<COMPILE_LANGUAGE:CXX>:-Wnon-virtual-dtor>)
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    if (WIN32)
-      if (NOT ${CMAKE_CXX_FLAGS} MATCHES ".*[ \t\r\n]-flto[^a-zA-Z_].*")
-        add_compile_options(-Wa,-mbig-obj)
+# Macro consolidating all logic of compile options for Pylir but not any of its
+# dependencies.
+macro(add_project_compile_options)
+  if (NOT MSVC)
+    # GNU style flags.
+    add_compile_options(-pedantic -Wall -Wextra $<$<COMPILE_LANGUAGE:CXX>:-Wnon-virtual-dtor>)
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+      if (WIN32)
+        if (NOT ${CMAKE_CXX_FLAGS} MATCHES ".*[ \t\r\n]-flto[^a-zA-Z_].*")
+          add_compile_options(-Wa,-mbig-obj)
+        endif ()
+      endif ()
+    endif ()
+  elseif (MSVC)
+    # MSVC style flags.
+    add_compile_options(/bigobj /permissive- /W4 /Zc:__cplusplus /utf-8)
+    if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+      add_compile_options(/Zc:preprocessor)
+    endif ()
+  endif ()
+
+  if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang")
+    # Flags for both clang-cl and normal clang.
+    add_compile_options(-Wno-nullability-completeness -Wno-nullability-extension -Wno-assume
+      $<$<COMPILE_LANGUAGE:CXX>:-Wno-return-type-c-linkage>)
+  endif ()
+endmacro()
+
+# Macro consolidating all logic of compile options for Pylir and all of its
+# dependencies. This mostly contains compiler instrumentation options and code
+# generation options that have to match between all dependencies.
+macro(add_global_compile_options)
+  # All platforms we currently care about default to PIC. This is also required
+  # when linking a shared library (including a static into a shared).
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON CACHE "BOOL" "")
+
+  # Turn off exceptions entirely within the compiler. They are simply not used
+  # and there is therefore no need to pay the size cost for them.
+  if (MSVC)
+    add_compile_options(/EHs-c-)
+  else ()
+    add_compile_options(-fno-exceptions)
+  endif ()
+
+  # Workaround https://github.com/llvm/llvm-project/issues/65255
+  if (MSVC)
+    add_compile_definitions(_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING
+      _CRT_SECURE_NO_WARNINGS)
+  endif ()
+
+  if (PYLIR_ENABLE_ASSERTIONS)
+    # On non-Debug builds cmake automatically defines NDEBUG, so we
+    # explicitly undefine it:
+    if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+      # NOTE: use `add_compile_options` rather than `add_definitions` since
+      # `add_definitions` does not support generator expressions.
+      add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-UNDEBUG>)
+      if (MSVC)
+        # Also remove /D NDEBUG to avoid MSVC warnings about conflicting defines.
+        foreach (flags_var_to_scrub
+          CMAKE_CXX_FLAGS_RELEASE
+          CMAKE_CXX_FLAGS_RELWITHDEBINFO
+          CMAKE_CXX_FLAGS_MINSIZEREL
+          CMAKE_C_FLAGS_RELEASE
+          CMAKE_C_FLAGS_RELWITHDEBINFO
+          CMAKE_C_FLAGS_MINSIZEREL)
+          string(REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" " "
+            "${flags_var_to_scrub}" "${${flags_var_to_scrub}}")
+        endforeach ()
       endif ()
     endif ()
   endif ()
-elseif (MSVC)
-  # MSVC style flags.
-  add_compile_options(/bigobj /permissive- /W4 /Zc:__cplusplus /utf-8 /EHsc)
-  add_compile_definitions(_CRT_SECURE_NO_WARNINGS _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING)
-  if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    add_compile_options(/Zc:preprocessor)
+
+  # Clang-cl is not used for linking, cmake calls lld-link directly. We have to
+  # pass the runtime directory of clang-cl instead to find the directory where
+  # the runtime libraries are contained in.
+  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND MSVC AND (PYLIR_COVERAGE OR PYLIR_SANITIZERS OR PYLIR_FUZZER))
+    execute_process(
+      COMMAND ${CMAKE_CXX_COMPILER} /clang:-print-libgcc-file-name /clang:--rtlib=compiler-rt
+      OUTPUT_VARIABLE clang_compiler_rt_file
+      ERROR_VARIABLE clang_cl_stderr
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_STRIP_TRAILING_WHITESPACE
+      RESULT_VARIABLE clang_cl_exit_code)
+    if (NOT "${clang_cl_exit_code}" STREQUAL "0")
+      message(FATAL_ERROR
+        "Unable to invoke clang-cl to find resource dir: ${clang_cl_stderr}")
+    endif ()
+    file(TO_CMAKE_PATH "${clang_compiler_rt_file}" clang_compiler_rt_file)
+    get_filename_component(clang_runtime_dir "${clang_compiler_rt_file}" DIRECTORY)
+    message(STATUS "Clang-cl runtimes found in ${clang_runtime_dir}")
+    link_directories(${clang_runtime_dir})
   endif ()
-endif ()
 
-if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang")
-  # Flags for both clang-cl and normal clang.
-  add_compile_options(-Wno-nullability-completeness -Wno-nullability-extension -Wno-assume
-    $<$<COMPILE_LANGUAGE:CXX>:-Wno-return-type-c-linkage>)
-endif ()
+  if (PYLIR_COVERAGE)
+    message(STATUS "Compiling with Coverage")
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+      add_compile_options(--coverage)
+      if (WIN32)
+        link_libraries(gcov)
+      endif ()
+    elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+      add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
+      if (NOT MSVC)
+        add_link_options(-fprofile-instr-generate)
+      endif ()
+    else ()
+      message(ERROR "Unknown coverage implementation")
+    endif ()
+  endif ()
 
-if (PYLIR_ENABLE_ASSERTIONS)
-  # On non-Debug builds cmake automatically defines NDEBUG, so we
-  # explicitly undefine it:
-  if (NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
-    # NOTE: use `add_compile_options` rather than `add_definitions` since
-    # `add_definitions` does not support generator expressions.
-    add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-UNDEBUG>)
+  if (PYLIR_SANITIZERS)
     if (MSVC)
-      # Also remove /D NDEBUG to avoid MSVC warnings about conflicting defines.
-      foreach (flags_var_to_scrub
-        CMAKE_CXX_FLAGS_RELEASE
-        CMAKE_CXX_FLAGS_RELWITHDEBINFO
-        CMAKE_CXX_FLAGS_MINSIZEREL
-        CMAKE_C_FLAGS_RELEASE
-        CMAKE_C_FLAGS_RELWITHDEBINFO
-        CMAKE_C_FLAGS_MINSIZEREL)
-        string(REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" " "
-          "${flags_var_to_scrub}" "${${flags_var_to_scrub}}")
-      endforeach ()
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Oy- -fsanitize=${PYLIR_SANITIZERS} -fno-sanitize-recover=all")
+      link_libraries(clang_rt.asan.lib)
+      link_libraries(clang_rt.asan_cxx.lib)
+      link_libraries(clang_rt.asan-preinit.lib)
+    else ()
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=${PYLIR_SANITIZERS} -fno-sanitize-recover=all")
     endif ()
   endif ()
-endif ()
 
-# Clang-cl is not used for linking, cmake calls lld-link directly. We have to pass the runtime directory of clang-cl
-# instead to find the directory where the runtime libraries are contained in.
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND MSVC AND (PYLIR_COVERAGE OR PYLIR_SANITIZERS OR PYLIR_FUZZER))
-  execute_process(
-    COMMAND ${CMAKE_CXX_COMPILER} /clang:-print-libgcc-file-name /clang:--rtlib=compiler-rt
-    OUTPUT_VARIABLE clang_compiler_rt_file
-    ERROR_VARIABLE clang_cl_stderr
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_STRIP_TRAILING_WHITESPACE
-    RESULT_VARIABLE clang_cl_exit_code)
-  if (NOT "${clang_cl_exit_code}" STREQUAL "0")
-    message(FATAL_ERROR
-      "Unable to invoke clang-cl to find resource dir: ${clang_cl_stderr}")
+  # Pass -Wl,-z,defs. This makes sure all symbols are defined. Otherwise a DSO
+  # build might work on ELF but fail on MachO/COFF.
+  if (NOT (CMAKE_SYSTEM_NAME MATCHES "Darwin|FreeBSD|OpenBSD|DragonFly|AIX|OS390" OR
+    WIN32 OR CYGWIN) AND
+    NOT PYLIR_SANITIZERS)
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,defs")
   endif ()
-  file(TO_CMAKE_PATH "${clang_compiler_rt_file}" clang_compiler_rt_file)
-  get_filename_component(clang_runtime_dir "${clang_compiler_rt_file}" DIRECTORY)
-  message(STATUS "Clang-cl runtimes found in ${clang_runtime_dir}")
-  link_directories(${clang_runtime_dir})
-endif ()
 
-if (PYLIR_COVERAGE)
-  message(STATUS "Compiling with Coverage")
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    add_compile_options(--coverage)
+  # Matching LLVMs visibility option here. Mismatch of visibility can cause linker warnings on macOS.
+  if ((NOT (${CMAKE_SYSTEM_NAME} MATCHES "AIX")) AND
+  (NOT (WIN32 OR CYGWIN) OR (MINGW AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")))
+    # GCC for MinGW does nothing about -fvisibility-inlines-hidden, but warns
+    # about use of the attributes. As long as we don't use the attributes (to
+    # override the default) we shouldn't set the command line options either.
+    # GCC on AIX warns if -fvisibility-inlines-hidden is used and Clang on AIX doesn't currently support visibility.
+    check_cxx_compiler_flag("-fvisibility-inlines-hidden" SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG)
+    if (SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility-inlines-hidden")
+    endif ()
+  endif ()
+
+  set(to_replace)
+  set(to_add)
+  if (MSVC)
+    set(to_replace "/GR-")
+    set(to_add "/GR")
+  else ()
+    set(to_replace "-fno-rtti")
+    set(to_add "-frtti")
+  endif ()
+  if (NOT PYLIR_ENABLE_RTTI)
+    set(temp ${to_replace})
+    set(to_replace ${to_add})
+    set(to_add ${temp})
+  endif ()
+  string(REGEX REPLACE "${to_replace}" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${to_add}")
+
+  if (PYLIR_FUZZER)
+    add_compile_definitions(PYLIR_IN_FUZZER)
     if (WIN32)
-      link_libraries(gcov)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=fuzzer-no-link,address -fno-sanitize-recover=all")
+      link_libraries(clang_rt.asan.lib)
+      link_libraries(clang_rt.asan_cxx.lib)
+      link_libraries(clang_rt.asan-preinit.lib)
+      link_libraries(clang_rt.fuzzer.lib)
+    else ()
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=fuzzer-no-link,undefined,address -fno-sanitize-recover=all")
     endif ()
-  elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
-    if (NOT MSVC)
-      add_link_options(-fprofile-instr-generate)
-    endif ()
-  else ()
-    message(ERROR "Unknown coverage implementation")
   endif ()
-endif ()
-
-if (PYLIR_SANITIZERS)
-  if (MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Oy- -fsanitize=${PYLIR_SANITIZERS} -fno-sanitize-recover=all")
-    link_libraries(clang_rt.asan.lib)
-    link_libraries(clang_rt.asan_cxx.lib)
-    link_libraries(clang_rt.asan-preinit.lib)
-  else ()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=${PYLIR_SANITIZERS} -fno-sanitize-recover=all")
-  endif ()
-endif ()
-
-# Pass -Wl,-z,defs. This makes sure all symbols are defined. Otherwise a DSO
-# build might work on ELF but fail on MachO/COFF.
-if (NOT (CMAKE_SYSTEM_NAME MATCHES "Darwin|FreeBSD|OpenBSD|DragonFly|AIX|OS390" OR
-  WIN32 OR CYGWIN) AND
-  NOT PYLIR_SANITIZERS)
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,defs")
-endif ()
-
-# Matching LLVMs visibility option here. Mismatch of visibility can cause linker warnings on macOS.
-if ((NOT (${CMAKE_SYSTEM_NAME} MATCHES "AIX")) AND
-(NOT (WIN32 OR CYGWIN) OR (MINGW AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")))
-  # GCC for MinGW does nothing about -fvisibility-inlines-hidden, but warns
-  # about use of the attributes. As long as we don't use the attributes (to
-  # override the default) we shouldn't set the command line options either.
-  # GCC on AIX warns if -fvisibility-inlines-hidden is used and Clang on AIX doesn't currently support visibility.
-  check_cxx_compiler_flag("-fvisibility-inlines-hidden" SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG)
-  if (SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility-inlines-hidden")
-  endif ()
-endif ()
-
-# Matching LLVMs RTTI setting here. Could cause linker issues otherwise.
-if (NOT LLVM_ENABLE_RTTI)
-  if (MSVC)
-    string(REGEX REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
-  else ()
-    string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
-  endif ()
-endif ()
-
-# Always build even static libraries with PIC to be able to link them against shared libraries.
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-if (PYLIR_FUZZER)
-  add_compile_definitions(PYLIR_IN_FUZZER)
-  if (WIN32)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=fuzzer-no-link,address -fno-sanitize-recover=all")
-    link_libraries(clang_rt.asan.lib)
-    link_libraries(clang_rt.asan_cxx.lib)
-    link_libraries(clang_rt.asan-preinit.lib)
-    link_libraries(clang_rt.fuzzer.lib)
-  else ()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=fuzzer-no-link,undefined,address -fno-sanitize-recover=all")
-  endif ()
-endif ()
+endmacro()

--- a/cmake/PylirLLVMBuild.cmake
+++ b/cmake/PylirLLVMBuild.cmake
@@ -1,0 +1,94 @@
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Uses CPM to download and configure LLVM at the given revision.
+function(add_required_llvm_build llvm_revision)
+  include(CPM)
+
+  # Set the default value of the MSVC runtime library to the same as CMake
+  # as is documented here: https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html
+  # This is required to make the LLVM build use the same runtime library
+  # regardless of the value of `PYLIR_LLVM_CMAKE_BUILD_TYPE`.
+  set(msvc_runtime_default "MultiThreadedDLL")
+  if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(msvc_runtime_default "MultiThreadedDebugDLL")
+  endif ()
+
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "${msvc_runtime_default}"
+    CACHE STRING "MSVC Runtime library to use")
+
+  # Purposefully enable console output as LLVM takes a long time to clone and
+  # users would not get feedback otherwise.
+  set(FETCHCONTENT_QUIET FALSE)
+  # These variables have to be unset if updating the LLVM version or similar
+  # as they may still point to the previous directory otherwise.
+  unset(LLVM_EXTERNAL_LLD_SOURCE_DIR CACHE)
+  unset(LLVM_EXTERNAL_MLIR_SOURCE_DIR CACHE)
+  CPMAddPackage(
+    NAME llvm_project
+    GITHUB_REPOSITORY llvm/llvm-project
+    GIT_TAG ${llvm_revision}
+    EXCLUDE_FROM_ALL TRUE
+    SYSTEM TRUE
+    SOURCE_SUBDIR llvm
+    GIT_PROGRESS TRUE
+    # Required for ninja:
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/18238#note_440475.
+    USES_TERMINAL_DOWNLOAD TRUE
+    OPTIONS "LLVM_ENABLE_PROJECTS mlir\\\\;lld"
+    # The interface given by an "In-tree" LLVM build is not identical to the one
+    # given by the LLVM Config when using `find_package`. To workaround this,
+    # add an external project to the LLVM build that is called from within LLVM
+    # via `add_subdirectory`. This gives us the chance to inspect and set the
+    # required variables to get both build types to parity.
+    "LLVM_EXTERNAL_PROJECTS Pylir"
+    "LLVM_EXTERNAL_PYLIR_SOURCE_DIR ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/LLVM-Unified-Adaptor"
+    "LLVM_INCLUDE_TESTING OFF"
+    "LLVM_INCLUDE_RUNTIMES OFF"
+    "LLVM_INCLUDE_EXAMPLES OFF"
+    "LLVM_INCLUDE_BENCHMARKS OFF"
+    "LLVM_INCLUDE_DOCS OFF"
+    # Targets currently tested with Pylir
+    # TODO: Make this an option that is automatically quoted.
+    "LLVM_TARGETS_TO_BUILD X86\\\\;AArch64"
+    "CMAKE_BUILD_TYPE ${PYLIR_LLVM_CMAKE_BUILD_TYPE}"
+    "LLVM_ENABLE_RTTI ${PYLIR_ENABLE_RTTI}"
+  )
+
+  # LLVMs cmake file currently has a bug where it sets `EXCLUDE_FROM_ALL` to
+  # `OFF` within a macro(!), affecting all targets created afterwards.
+  # Workaround this by manually going over all targets and explicitly excluding
+  # them again.
+  macro(exclude_all_targets_recursive dir)
+    get_property(subdirectories DIRECTORY ${dir} PROPERTY SUBDIRECTORIES)
+    foreach (subdir ${subdirectories})
+      exclude_all_targets_recursive(${subdir})
+    endforeach ()
+
+    get_property(current_targets DIRECTORY ${dir} PROPERTY BUILDSYSTEM_TARGETS)
+    foreach (target IN LISTS current_targets)
+      set_target_properties(${target} PROPERTIES EXCLUDE_FROM_ALL "ON")
+    endforeach ()
+  endmacro()
+
+  exclude_all_targets_recursive("${llvm_project_SOURCE_DIR}/llvm")
+  exclude_all_targets_recursive("${llvm_project_SOURCE_DIR}/mlir")
+  exclude_all_targets_recursive("${llvm_project_SOURCE_DIR}/lld")
+
+  # Fetch the variables set by `LLVM-Unified-Adaptor` cmake from the global
+  # property and apply them to this scope as `find_package(LLVM)` would.
+  get_property(propagated_flags GLOBAL PROPERTY PYLIR_PROPAGATED_LLVM_FLAGS)
+  foreach (pair IN LISTS propagated_flags)
+    # A list element has the form "var=value" where `value` has all `;`
+    # replaced with `,`.
+    string(REGEX MATCH "^[^ =]+" var_key "${pair}")
+    string(LENGTH "${pair}" var_length)
+    string(LENGTH "${var_key}" var_key_length)
+    math(EXPR var_key_length "${var_key_length}+1")
+    string(SUBSTRING "${pair}" "${var_key_length}" "-1" var_value)
+    string(REPLACE "," ";" var_value "${var_value}")
+    # Set the variable in the caller.
+    set(${var_key} ${var_value} PARENT_SCOPE)
+  endforeach ()
+endfunction()

--- a/src/pylir/Runtime/CMakeLists.txt
+++ b/src/pylir/Runtime/CMakeLists.txt
@@ -10,6 +10,12 @@ endif ()
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/pylir/${TARGET_TRIPLE}")
 
+if (MSVC)
+  add_compile_options(/EHsc)
+else ()
+  add_compile_options(-fexceptions)
+endif ()
+
 # Collects all non-imported targets that 'target' links against transitively into 'listvar', including 'target' itself.
 function(collect_libs target listvar)
   set(worklist ${${listvar}})

--- a/src/pylir/Runtime/CMakeLists.txt
+++ b/src/pylir/Runtime/CMakeLists.txt
@@ -10,12 +10,6 @@ endif ()
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/pylir/${TARGET_TRIPLE}")
 
-if (MSVC)
-  add_compile_options(/EHsc)
-else ()
-  add_compile_options(-fexceptions)
-endif ()
-
 # Collects all non-imported targets that 'target' links against transitively into 'listvar', including 'target' itself.
 function(collect_libs target listvar)
   set(worklist ${${listvar}})


### PR DESCRIPTION
The current mono-build with LLVM had a few issues when using options such as `PYLIR_LLVM_CMAKE_BUILD_TYPE` or `LLVM_USE_SANITIZER` due to MSVC requiring strictre matchup of the flags used for compiling all files.

This PR fixes that and refactors the cmake code, nicely splitting cmake options and settings into "Project specific" and "Project + 3rd Party" specific sections.