### PR TITLE
[test][NFC] Remove redundant `#py.globalValue` attributes

### DIFF
--- a/test/Main/input.mlir
+++ b/test/Main/input.mlir
@@ -2,19 +2,6 @@
 // RUN: pylir-opt %s -o %t.mlirbc -emit-bytecode
 // RUN: pylir %t.mlirbc -o - -S -emit-llvm | FileCheck %s
 
-#const = #py.globalValue<"const$", const, initializer = #py.tuple<(#py.str<"__slots__">)>>
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type<slots = {__slots__ = #const}>>
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-#builtins_function = #py.globalValue<builtins.function, initializer = #py.type>
-#builtins_dict = #py.globalValue<builtins.dict, initializer = #py.type>
-
-py.external @builtins.type, #builtins_type
-py.external @builtins.tuple, #builtins_tuple
-py.external @builtins.str, #builtins_str
-py.external @builtins.function, #builtins_function
-py.external @builtins.dict, #builtins_dict
-
 py.func @foo(%arg0 : !py.dynamic) -> !py.dynamic {
     %0 = typeOf %arg0
     %1 = typeOf %0

--- a/test/Optimizer/PylirPy/IR/constant.mlir
+++ b/test/Optimizer/PylirPy/IR/constant.mlir
@@ -1,26 +1,6 @@
 // RUN: pylir-opt %s | pylir-opt | FileCheck %s
 // RUN: pylir-opt %s --mlir-print-op-generic | pylir-opt | FileCheck %s
 
-// Stubs
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-#builtins_float = #py.globalValue<builtins.float, initializer = #py.type>
-py.external @builtins.float, #builtins_float
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-#builtins_list= #py.globalValue<builtins.list, initializer = #py.type>
-py.external @builtins.list, #builtins_list
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_dict= #py.globalValue<builtins.dict, initializer = #py.type>
-py.external @builtins.dict, #builtins_dict
-#builtins_function = #py.globalValue<builtins.function, initializer = #py.type>
-py.external @builtins.function, #builtins_function
-#builtins_None = #py.globalValue<builtins.None, initializer = #py.type>
-py.external @builtins.None, #builtins_None
-
 py.func @foo(%arg0 : !py.dynamic, %arg1 : !py.dynamic, %arg2 : !py.dynamic) -> !py.dynamic {
     return %arg0 : !py.dynamic
 }

--- a/test/Optimizer/PylirPy/IR/dict-attr.mlir
+++ b/test/Optimizer/PylirPy/IR/dict-attr.mlir
@@ -1,16 +1,5 @@
 // RUN: pylir-opt %s -split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_dict= #py.globalValue<builtins.dict, initializer = #py.type>
-py.external @builtins.dict, #builtins_dict
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-#builtins_float = #py.globalValue<builtins.float, initializer = #py.type>
-py.external @builtins.float, #builtins_float
-
 // CHECK-LABEL: @foo
 py.func @foo() {
   // CHECK-NEXT: constant

--- a/test/Optimizer/PylirPy/IR/dict-len-op-fold.mlir
+++ b/test/Optimizer/PylirPy/IR/dict-len-op-fold.mlir
@@ -1,16 +1,7 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_dict= #py.globalValue<builtins.dict, initializer = #py.type>
-py.external @builtins.dict, #builtins_dict
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-
 py.func @test() -> index {
-    %0 = constant(#py.dict<{#py.str<"test"> to #builtins_str}>)
+    %0 = constant(#py.dict<{#py.str<"test"> to #py.int<3>}>)
     %2 = dict_len %0
     return %2 : index
 }

--- a/test/Optimizer/PylirPy/IR/dict-try-get-item-fold.mlir
+++ b/test/Optimizer/PylirPy/IR/dict-try-get-item-fold.mlir
@@ -1,18 +1,5 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_dict= #py.globalValue<builtins.dict, initializer = #py.type>
-py.external @builtins.dict, #builtins_dict
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-#builtins_float = #py.globalValue<builtins.float, initializer = #py.type>
-py.external @builtins.float, #builtins_float
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-
 py.func @test(%arg0 : !py.dynamic, %arg1 : index) -> i1 {
     %0 = constant(#py.dict<{}>)
     %2 = dict_tryGetItem %0[%arg0 hash(%arg1)]

--- a/test/Optimizer/PylirPy/IR/function-call-fold.mlir
+++ b/test/Optimizer/PylirPy/IR/function-call-fold.mlir
@@ -1,18 +1,5 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_function = #py.globalValue<builtins.function, initializer = #py.type>
-py.external @builtins.function, #builtins_function
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_dict= #py.globalValue<builtins.dict, initializer = #py.type>
-py.external @builtins.dict, #builtins_dict
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-#builtins_None = #py.globalValue<builtins.None, initializer = #py.type>
-py.external @builtins.None, #builtins_None
-
 py.func @foo(%arg0 : !py.dynamic, %arg1 : !py.dynamic, %arg2 : !py.dynamic) -> !py.dynamic {
     return %arg0 : !py.dynamic
 }

--- a/test/Optimizer/PylirPy/IR/get-slot-op-fold.mlir
+++ b/test/Optimizer/PylirPy/IR/get-slot-op-fold.mlir
@@ -2,10 +2,6 @@
 
 #foo = #py.globalValue<foo, const, initializer = #py.tuple<(#py.str<"__slots__">)>>
 #builtins_type = #py.globalValue<builtins.type, const, initializer = #py.type<instance_slots = <(#py.str<"__slots__">)>, slots = { __slots__ = #foo }>>
-#builtins_tuple = #py.globalValue<builtins.tuple, const, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
 
 py.func @test() -> !py.dynamic {
     %0 = constant(#builtins_type)

--- a/test/Optimizer/PylirPy/IR/inliner-interface.mlir
+++ b/test/Optimizer/PylirPy/IR/inliner-interface.mlir
@@ -1,11 +1,6 @@
 // RUN: pylir-opt %s --test-inliner-interface --split-input-file | FileCheck %s
 // RUN: pylir-opt %s --test-inliner-interface --split-input-file -mlir-print-debuginfo -mlir-print-local-scope  | FileCheck %s --check-prefix INLINE-LOC
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-
 py.func private @create_exception() -> !py.dynamic
 
 py.func @inline_foo(%arg0 : i1) -> !py.dynamic {
@@ -64,15 +59,6 @@ py.func @__init__() -> !py.dynamic {
 // CHECK-NEXT: return %[[EX]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, const, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-#builtins_dict= #py.globalValue<builtins.dict, const, initializer = #py.type>
-py.external @builtins.dict, #builtins_dict
 
 #function = #py.globalValue<function>
 
@@ -138,16 +124,7 @@ py.func @__init__() -> !py.dynamic {
 
 // -----
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, const, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-#builtins_dict= #py.globalValue<builtins.dict, const, initializer = #py.type>
-py.external @builtins.dict, #builtins_dict
 #builtins_BaseException = #py.globalValue<builtins.BaseException, initializer = #py.type>
-py.external @builtins.BaseException, #builtins_BaseException
 
 #function = #py.globalValue<function>
 
@@ -169,16 +146,7 @@ py.func @test_loc() -> !py.dynamic {
 
 // -----
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, const, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-#builtins_dict= #py.globalValue<builtins.dict, const, initializer = #py.type>
-py.external @builtins.dict, #builtins_dict
 #builtins_BaseException = #py.globalValue<builtins.BaseException, initializer = #py.type>
-py.external @builtins.BaseException, #builtins_BaseException
 
 #function = #py.globalValue<function>
 

--- a/test/Optimizer/PylirPy/IR/int-add-fold.mlir
+++ b/test/Optimizer/PylirPy/IR/int-add-fold.mlir
@@ -1,12 +1,5 @@
 // RUN: pylir-opt %s -canonicalize | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-
 py.func @test1(%arg0 : !py.dynamic) -> !py.dynamic {
     %0 = constant(#py.int<5>)
     %1 = constant(#py.int<3>)

--- a/test/Optimizer/PylirPy/IR/int-cmp-fold.mlir
+++ b/test/Optimizer/PylirPy/IR/int-cmp-fold.mlir
@@ -1,12 +1,5 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-
 py.func @test1(%arg0 : !py.dynamic) -> i1 {
     %0 = constant(#py.int<5>)
     %1 = int_cmp eq %0, %arg0
@@ -193,13 +186,6 @@ py.func @test_eq() -> i1 {
 // CHECK-NEXT: return %[[C]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
 
 // CHECK-LABEL: @test_redundant_convert_1
 // CHECK-SAME: %[[ARG0:[[:alnum:]]+]]: index

--- a/test/Optimizer/PylirPy/IR/int-from-signed-fold.mlir
+++ b/test/Optimizer/PylirPy/IR/int-from-signed-fold.mlir
@@ -1,12 +1,5 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-
 py.func @test() -> !py.dynamic {
     %0 = arith.constant 5 : index
     %1 = int_fromSigned %0

--- a/test/Optimizer/PylirPy/IR/int-from-unsigned-fold.mlir
+++ b/test/Optimizer/PylirPy/IR/int-from-unsigned-fold.mlir
@@ -1,12 +1,5 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-
 py.func @test() -> !py.dynamic {
     %0 = arith.constant 5 : index
     %1 = int_fromUnsigned %0

--- a/test/Optimizer/PylirPy/IR/int-to-index-fold.mlir
+++ b/test/Optimizer/PylirPy/IR/int-to-index-fold.mlir
@@ -1,12 +1,5 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-
 py.func @test1() -> index {
     %0 = constant(#py.int<5>)
     %1 = int_toIndex %0

--- a/test/Optimizer/PylirPy/IR/int-to-str.mlir
+++ b/test/Optimizer/PylirPy/IR/int-to-str.mlir
@@ -1,14 +1,5 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-
 py.func @test() -> (!py.dynamic, !py.dynamic) {
     %0 = constant(#py.int<5>)
     %1 = constant(#py.int<-3>)

--- a/test/Optimizer/PylirPy/IR/is-fold.mlir
+++ b/test/Optimizer/PylirPy/IR/is-fold.mlir
@@ -1,11 +1,5 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
-// Stubs
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-
 // CHECK-LABEL: @same_value
 // CHECK: %[[RES:.*]] = arith.constant true
 // CHECK: return %[[RES]]
@@ -16,12 +10,6 @@ py.func @same_value() -> i1 {
 }
 
 // -----
-
-// Stubs
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
 
 // CHECK-LABEL: @two_allocs
 // CHECK: %[[RES:.*]] = arith.constant false
@@ -35,11 +23,8 @@ py.func @two_allocs(%arg0 : !py.dynamic) -> i1 {
 
 // -----
 
-// Stubs
 #builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
 #builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
 
 // CHECK-LABEL: @singletons
 // CHECK: %[[RES:.*]] = arith.constant true
@@ -63,11 +48,7 @@ py.func @singletons_not() -> i1 {
 
 // -----
 
-// Stubs
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
 #builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
 
 // CHECK-LABEL: @alloca_symbol
 // CHECK: %[[RES:.*]] = arith.constant false

--- a/test/Optimizer/PylirPy/IR/is-unbound-value-fold.mlir
+++ b/test/Optimizer/PylirPy/IR/is-unbound-value-fold.mlir
@@ -1,10 +1,5 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-
 py.func @entry_block(%arg0 : !py.dynamic) -> i1 {
     %0 = isUnboundValue %arg0
     return %0 : i1
@@ -15,11 +10,6 @@ py.func @entry_block(%arg0 : !py.dynamic) -> i1 {
 // CHECK: return %[[CONST]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
 
 py.global @a : !py.dynamic
 
@@ -42,11 +32,6 @@ py.func @block_argument(%arg0 : i1) -> i1 {
 // CHECK: return %[[I1]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
 
 py.global @a : !py.dynamic
 

--- a/test/Optimizer/PylirPy/IR/make-dict-dead-args.mlir
+++ b/test/Optimizer/PylirPy/IR/make-dict-dead-args.mlir
@@ -1,16 +1,5 @@
 // RUN: pylir-opt %s --canonicalize | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-#builtins_float = #py.globalValue<builtins.float, initializer = #py.type>
-py.external @builtins.float, #builtins_float
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-
 py.func @test1(%hash: index) -> !py.dynamic {
     %0 = constant(#py.int<0>)
     %1 = constant(#py.float<0.0>)

--- a/test/Optimizer/PylirPy/IR/make-ex-ops-remove-exception.mlir
+++ b/test/Optimizer/PylirPy/IR/make-ex-ops-remove-exception.mlir
@@ -1,12 +1,5 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-
 py.func @make_tuple_ex_op_unique(%arg0 : !py.dynamic) -> !py.dynamic {
     %0 = makeTuple (%arg0)
     %1 = constant(#py.int<3>)
@@ -27,13 +20,6 @@ py.func @make_tuple_ex_op_unique(%arg0 : !py.dynamic) -> !py.dynamic {
 // CHECK: return %[[TUPLE]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
 
 py.func @make_tuple_ex_op(%arg0 : !py.dynamic) -> !py.dynamic {
     %0 = makeTuple (%arg0)
@@ -56,13 +42,6 @@ py.func @make_tuple_ex_op(%arg0 : !py.dynamic) -> !py.dynamic {
 
 // -----
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-
 py.func @make_list_ex_op_unique(%arg0 : !py.dynamic) -> !py.dynamic {
     %0 = makeTuple (%arg0)
     %1 = constant(#py.int<3>)
@@ -83,13 +62,6 @@ py.func @make_list_ex_op_unique(%arg0 : !py.dynamic) -> !py.dynamic {
 // CHECK: return %[[LIST]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
 
 py.func @make_list_ex_op(%arg0 : !py.dynamic) -> !py.dynamic {
     %0 = makeTuple (%arg0)
@@ -112,13 +84,6 @@ py.func @make_list_ex_op(%arg0 : !py.dynamic) -> !py.dynamic {
 
 // -----
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-
 py.func @make_set_ex_op_unique(%arg0 : !py.dynamic) -> !py.dynamic {
     %0 = makeTuple (%arg0)
     %1 = constant(#py.int<3>)
@@ -139,13 +104,6 @@ py.func @make_set_ex_op_unique(%arg0 : !py.dynamic) -> !py.dynamic {
 // CHECK: return %[[SET]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
 
 py.func @make_set_ex_op(%arg0 : !py.dynamic) -> !py.dynamic {
     %0 = makeTuple (%arg0)
@@ -168,13 +126,6 @@ py.func @make_set_ex_op(%arg0 : !py.dynamic) -> !py.dynamic {
 
 // -----
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-
 py.func @make_dict_ex_op_unique(%arg0 : !py.dynamic, %hash : index) -> !py.dynamic {
     %1 = constant(#py.int<3>)
     %2 = makeDictEx (%1 hash(%hash) : %arg0)
@@ -195,13 +146,6 @@ py.func @make_dict_ex_op_unique(%arg0 : !py.dynamic, %hash : index) -> !py.dynam
 // CHECK: return %[[DICT]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
 
 py.func @make_dict_ex_op(%arg0 : !py.dynamic, %hash : index) -> !py.dynamic {
     %1 = constant(#py.int<3>)

--- a/test/Optimizer/PylirPy/IR/makedictop-parsing.mlir
+++ b/test/Optimizer/PylirPy/IR/makedictop-parsing.mlir
@@ -1,18 +1,5 @@
 // RUN: pylir-opt %s | pylir-opt | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-#builtins_dict= #py.globalValue<builtins.dict, initializer = #py.type>
-py.external @builtins.dict, #builtins_dict
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_list= #py.globalValue<builtins.list, initializer = #py.type>
-py.external @builtins.list, #builtins_list
-
 // CHECK-LABEL: @makedictop_test
 py.func @makedictop_test(%hash: index) -> !py.dynamic {
     %0 = constant(#py.int<0>)

--- a/test/Optimizer/PylirPy/IR/maketuple-fold.mlir
+++ b/test/Optimizer/PylirPy/IR/maketuple-fold.mlir
@@ -1,16 +1,5 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-#builtins_float = #py.globalValue<builtins.float, initializer = #py.type>
-py.external @builtins.float, #builtins_float
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-
 // CHECK-LABEL: @maketuple_simple
 // CHECK: %[[RES:.*]] = constant(#py.tuple
 // CHECK-SAME: #py.str<"text">
@@ -26,19 +15,6 @@ py.func @maketuple_simple() -> !py.dynamic {
 }
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-#builtins_float = #py.globalValue<builtins.float, initializer = #py.type>
-py.external @builtins.float, #builtins_float
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_list= #py.globalValue<builtins.list, initializer = #py.type>
-py.external @builtins.list, #builtins_list
 
 // CHECK-LABEL: @maketuple_expansion
 // CHECK: %[[RES:.*]] = constant(#py.tuple

--- a/test/Optimizer/PylirPy/IR/mro-lookup-fold.mlir
+++ b/test/Optimizer/PylirPy/IR/mro-lookup-fold.mlir
@@ -2,10 +2,6 @@
 
 #foo = #py.globalValue<foo, const, initializer = #py.tuple<(#py.str<"__slots__">)>>
 #builtins_type = #py.globalValue<builtins.type, const, initializer = #py.type<instance_slots = <(#py.str<"__slots__">)>, slots = { __slots__ = #foo }>>
-#builtins_tuple = #py.globalValue<builtins.tuple, const, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
 
 py.func @test1() -> !py.dynamic {
     %0 = constant(#py.tuple<(#builtins_type)>)

--- a/test/Optimizer/PylirPy/IR/str-concat-fold.mlir
+++ b/test/Optimizer/PylirPy/IR/str-concat-fold.mlir
@@ -1,12 +1,5 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-
 py.func @test() -> !py.dynamic {
     %0 = constant(#py.str<"Hello">)
     %1 = constant(#py.str<" ">)

--- a/test/Optimizer/PylirPy/IR/str-copy-ellision.mlir
+++ b/test/Optimizer/PylirPy/IR/str-copy-ellision.mlir
@@ -1,12 +1,5 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-
 py.func @test(%arg0 : !py.dynamic, %arg1 : !py.dynamic, %arg2 : !py.dynamic, %arg3 : !py.dynamic) -> !py.dynamic {
     %0 = str_copy %arg1 : %arg0
     %1 = str_copy %arg2 : %arg0
@@ -25,13 +18,6 @@ py.func @test(%arg0 : !py.dynamic, %arg1 : !py.dynamic, %arg2 : !py.dynamic, %ar
 
 // -----
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-
 py.func @test(%arg0 : !py.dynamic, %arg1 : !py.dynamic, %arg2 : !py.dynamic) -> !py.dynamic {
     %0 = str_copy %arg1 : %arg0
     %1 = str_copy %0 : %arg2
@@ -46,13 +32,6 @@ py.func @test(%arg0 : !py.dynamic, %arg1 : !py.dynamic, %arg2 : !py.dynamic) -> 
 // CHECK-NEXT: return %[[RES]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
 
 py.func @test(%arg0 : !py.dynamic, %arg1 : !py.dynamic, %arg2 : !py.dynamic) -> i1 {
     %0 = str_copy %arg1 : %arg0
@@ -69,14 +48,6 @@ py.func @test(%arg0 : !py.dynamic, %arg1 : !py.dynamic, %arg2 : !py.dynamic) -> 
 // CHECK-NEXT: return %[[RES]]
 
 // -----
-
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
 
 py.func @test(%arg0 : !py.dynamic, %arg1 : !py.dynamic) -> index {
     %0 = str_copy %arg1 : %arg0

--- a/test/Optimizer/PylirPy/IR/tuple-contains-fold.mlir
+++ b/test/Optimizer/PylirPy/IR/tuple-contains-fold.mlir
@@ -1,9 +1,6 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
 #builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
 
 py.func @test1(%arg0 : !py.dynamic) -> i1 {
     %0 = constant(#builtins_tuple)

--- a/test/Optimizer/PylirPy/IR/tuple-copy-fold.mlir
+++ b/test/Optimizer/PylirPy/IR/tuple-copy-fold.mlir
@@ -1,10 +1,5 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-
 py.func @test(%arg0 : !py.dynamic, %arg1 : !py.dynamic, %arg2 : !py.dynamic) -> !py.dynamic {
     %2 = tuple_copy %arg0 : %arg1
     %3 = tuple_copy %2 : %arg2
@@ -17,6 +12,8 @@ py.func @test(%arg0 : !py.dynamic, %arg1 : !py.dynamic, %arg2 : !py.dynamic) -> 
 // CHECK-SAME: %[[ARG2:[[:alnum:]]+]]
 // CHECK-NEXT: %[[COPY:.*]] = tuple_copy %[[ARG0]] : %[[ARG2]]
 // CHECK-NEXT: return %[[COPY]]
+
+#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
 
 py.func @test2(%arg0 : !py.dynamic) -> !py.dynamic {
 	%0 = makeTuple (%arg0)

--- a/test/Optimizer/PylirPy/IR/tuple-drop-front-fold.mlir
+++ b/test/Optimizer/PylirPy/IR/tuple-drop-front-fold.mlir
@@ -1,9 +1,7 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
 #builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
 #builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
 
 // CHECK: #[[$TUPLE:.*]] = #py.globalValue<builtins.tuple{{,|>}}
 

--- a/test/Optimizer/PylirPy/IR/tuple-expansion-canonicalization.mlir
+++ b/test/Optimizer/PylirPy/IR/tuple-expansion-canonicalization.mlir
@@ -1,12 +1,5 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-
 py.func @make_tuple_op(%arg0 : !py.dynamic) -> !py.dynamic {
     %0 = makeTuple (%arg0)
     %1 = constant(#py.int<3>)
@@ -21,13 +14,6 @@ py.func @make_tuple_op(%arg0 : !py.dynamic) -> !py.dynamic {
 // CHECK: return %[[RESULT]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
 
 py.func @make_list_op(%arg0 : !py.dynamic) -> !py.dynamic {
     %0 = makeTuple (%arg0)
@@ -44,13 +30,6 @@ py.func @make_list_op(%arg0 : !py.dynamic) -> !py.dynamic {
 
 // -----
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-
 py.func @make_set_op(%arg0 : !py.dynamic) -> !py.dynamic {
     %0 = makeTuple (%arg0)
     %1 = constant(#py.int<3>)
@@ -65,15 +44,6 @@ py.func @make_set_op(%arg0 : !py.dynamic) -> !py.dynamic {
 // CHECK: return %[[RESULT]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
 
 py.func @make_tuple_op_constant(%arg0 : !py.dynamic) -> !py.dynamic {
     %1 = constant(#py.tuple<(#py.int<3>, #py.str<"test">)>)

--- a/test/Optimizer/PylirPy/IR/tuple-get-item-fold.mlir
+++ b/test/Optimizer/PylirPy/IR/tuple-get-item-fold.mlir
@@ -1,9 +1,6 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
 #builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
 
 // CHECK: #[[$TUPLE:.*]] = #py.globalValue<builtins.tuple{{.*}}>
 

--- a/test/Optimizer/PylirPy/IR/tuple-len-fold.mlir
+++ b/test/Optimizer/PylirPy/IR/tuple-len-fold.mlir
@@ -1,16 +1,5 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-#builtins_float = #py.globalValue<builtins.float, initializer = #py.type>
-py.external @builtins.float, #builtins_float
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-
 py.func @constant_tuple() -> index {
     %0 = constant(#py.tuple<(#py.int<0>, #py.str<"text">, #py.float<5.0>)>)
     %1 = tuple_len %0
@@ -22,17 +11,6 @@ py.func @constant_tuple() -> index {
 // CHECK: return %[[RESULT]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-#builtins_float = #py.globalValue<builtins.float, initializer = #py.type>
-py.external @builtins.float, #builtins_float
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
 
 #foo = #py.globalValue<foo, initializer = #py.tuple<(#py.int<0>, #py.str<"text">, #py.float<5.0>)>>
 
@@ -47,11 +25,6 @@ py.func @constant_tuple() -> index {
 // CHECK: return %[[RESULT]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
 
 py.func @make_tuple(%arg0 : !py.dynamic, %arg1 : !py.dynamic) -> index {
     %0 = makeTuple (%arg0, %arg1)

--- a/test/Optimizer/PylirPy/IR/tuple-prepend-fold.mlir
+++ b/test/Optimizer/PylirPy/IR/tuple-prepend-fold.mlir
@@ -1,11 +1,6 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
 #builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
 
 py.func @test() -> !py.dynamic {
     %0 = constant(#py.tuple<()>)

--- a/test/Optimizer/PylirPy/IR/type-of-fold.mlir
+++ b/test/Optimizer/PylirPy/IR/type-of-fold.mlir
@@ -12,10 +12,6 @@ py.func @make_object(%arg0 : !py.dynamic) -> !py.dynamic {
 
 // -----
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
 #a = #py.globalValue<a, initializer = #py.type>
 
 py.func @constant_obj() -> !py.dynamic {
@@ -32,10 +28,6 @@ py.func @constant_obj() -> !py.dynamic {
 
 // -----
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
 #a = #py.globalValue<a, initializer = #py.type>
 
 py.func @global_value() -> !py.dynamic {
@@ -52,13 +44,6 @@ py.func @global_value() -> !py.dynamic {
 
 // -----
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-
 py.func @str_copy(%arg0 : !py.dynamic, %arg1 : !py.dynamic) -> !py.dynamic {
     %0 = str_copy %arg0 : %arg1
     %1 = typeOf %0
@@ -71,11 +56,6 @@ py.func @str_copy(%arg0 : !py.dynamic, %arg1 : !py.dynamic) -> !py.dynamic {
 // CHECK: return %[[ARG1]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
 
 py.func @type_refineable(%arg0 : !py.dynamic, %arg1 : !py.dynamic) -> !py.dynamic {
     %0 = makeTuple (%arg0, %arg1)
@@ -90,11 +70,6 @@ py.func @type_refineable(%arg0 : !py.dynamic, %arg1 : !py.dynamic) -> !py.dynami
 // CHECK: return %[[CONST]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
 
 py.func @tuple_prepend(%arg0 : !py.dynamic, %arg1 : !py.dynamic) -> !py.dynamic {
     %0 = tuple_prepend %arg0, %arg1

--- a/test/Optimizer/PylirPy/IR/type-slots-fold.mlir
+++ b/test/Optimizer/PylirPy/IR/type-slots-fold.mlir
@@ -1,11 +1,6 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
 #builtins_type = #py.globalValue<builtins.type, const, initializer = #py.type<instance_slots = <(#py.str<"first">, #py.str<"second">)>>>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, const, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
 
 py.func @test() -> !py.dynamic {
     %0 = constant(#builtins_type)

--- a/test/Optimizer/PylirPy/Transform/ExpandPyDialect/UnpackOp.mlir
+++ b/test/Optimizer/PylirPy/Transform/ExpandPyDialect/UnpackOp.mlir
@@ -1,12 +1,5 @@
 // RUN: pylir-opt %s -p 'builtin.module(any(pylir-expand-py-dialect))' --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_dict= #py.globalValue<builtins.dict, initializer = #py.type>
-py.external @builtins.dict, #builtins_dict
-
 py.func private @pylir__call__(!py.dynamic, !py.dynamic, !py.dynamic) ->  !py.dynamic
 
 py.func @test(%iterable : !py.dynamic) -> (!py.dynamic, !py.dynamic, !py.dynamic) {
@@ -91,13 +84,6 @@ py.func @test(%iterable : !py.dynamic) -> (!py.dynamic, !py.dynamic, !py.dynamic
 
 // -----
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_dict= #py.globalValue<builtins.dict, initializer = #py.type>
-py.external @builtins.dict, #builtins_dict
-
 py.func private @pylir__call__(!py.dynamic, !py.dynamic, !py.dynamic) ->  !py.dynamic
 
 py.func @no_rest_arg(%iterable : !py.dynamic) -> (!py.dynamic, !py.dynamic, !py.dynamic) {
@@ -174,13 +160,6 @@ py.func @no_rest_arg(%iterable : !py.dynamic) -> (!py.dynamic, !py.dynamic, !py.
 // CHECK: return %[[A]], %[[B]], %[[C]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_dict= #py.globalValue<builtins.dict, initializer = #py.type>
-py.external @builtins.dict, #builtins_dict
 
 py.func private @pylir__call__(!py.dynamic, !py.dynamic, !py.dynamic) ->  !py.dynamic
 

--- a/test/Optimizer/PylirPy/Transform/FoldGlobals.mlir
+++ b/test/Optimizer/PylirPy/Transform/FoldGlobals.mlir
@@ -1,12 +1,5 @@
 // RUN: pylir-opt %s --pylir-fold-globals --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-
 py.global "private" @foo : !py.dynamic
 
 py.func @test() {
@@ -31,13 +24,6 @@ py.func @bar() -> !py.dynamic {
 // CHECK-NEXT: return %[[C]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
 
 py.global "private" @foo : !py.dynamic
 
@@ -65,12 +51,7 @@ py.func @bar() {
 
 // -----
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
 #builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
 
 py.global "private" @foo : !py.dynamic
 
@@ -97,14 +78,6 @@ py.func @bar() -> !py.dynamic {
 
 // -----
 
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-
 py.global "private" @foo : !py.dynamic
 
 py.func @test() {
@@ -127,21 +100,6 @@ py.func @bar() -> !py.dynamic {
 // CHECK-NEXT: return %[[C]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-#builtins_function = #py.globalValue<builtins.function, initializer = #py.type>
-py.external @builtins.function, #builtins_function
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_dict= #py.globalValue<builtins.dict, initializer = #py.type>
-py.external @builtins.dict, #builtins_dict
-#builtins_None = #py.globalValue<builtins.None, initializer = #py.type>
-py.external @builtins.None, #builtins_None
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
 
 py.func @real(%arg0 : !py.dynamic, %arg1 : !py.dynamic, %arg2 : !py.dynamic) -> !py.dynamic {
     %0 = typeOf %arg0
@@ -173,13 +131,6 @@ py.func @bar() -> !py.dynamic {
 // CHECK-NEXT: return %[[C]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
 
 py.global "private" @foo : !py.dynamic
 
@@ -225,13 +176,6 @@ py.func @test() -> !py.dynamic {
 
 // -----
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-
 py.global "private" @bar : !py.dynamic
 py.global "private" @foo : !py.dynamic
 
@@ -267,13 +211,6 @@ py.func @other2() -> !py.dynamic {
 // CHECK: return
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
 
 py.global "private" @foo : index
 
@@ -325,13 +262,6 @@ py.func @bar() -> index {
 
 // -----
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-
 py.global "private" @foo : index = 3 : index
 
 py.func @test() {
@@ -353,13 +283,6 @@ py.func @bar() -> index {
 
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
 
 py.global "private" @foo : index = 5 : index
 

--- a/test/Optimizer/PylirPy/Transform/GlobalLoadStoreElimination.mlir
+++ b/test/Optimizer/PylirPy/Transform/GlobalLoadStoreElimination.mlir
@@ -1,12 +1,5 @@
 // RUN: pylir-opt %s -pass-pipeline='builtin.module(any(pylir-global-load-store-elimination))' --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-
 py.global @foo : !py.dynamic
 
 py.func @test() -> !py.dynamic {
@@ -22,13 +15,6 @@ py.func @test() -> !py.dynamic {
 // CHECK-NEXT: return %[[C]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
 
 py.global @foo : !py.dynamic
 
@@ -48,13 +34,6 @@ py.func @test() -> !py.dynamic {
 // CHECK-NEXT: return %[[C]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
 
 py.func private @clobber()
 
@@ -76,13 +55,6 @@ py.func @test() -> !py.dynamic {
 // CHECK-NEXT: return %[[LOAD]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
 
 py.global @foo : !py.dynamic
 
@@ -126,13 +98,6 @@ py.func @test() -> !py.dynamic {
 
 // -----
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-
 py.global @foo : !py.dynamic
 
 py.func private @clobber()
@@ -168,13 +133,6 @@ py.func @test() -> !py.dynamic {
 
 // -----
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-
 py.global @foo : !py.dynamic
 
 py.func @test() -> !py.dynamic {
@@ -205,13 +163,6 @@ py.func @test() -> !py.dynamic {
 // CHECK: return %[[ARG]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
 
 py.global @foo : !py.dynamic
 
@@ -246,13 +197,6 @@ py.func @test() -> !py.dynamic {
 
 // -----
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-
 py.global @foo : !py.dynamic
 
 py.func @test() -> !py.dynamic {
@@ -283,13 +227,6 @@ py.func @test() -> !py.dynamic {
 // CHECK: return %[[ARG]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
 
 py.global @foo : !py.dynamic
 

--- a/test/Optimizer/PylirPy/Transform/GlobalSROA.mlir
+++ b/test/Optimizer/PylirPy/Transform/GlobalSROA.mlir
@@ -1,14 +1,5 @@
 // RUN: pylir-opt %s --pylir-global-sroa --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_dict= #py.globalValue<builtins.dict, initializer = #py.type>
-py.external @builtins.dict, #builtins_dict
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-
 #thing = #py.globalValue<thing, initializer = #py.dict<{}>>
 
 py.func @test(%hash: index) -> !py.dynamic {
@@ -40,15 +31,6 @@ py.func @foo(%hash: index, %arg0 : !py.dynamic) {
 
 // -----
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_dict= #py.globalValue<builtins.dict, initializer = #py.type>
-py.external @builtins.dict, #builtins_dict
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-
 #thing = #py.globalValue<thing, initializer = #py.dict<{}>>
 
 py.func @store_only(%hash: index, %arg0 : !py.dynamic) {
@@ -68,15 +50,6 @@ py.func @store_only(%hash: index, %arg0 : !py.dynamic) {
 
 // -----
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_dict= #py.globalValue<builtins.dict, initializer = #py.type>
-py.external @builtins.dict, #builtins_dict
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-
 #thing = #py.globalValue<thing, initializer = #py.dict<{}>>
 
 py.func @load_only(%hash: index) -> !py.dynamic {
@@ -94,17 +67,6 @@ py.func @load_only(%hash: index) -> !py.dynamic {
 // CHECK: global "private" @[[$DES]] : !py.dynamic
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_dict= #py.globalValue<builtins.dict, initializer = #py.type>
-py.external @builtins.dict, #builtins_dict
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
 
 #thing = #py.globalValue<thing, initializer = #py.dict<{#py.str<"lol"> to #py.int<5>}>>
 
@@ -126,17 +88,6 @@ py.func @init_attr(%hash: index) -> !py.dynamic {
 
 // -----
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_dict= #py.globalValue<builtins.dict, initializer = #py.type>
-py.external @builtins.dict, #builtins_dict
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-
 #thing = #py.globalValue<thing, initializer = #py.dict<{}>>
 
 py.func @sub_attr(%hash: index) -> !py.dynamic {
@@ -150,17 +101,6 @@ py.func @sub_attr(%hash: index) -> !py.dynamic {
 // CHECK: constant(#py.dict<{#py.int<5> to #thing}>)
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_dict= #py.globalValue<builtins.dict, initializer = #py.type>
-py.external @builtins.dict, #builtins_dict
-#builtins_float = #py.globalValue<builtins.float, initializer = #py.type>
-py.external @builtins.float, #builtins_float
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
 
 #thing = #py.globalValue<thing, initializer = #py.dict<{#py.int<3> to #py.int<5>}>>
 

--- a/test/Optimizer/Transforms/BranchOpInterfacePatterns/trivial-block-arg-remove.mlir
+++ b/test/Optimizer/Transforms/BranchOpInterfacePatterns/trivial-block-arg-remove.mlir
@@ -1,11 +1,5 @@
 // RUN: pylir-opt %s -canonicalize --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
 py.global @foo : !py.dynamic
 
 py.func @test() -> !py.dynamic {

--- a/test/Optimizer/Transforms/ConditionalsImplications.mlir
+++ b/test/Optimizer/Transforms/ConditionalsImplications.mlir
@@ -62,12 +62,7 @@ py.func @test(%c: i1) -> i1 {
 
 // -----
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
 #builtins_None = #py.globalValue<builtins.None, initializer = #py.type>
-py.external @builtins.None, #builtins_None
 
 py.func @test(%arg0 : !py.dynamic) -> !py.dynamic {
     %0 = constant(#builtins_None)

--- a/test/Optimizer/Transforms/SROA/block-arg-undef-bug.mlir
+++ b/test/Optimizer/Transforms/SROA/block-arg-undef-bug.mlir
@@ -1,12 +1,5 @@
 // RUN: pylir-opt %s -pass-pipeline="builtin.module(any(pylir-sroa))" | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-
 py.func @test(%arg : !py.dynamic, %hash : index) {
     %0 = makeDict ()
     %c0 = arith.constant 2 : index

--- a/test/Optimizer/Transforms/SROA/dict.mlir
+++ b/test/Optimizer/Transforms/SROA/dict.mlir
@@ -1,14 +1,5 @@
 // RUN: pylir-opt -pass-pipeline="builtin.module(any(pylir-sroa))" %s --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-
 py.func @test(%arg0 : !py.dynamic, %hash : index) -> !py.dynamic {
     %0 = constant(#py.str<"Hello">)
     %1 = constant(#py.str<" ">)
@@ -35,15 +26,6 @@ py.func @test(%arg0 : !py.dynamic, %hash : index) -> !py.dynamic {
 // CHECK: return %[[R]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
 
 py.func @test(%arg0 : !py.dynamic, %hash : index) -> (!py.dynamic, index) {
     %0 = constant(#py.str<"Hello">)
@@ -82,15 +64,6 @@ py.func @test(%arg0 : !py.dynamic, %hash : index) -> (!py.dynamic, index) {
 
 // -----
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-
 py.func @test(%arg0 : !py.dynamic, %hash : index) -> !py.dynamic {
     %0 = constant(#py.str<"Hello">)
     %zero = constant(#py.int<0>)
@@ -105,13 +78,6 @@ py.func @test(%arg0 : !py.dynamic, %hash : index) -> !py.dynamic {
 // CHECK: return %[[U]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
 
 py.func @test(%arg0 : !py.dynamic, %hash : index) -> (i1, index) {
     %0 = makeDict ()
@@ -154,15 +120,6 @@ py.func @test(%arg0 : !py.dynamic, %hash : index) -> (i1, index) {
 // CHECK-NEXT: return %[[EXISTED]], %[[NEW_SIZE]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-#builtins_float = #py.globalValue<builtins.float, initializer = #py.type>
-py.external @builtins.float, #builtins_float
 
 py.func @test(%arg0 : !py.dynamic, %hash : index) -> i1 {
     %0 = makeDict ()

--- a/test/Optimizer/Transforms/SROA/list.mlir
+++ b/test/Optimizer/Transforms/SROA/list.mlir
@@ -1,12 +1,5 @@
 // RUN: pylir-opt -pass-pipeline="builtin.module(any(pylir-sroa))" %s --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-
 py.func @test(%arg0 : !py.dynamic) -> (!py.dynamic, index) {
     %0 = constant(#py.str<"Hello">)
     %1 = constant(#py.str<" ">)
@@ -35,13 +28,6 @@ py.func @test(%arg0 : !py.dynamic) -> (!py.dynamic, index) {
 // CHECK: return %[[R]], %[[L]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
 
 py.func @test(%arg0 : !py.dynamic) -> !py.dynamic {
     %0 = constant(#py.str<"Hello">)
@@ -72,13 +58,6 @@ py.func @test(%arg0 : !py.dynamic) -> !py.dynamic {
 // CHECK-NEXT: return %[[ARG]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
 
 py.func @neg_test(%arg0 : !py.dynamic, %arg1 : index) -> (!py.dynamic, index) {
     %0 = constant(#py.str<"Hello">)

--- a/test/Optimizer/Transforms/SROA/slots.mlir
+++ b/test/Optimizer/Transforms/SROA/slots.mlir
@@ -1,13 +1,6 @@
 // RUN: pylir-opt -pass-pipeline="builtin.module(any(pylir-sroa))" %s --split-input-file | FileCheck %s
 
 #builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
 
 py.func @test(%arg0 : !py.dynamic) -> !py.dynamic {
     %0 = constant(#py.str<"Hello">)
@@ -40,15 +33,6 @@ py.func @test(%arg0 : !py.dynamic) -> !py.dynamic {
 // CHECK: return %[[R]]
 
 // -----
-
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
 
 py.func @test_neg(%arg0 : !py.dynamic) -> !py.dynamic {
     %0 = typeOf %arg0

--- a/test/Optimizer/Transforms/SROA/ssa-builder-bug.mlir
+++ b/test/Optimizer/Transforms/SROA/ssa-builder-bug.mlir
@@ -1,14 +1,5 @@
 // RUN: pylir-opt -pass-pipeline="builtin.module(any(pylir-sroa))" %s --split-input-file | FileCheck %s
 
-#builtins_type = #py.globalValue<builtins.type, initializer = #py.type>
-py.external @builtins.type, #builtins_type
-#builtins_tuple = #py.globalValue<builtins.tuple, initializer = #py.type>
-py.external @builtins.tuple, #builtins_tuple
-#builtins_str = #py.globalValue<builtins.str, initializer = #py.type>
-py.external @builtins.str, #builtins_str
-#builtins_int = #py.globalValue<builtins.int, initializer = #py.type>
-py.external @builtins.int, #builtins_int
-
 py.func @test(%arg0 : !py.dynamic, %hash : index) -> !py.dynamic {
     %zero = constant(#py.int<0>)
     %l = makeDict (%zero hash(%hash) : %arg0)


### PR DESCRIPTION
These have previously been `py.globalValue` operations that were simply converted 1:1. The precondition that these have to exist has recently been dropped from everywhere but the LLVM conversion pass, which is why the vast majority of them have become redundant and can be removed.