### PR TITLE
[PyHIR] Remove `builtinsRef` entirely

### DIFF
--- a/src/pylir/CodeGenNew/CodeGenNew.cpp
+++ b/src/pylir/CodeGenNew/CodeGenNew.cpp
@@ -164,7 +164,8 @@ private:
       m_builder.setInsertionPointToEnd(&function.getBody().front());
       visit(funcDef.suite);
       if (m_builder.getInsertionBlock()) {
-        auto ref = m_builder.create<HIR::BuiltinsRefOp>(Builtins::None.name);
+        auto ref = m_builder.create<Py::ConstantOp>(Py::GlobalValueAttr::get(
+            m_builder.getContext(), Builtins::None.name));
         m_builder.create<HIR::ReturnOp>(ref);
       }
     }

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
@@ -25,28 +25,6 @@ class PylirHIR_Op<string mneomic, list<Trait> traits = []>
 // Basics
 //===----------------------------------------------------------------------===//
 
-def PylirHIR_BuiltinsRefOp : PylirHIR_Op<"builtinsRef", [Pure]> {
-  let arguments = (ins FlatSymbolRefAttr:$reference);
-
-  let results = (outs DynamicType:$result);
-
-  let description = [{
-    Op used to refer to objects in Pythons `builtins` module.
-    Returns a reference to that object.
-    Unlike most ops using symbol references, this op does not verify, nor care
-    whether the symbol exists.
-    Symbol names should be fully qualified.
-
-    Example:
-    ```
-    %0 = pyHIR.builtinsRef @builtins.None
-    ```
-  }];
-
-  let assemblyFormat = [{
-    $reference attr-dict
-  }];
-}
 
 //===----------------------------------------------------------------------===//
 // Functions

--- a/test/CodeGenNew/functions.py
+++ b/test/CodeGenNew/functions.py
@@ -1,5 +1,7 @@
 # RUN: pylir %s -Xnew-codegen -emit-pylir -o - -S | FileCheck %s
 
+# CHECK: #[[$NONE:.*]] = #py.globalValue<builtins.None{{>|,}}
+
 # CHECK-LABEL: pyHIR.init "__main__"
 
 def test1():
@@ -7,7 +9,7 @@ def test1():
 
 
 # CHECK: func "test1"() {
-# CHECK-NEXT: %[[REF:.*]] = builtinsRef @builtins.None
+# CHECK-NEXT: %[[REF:.*]] = py.constant(#[[$NONE]])
 # CHECK-NEXT: return %[[REF]]
 
 def test2(arg, arg2, /):


### PR DESCRIPTION
With the new design of `#py.globalValue` it no longer has any need to exist.