### PR TITLE
[PylirToLLVM] Explicitly check precondition of pass

### DIFF
--- a/src/pylir/Optimizer/Conversion/PylirToLLVMIR/CodeGenState.cpp
+++ b/src/pylir/Optimizer/Conversion/PylirToLLVMIR/CodeGenState.cpp
@@ -267,7 +267,7 @@ void CodeGenState::initializeGlobal(LLVM::GlobalOp global, OpBuilder& builder,
 
   DictionaryAttr initMap = constObjectAttrInterface.getSlots();
   for (auto [index, slotName] : llvm::enumerate(
-           dyn_cast<TypeAttrInterface>(typeObject).getInstanceSlots())) {
+           cast<TypeAttrInterface>(typeObject).getInstanceSlots())) {
     Value value;
     Attribute element = initMap.get(slotName.cast<Py::StrAttr>().getValue());
     if (!element)
@@ -477,7 +477,7 @@ Value CodeGenState::initialize(Location loc, OpBuilder& builder, DictAttr attr,
     for (const auto& [key, value] : attr.getKeyValuePairs()) {
       Value keyValue = getConstant(loc, builder, key);
       std::optional<Mem::LayoutType> layoutType = m_typeConverter.getLayoutType(
-          dyn_cast<ObjectAttrInterface>(key).getTypeObject());
+          cast<ObjectAttrInterface>(key).getTypeObject());
       Value hash;
       if (layoutType == Mem::LayoutType::String) {
         hash = createRuntimeCall(loc, builder, Runtime::pylir_str_hash,

--- a/src/pylir/Optimizer/Conversion/PylirToLLVMIR/PylirTypeConverter.cpp
+++ b/src/pylir/Optimizer/Conversion/PylirToLLVMIR/PylirTypeConverter.cpp
@@ -197,7 +197,7 @@ pylir::PylirTypeConverter::getLayoutType(mlir::Attribute attr) {
 
 mlir::LLVM::LLVMStructType
 pylir::PylirTypeConverter::typeOf(pylir::Py::ObjectAttrInterface objectAttr) {
-  unsigned count = dyn_cast<TypeAttrInterface>(objectAttr.getTypeObject())
+  unsigned count = cast<TypeAttrInterface>(objectAttr.getTypeObject())
                        .getInstanceSlots()
                        .size();
   return llvm::TypeSwitch<pylir::Py::ObjectAttrInterface,


### PR DESCRIPTION
Violating this precondition has previously led to horrible to comprehend stack traces with either a debugger or guess work required to fix. This now checks the preconditions prior to the pass, emits a proper error message if violated, and also serves to better document the pass preconditions