### PR TITLE
[ci] fix CI after powershell updates

### DIFF
--- a/.github/workflows/build-and-lint.yml
+++ b/.github/workflows/build-and-lint.yml
@@ -97,7 +97,7 @@ jobs:
         run: |
           $sanitizer_arg = ''
           if ('${{matrix.sanitizers}}') {
-            $sanitizer_arg = '-DPYLIR_SANITIZERS="${{matrix.sanitizers}}"', '-DCMAKE_CXX_FLAGS="-g1"'
+            $sanitizer_arg = '-DPYLIR_SANITIZERS=${{matrix.sanitizers}}', '-DCMAKE_CXX_FLAGS="-g1"'
           }
           $runtime_arg = ''
           if ('${{matrix.runtime_lib}}') {


### PR DESCRIPTION
Recent changes in powershell changed how expansions interact with arguments, creating errors with the current syntax. 
Simply get rid of the `"` to fix it.