### PR TITLE
[PyHIRToPylirPy] Initial Lowering of `pyHIR.init` to `py`

### DIFF
--- a/src/pylir/Optimizer/Conversion/CMakeLists.txt
+++ b/src/pylir/Optimizer/Conversion/CMakeLists.txt
@@ -4,5 +4,6 @@
 
 add_pylir_passes(Passes Conversion PREFIX Pylir)
 
+add_subdirectory(PylirHIRToPylirPy)
 add_subdirectory(PylirPyToPylirMem)
 add_subdirectory(PylirToLLVMIR)

--- a/src/pylir/Optimizer/Conversion/Passes.td
+++ b/src/pylir/Optimizer/Conversion/Passes.td
@@ -32,4 +32,14 @@ def ConvertPylirPyToPylirMemPass : Pass<"convert-pylirPy-to-pylirMem",
   ];
 }
 
+def ConvertPylirHIRToPylirPyPass : Pass<"convert-pylirHIR-to-pylirPy",
+  "::mlir::ModuleOp"> {
+  let summary = "Convert PylirHIR dialect to PylirPy dialect";
+
+  let dependentDialects = [
+    "::pylir::Py::PylirPyDialect",
+    "::mlir::arith::ArithDialect"
+  ];
+}
+
 #endif

--- a/src/pylir/Optimizer/Conversion/PylirHIRToPylirPy/CMakeLists.txt
+++ b/src/pylir/Optimizer/Conversion/PylirHIRToPylirPy/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+add_library(PylirHIRToPylirPy
+  PylirHIRToPylirPy.cpp
+)
+add_dependencies(PylirHIRToPylirPy
+  PylirConversionPassIncGen
+)
+target_link_libraries(PylirHIRToPylirPy
+  PRIVATE
+  PylirHIRDialect
+  PylirPyDialect
+
+  MLIRArithDialect
+  MLIRPass
+  MLIRTransforms
+)

--- a/src/pylir/Optimizer/Conversion/PylirHIRToPylirPy/PylirHIRToPylirPy.cpp
+++ b/src/pylir/Optimizer/Conversion/PylirHIRToPylirPy/PylirHIRToPylirPy.cpp
@@ -1,0 +1,94 @@
+//  Licensed under the Apache License v2.0 with LLVM Exceptions.
+//  See https://llvm.org/LICENSE.txt for license information.
+//  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Pass/Pass.h>
+#include <mlir/Transforms/DialectConversion.h>
+
+#include <pylir/Optimizer/Conversion/Passes.hpp>
+#include <pylir/Optimizer/PylirHIR/IR/PylirHIRDialect.hpp>
+#include <pylir/Optimizer/PylirHIR/IR/PylirHIROps.hpp>
+#include <pylir/Optimizer/PylirPy/IR/PylirPyDialect.hpp>
+#include <pylir/Optimizer/PylirPy/IR/PylirPyOps.hpp>
+
+using namespace mlir;
+using namespace pylir;
+using namespace pylir::HIR;
+using namespace pylir::Py;
+
+namespace pylir {
+#define GEN_PASS_DEF_CONVERTPYLIRHIRTOPYLIRPYPASS
+#include "pylir/Optimizer/Conversion/Passes.h.inc"
+} // namespace pylir
+
+namespace {
+struct ConvertPylirHIRToPylirPy
+    : pylir::impl::ConvertPylirHIRToPylirPyPassBase<ConvertPylirHIRToPylirPy> {
+protected:
+  void runOnOperation() override;
+
+public:
+  using Base::Base;
+};
+
+//===----------------------------------------------------------------------===//
+// Conversion Patterns
+//===----------------------------------------------------------------------===//
+
+struct InitOpConversionPattern : OpRewritePattern<InitOp> {
+  using OpRewritePattern<InitOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(InitOp op,
+                                PatternRewriter& rewriter) const override {
+    std::string functionName = "__init__";
+    // The main init is treate specially as it is the entry point of the whole
+    // python program by default. It is callable with an `__init__` as that is a
+    // valid C identifier.
+    if (!op.isMainModule())
+      functionName = (op.getName() + "." + functionName).str();
+
+    auto funcOp = rewriter.create<Py::FuncOp>(
+        op->getLoc(), functionName,
+        rewriter.getFunctionType(/*inputs=*/{},
+                                 rewriter.getType<DynamicType>()));
+    // The region can be inlined directly without creating a suitable entry
+    // block for the function as the function body does not need any block
+    // arguments.
+    rewriter.inlineRegionBefore(op.getBody(), funcOp.getBody(),
+                                funcOp.getBody().end());
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+/// Lowering pattern for any Op that is `ReturnLike` to `py.return`.
+/// Returns ALL its operands.
+template <class OpT>
+struct ReturnOpLowering : OpRewritePattern<OpT> {
+  using OpRewritePattern<OpT>::OpRewritePattern;
+
+  static_assert(OpT::template hasTrait<OpTrait::ReturnLike>());
+
+  LogicalResult matchAndRewrite(OpT op,
+                                PatternRewriter& rewriter) const override {
+    rewriter.replaceOpWithNewOp<Py::ReturnOp>(op, op->getOperands());
+    return success();
+  }
+};
+
+} // namespace
+
+void ConvertPylirHIRToPylirPy::runOnOperation() {
+  ConversionTarget target(getContext());
+  target.markUnknownOpDynamicallyLegal([](auto...) { return true; });
+
+  target.addIllegalDialect<HIR::PylirHIRDialect>();
+
+  RewritePatternSet patterns(&getContext());
+  patterns.add<InitOpConversionPattern, ReturnOpLowering<InitReturnOp>>(
+      &getContext());
+  if (failed(
+          applyPartialConversion(getOperation(), target, std::move(patterns))))
+    return signalPassFailure();
+}

--- a/test/Optimizer/Conversion/PylirHIRToPylirPy/init.mlir
+++ b/test/Optimizer/Conversion/PylirHIRToPylirPy/init.mlir
@@ -1,0 +1,15 @@
+// RUN: pylir-opt %s --convert-pylirHIR-to-pylirPy --split-input-file | FileCheck %s
+
+// CHECK-LABEL: py.func @foo.__init__() -> !py.dynamic
+pyHIR.init "foo" {
+  // CHECK-NEXT: %[[DICT:.*]] = makeDict
+  // CHECK-NEXT: return %[[DICT]]
+  %0 = py.makeDict ()
+  init_return %0
+}
+
+// CHECK-LABEL: py.func @__init__() -> !py.dynamic
+pyHIR.init "__main__" {
+  %0 = py.makeDict ()
+  init_return %0
+}

--- a/tools/pylir-opt/CMakeLists.txt
+++ b/tools/pylir-opt/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(pylir-opt
   PylirAnalysis
   PylirExternalModels
   PylirHIRDialect
+  PylirHIRToPylirPy
   PylirMemDialect
   PylirMemTransforms
   PylirLinker


### PR DESCRIPTION
While the two dialects are largely meant to live side-by-side throughout most of the compiler, there will be later phases requiring all `pyHIR` operations to have disappeared for further lowering and optimizations. This PR is the first step in lowering the dialect and working towards an E2E flow with the `pyHIR` dialect and `CodeGenNew` Frontend lowering.