### PR TITLE
[PyHIRToPylirPy] Add `globalFunc` lowering

### DIFF
--- a/src/pylir/Optimizer/Conversion/Passes.td
+++ b/src/pylir/Optimizer/Conversion/Passes.td
@@ -38,7 +38,8 @@ def ConvertPylirHIRToPylirPyPass : Pass<"convert-pylirHIR-to-pylirPy",
 
   let dependentDialects = [
     "::pylir::Py::PylirPyDialect",
-    "::mlir::arith::ArithDialect"
+    "::mlir::arith::ArithDialect",
+    "::mlir::cf::ControlFlowDialect",
   ];
 }
 

--- a/src/pylir/Optimizer/Conversion/PylirHIRToPylirPy/CMakeLists.txt
+++ b/src/pylir/Optimizer/Conversion/PylirHIRToPylirPy/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(PylirHIRToPylirPy
   PylirPyDialect
 
   MLIRArithDialect
+  MLIRControlFlowDialect
   MLIRPass
   MLIRTransforms
 )

--- a/src/pylir/Optimizer/Conversion/PylirHIRToPylirPy/PylirHIRToPylirPy.cpp
+++ b/src/pylir/Optimizer/Conversion/PylirHIRToPylirPy/PylirHIRToPylirPy.cpp
@@ -3,8 +3,11 @@
 //  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/ControlFlow/IR/ControlFlowOps.h>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Transforms/DialectConversion.h>
+
+#include <llvm/ADT/ScopeExit.h>
 
 #include <pylir/Optimizer/Conversion/Passes.hpp>
 #include <pylir/Optimizer/PylirHIR/IR/PylirHIRDialect.hpp>
@@ -33,7 +36,211 @@ public:
 };
 
 //===----------------------------------------------------------------------===//
-// Conversion Patterns
+// Function Conversion Patterns
+//===----------------------------------------------------------------------===//
+
+/// Creates a new 'py.func' to translate from the universal calling convention
+/// to the parameters of 'implementation'. 'builder' will be used to create any
+/// MLIR operations. 'calleeSymbol' should refer to the symbol corresponding to
+/// 'implementation' after dialect conversion.
+Py::FuncOp buildFunctionCC(OpBuilder& builder, GlobalFuncOp implementation,
+                           FlatSymbolRefAttr calleeSymbol) {
+  Location loc = implementation.getLoc();
+  auto dynamicType = builder.getType<DynamicType>();
+  auto cc = builder.create<Py::FuncOp>(
+      loc, implementation.getName(),
+      FunctionType::get(builder.getContext(),
+                        {dynamicType, dynamicType, dynamicType},
+                        {dynamicType}));
+  OpBuilder::InsertionGuard guard{builder};
+  builder.setInsertionPointToStart(cc.addEntryBlock());
+
+  Value closure = cc.getArgument(0);
+  Value tuple = cc.getArgument(1);
+  Value dict = cc.getArgument(2);
+
+  Value defaultTuple = builder.create<Py::GetSlotOp>(
+      loc, closure,
+      builder.create<arith::ConstantIndexOp>(
+          loc, static_cast<std::size_t>(Builtins::FunctionSlots::Defaults)));
+  Value kwDefaultDict = builder.create<Py::GetSlotOp>(
+      loc, closure,
+      builder.create<arith::ConstantIndexOp>(
+          loc, static_cast<std::size_t>(Builtins::FunctionSlots::KwDefaults)));
+
+  Value tupleLen = builder.create<Py::TupleLenOp>(loc, tuple);
+
+  Value unboundValue =
+      builder.create<Py::ConstantOp>(loc, builder.getAttr<Py::UnboundAttr>());
+  std::size_t positionalArgsSeen = 0;
+  std::size_t positionalDefaultArgsSeen = 0;
+  std::optional<std::size_t> positionalRestArgsPos;
+  std::optional<std::size_t> kwRestArgsPos;
+  SmallVector<Value> callArguments;
+  for (HIR::FunctionParameter parameter :
+       HIR::FunctionParameterRange(implementation)) {
+    // There can only be one rest-parameter of each kind. These will be set
+    // at the end after all other parameters are converted. The index in the
+    // call parameter array with a null-placeholder are set here already.
+    if (parameter.isKeywordRest()) {
+      kwRestArgsPos = callArguments.size();
+      callArguments.emplace_back();
+      continue;
+    }
+    if (parameter.isPosRest()) {
+      positionalRestArgsPos = callArguments.size();
+      callArguments.emplace_back();
+      continue;
+    }
+
+    // Current value of the argument that will be placed in the arguments array
+    // at the end of the loop body.
+    Value currentArg = unboundValue;
+    auto atExit =
+        llvm::make_scope_exit([&] { callArguments.emplace_back(currentArg); });
+
+    if (!parameter.isKeywordOnly()) {
+      // Checks whether a positional argument for the parameter is present in
+      // the tuple.
+      Value index =
+          builder.create<arith::ConstantIndexOp>(loc, positionalArgsSeen++);
+      Value inTuple = builder.create<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::ult, index, tupleLen);
+
+      auto* hasValue = cc.addBlock();
+      auto* continueSearch = cc.addBlock();
+      currentArg =
+          continueSearch->addArgument(builder.getType<Py::DynamicType>(), loc);
+      builder.create<cf::CondBranchOp>(loc, inTuple, hasValue, continueSearch,
+                                       unboundValue);
+
+      builder.setInsertionPointToStart(hasValue);
+      Value value = builder.create<Py::TupleGetItemOp>(loc, tuple, index);
+      builder.create<cf::BranchOp>(loc, continueSearch, value);
+      builder.setInsertionPointToStart(continueSearch);
+    }
+
+    Value keyword;
+    Value hash;
+    if (!parameter.isPositionalOnly()) {
+      // If the parameter is callable using the keyword-syntax, check the
+      // dictionary as well.
+      keyword = builder.create<Py::ConstantOp>(
+          loc, builder.getAttr<Py::StrAttr>(parameter.getName()));
+      hash = builder.create<Py::StrHashOp>(loc, keyword);
+      Value lookup =
+          builder.create<Py::DictTryGetItemOp>(loc, dict, keyword, hash);
+      Value failure = builder.create<Py::IsUnboundValueOp>(loc, lookup);
+
+      auto* foundBlock = cc.addBlock();
+      auto* continueBlock = cc.addBlock();
+      continueBlock->addArgument(currentArg.getType(), loc);
+      builder.create<cf::CondBranchOp>(loc, failure, continueBlock, currentArg,
+                                       foundBlock, ValueRange{});
+
+      builder.setInsertionPointToStart(foundBlock);
+      // Delete the entry from the argument dictionary for the rest parameter.
+      builder.create<Py::DictDelItemOp>(loc, dict, keyword, hash);
+
+      // It is an error for a parameter to be bound twice (once through
+      // positional argument, again through keyword argument).
+      Value notFoundPreviously =
+          builder.create<Py::IsUnboundValueOp>(loc, currentArg);
+      // TODO: This should raise a 'TypeError'.
+      builder.create<cf::AssertOp>(
+          loc, notFoundPreviously,
+          "keyword arg matched previous positional arg");
+      builder.create<cf::BranchOp>(loc, continueBlock, lookup);
+
+      builder.setInsertionPointToStart(continueBlock);
+      currentArg = continueBlock->getArgument(0);
+    }
+
+    // Default parameter handling.
+    Value notFound = builder.create<Py::IsUnboundValueOp>(loc, currentArg);
+    if (!parameter.hasDefault()) {
+      // TODO: This should raise a 'TypeError'.
+      builder.create<cf::AssertOp>(loc, notFound,
+                                   "failed to find argument for parameter");
+      continue;
+    }
+
+    // Depending on whether the parameter is a keyword-only parameter or not,
+    // the default value is either read from the default tuple or the keyword
+    // defaults dictionary.
+    Block* needsDefault = cc.addBlock();
+    Block* afterDefault = cc.addBlock();
+    afterDefault->addArgument(currentArg.getType(), loc);
+    builder.create<cf::CondBranchOp>(loc, notFound, needsDefault, afterDefault,
+                                     currentArg);
+
+    builder.setInsertionPointToStart(needsDefault);
+    if (parameter.isKeywordOnly()) {
+      Value lookup = builder.create<Py::DictTryGetItemOp>(loc, kwDefaultDict,
+                                                          keyword, hash);
+      builder.create<cf::BranchOp>(loc, afterDefault, lookup);
+    } else {
+      Value index = builder.create<mlir::arith::ConstantIndexOp>(
+          loc, positionalDefaultArgsSeen++);
+      Value lookup =
+          builder.create<Py::TupleGetItemOp>(loc, defaultTuple, index);
+      builder.create<cf::BranchOp>(loc, afterDefault, lookup);
+    }
+
+    builder.setInsertionPointToStart(afterDefault);
+    currentArg = afterDefault->getArgument(0);
+    notFound = builder.create<Py::IsUnboundValueOp>(loc, currentArg);
+    // TODO: This should raise a 'TypeError'.
+    builder.create<cf::AssertOp>(loc, notFound,
+                                 "failed to find argument for parameter");
+  }
+
+  if (positionalRestArgsPos) {
+    callArguments[*positionalRestArgsPos] =
+        builder.create<Py::TupleDropFrontOp>(
+            loc,
+            builder.create<arith::ConstantIndexOp>(loc, positionalArgsSeen),
+            tuple);
+  }
+  if (kwRestArgsPos)
+    callArguments[*kwRestArgsPos] = dict;
+
+  Value ret =
+      builder.create<Py::CallOp>(loc, dynamicType, calleeSymbol, callArguments)
+          .getResult(0);
+  builder.create<Py::ReturnOp>(loc, ret);
+
+  return cc;
+}
+
+constexpr llvm::StringRef functionImplSuffix = "$impl";
+
+struct GlobalFuncOpConversionPattern : OpRewritePattern<GlobalFuncOp> {
+  using OpRewritePattern<GlobalFuncOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(GlobalFuncOp op,
+                                PatternRewriter& rewriter) const override {
+    // Global func splits into two functions:
+    // * the implementation function with the suffix "$impl",
+    // * the CC function copying the name.
+    // The latter always has 'object(function, tuple, dict)' as calling
+    // convention.
+    auto functionImpl = rewriter.create<Py::FuncOp>(
+        op.getLoc(), op.getName() + functionImplSuffix, op.getFunctionType());
+    buildFunctionCC(rewriter, op, FlatSymbolRefAttr::get(functionImpl));
+
+    rewriter.inlineRegionBefore(op.getBody(), functionImpl.getBody(),
+                                functionImpl.getBody().end());
+    functionImpl.setArgAttrsAttr(op.getArgAttrsAttr());
+    functionImpl.setResAttrsAttr(op.getResAttrsAttr());
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Module Conversion Patterns
 //===----------------------------------------------------------------------===//
 
 struct InitOpConversionPattern : OpRewritePattern<InitOp> {
@@ -86,7 +293,8 @@ void ConvertPylirHIRToPylirPy::runOnOperation() {
   target.addIllegalDialect<HIR::PylirHIRDialect>();
 
   RewritePatternSet patterns(&getContext());
-  patterns.add<InitOpConversionPattern, ReturnOpLowering<InitReturnOp>>(
+  patterns.add<InitOpConversionPattern, ReturnOpLowering<InitReturnOp>,
+               ReturnOpLowering<HIR::ReturnOp>, GlobalFuncOpConversionPattern>(
       &getContext());
   if (failed(
           applyPartialConversion(getOperation(), target, std::move(patterns))))

--- a/test/Optimizer/Conversion/PylirHIRToPylirPy/globalFunc.mlir
+++ b/test/Optimizer/Conversion/PylirHIRToPylirPy/globalFunc.mlir
@@ -1,0 +1,84 @@
+// RUN: pylir-opt %s --convert-pylirHIR-to-pylirPy --split-input-file | FileCheck %s
+
+pyHIR.globalFunc @basic(%arg0, %arg1 "first" has_default, *%arg2, %arg3 only "second" has_default, **%arg4) {
+  return %arg0
+}
+
+// CHECK-LABEL: py.func @basic$impl
+// CHECK-NEXT: return
+
+// CHECK-LABEL: py.func @basic(
+// CHECK-SAME: %[[CLOSURE:[[:alnum:]]+]]
+// CHECK-SAME: %[[TUPLE:[[:alnum:]]+]]
+// CHECK-SAME: %[[DICT:[[:alnum:]]+]]
+
+// CHECK: %[[DEFAULT_TUPLE:.*]] = getSlot %[[CLOSURE]]
+// CHECK: %[[DEFAULT_DICT:.*]] = getSlot %[[CLOSURE]]
+// CHECK: %[[ARG_LEN:.*]] = tuple_len %[[TUPLE]]
+// CHECK: %[[UNBOUND:.*]] = constant(#py.unbound)
+
+// %arg0 code:
+// CHECK: %[[ZERO:.*]] = arith.constant 0
+// CHECK: %[[LT:.*]] = arith.cmpi ult, %[[ZERO]], %[[ARG_LEN]]
+// CHECK: cf.cond_br %[[LT]], ^[[BB1:.*]], ^[[BB2:.*]](%[[UNBOUND]] : !py.dynamic)
+
+// CHECK: ^[[BB1]]:
+// CHECK: %[[VALUE:.*]] = tuple_getItem %[[TUPLE]][%[[ZERO]]]
+// CHECK: cf.br ^[[BB2]](%[[VALUE]] : !py.dynamic)
+
+// %arg1 code:
+// CHECK: ^[[BB2]](%[[ARG0:.*]]: !py.dynamic):
+// CHECK: %[[ONE:.*]] = arith.constant 1
+// CHECK: %[[LT:.*]] = arith.cmpi ult, %[[ONE]], %[[ARG_LEN]]
+// CHECK: cf.cond_br %[[LT]], ^[[BB3:.*]], ^[[BB4:.*]](%[[UNBOUND]] : !py.dynamic)
+
+// CHECK: ^[[BB3]]:
+// CHECK: %[[VALUE:.*]] = tuple_getItem %[[TUPLE]][%[[ONE]]]
+// CHECK: cf.br ^[[BB4]](%[[VALUE]] : !py.dynamic)
+
+// CHECK: ^[[BB4]](%[[ARG1:.*]]: !py.dynamic):
+// CHECK: %[[KW:.*]] = constant(#py.str<"first">)
+// CHECK: %[[HASH:.*]] = str_hash %[[KW]]
+// CHECK: %[[LOOKUP:.*]] = dict_tryGetItem %[[DICT]][%[[KW]] hash(%[[HASH]])]
+// CHECK: %[[FAILURE:.*]] = isUnboundValue %[[LOOKUP]]
+// CHECK: cf.cond_br %[[FAILURE]], ^[[BB6:.*]](%[[ARG1]] : !py.dynamic), ^[[BB5:.*]]
+
+// CHECK: ^[[BB5]]:
+// CHECK: dict_delItem %[[KW]] hash(%[[HASH]]) from %[[DICT]]
+// CHECK: cf.br ^[[BB6]]
+
+// CHECK: ^[[BB6]](%[[ARG1:.*]]: !py.dynamic):
+// CHECK: %[[FAILURE:.*]] = isUnboundValue %[[ARG1]]
+// CHECK: cf.cond_br %[[FAILURE]], ^[[BB7:.*]], ^[[BB8:.*]](%[[ARG1]] : !py.dynamic)
+
+// CHECK: ^[[BB7]]:
+// CHECK: %[[ZERO:.*]] = arith.constant 0
+// CHECK: %[[DEFAULT:.*]] = tuple_getItem %[[DEFAULT_TUPLE]][%[[ZERO]]]
+// CHECK: cf.br ^[[BB8]](%[[DEFAULT]] : !py.dynamic)
+
+// %arg3 code:
+// CHECK: ^[[BB8]](%[[ARG1:.*]]: !py.dynamic):
+// CHECK: %[[KW:.*]] = constant(#py.str<"second">)
+// CHECK: %[[HASH:.*]] = str_hash %[[KW]]
+// CHECK: %[[LOOKUP:.*]] = dict_tryGetItem %[[DICT]][%[[KW]] hash(%[[HASH]])]
+// CHECK: %[[FAILURE:.*]] = isUnboundValue %[[LOOKUP]]
+// CHECK: cf.cond_br %[[FAILURE]], ^[[BB10:.*]](%[[UNBOUND]] : !py.dynamic), ^[[BB9:.*]]
+
+// CHECK: ^[[BB9]]:
+// CHECK: dict_delItem %[[KW]] hash(%[[HASH]]) from %[[DICT]]
+// CHECK: cf.br ^[[BB10]](%[[LOOKUP]] : !py.dynamic)
+
+// CHECK: ^[[BB10]](%[[ARG3:.*]]: !py.dynamic):
+// CHECK: %[[FAILURE:.*]] = isUnboundValue %[[ARG3]]
+// CHECK: cf.cond_br %[[FAILURE]], ^[[BB11:.*]], ^[[BB12:.*]](%[[ARG3]] : !py.dynamic)
+
+// CHECK: ^[[BB11]]:
+// CHECK: %[[DEFAULT:.*]] = dict_tryGetItem %[[DEFAULT_DICT]][%[[KW]] hash(%[[HASH]])]
+// CHECK: cf.br ^[[BB12]](%[[DEFAULT]] : !py.dynamic)
+
+// rest code:
+// CHECK: ^[[BB12]](%[[ARG3:.*]]: !py.dynamic):
+// CHECK: %[[TWO:.*]] = arith.constant 2
+// CHECK: %[[REST:.*]] = tuple_dropFront %[[TWO]], %[[TUPLE]]
+// CHECK: %[[RET:.*]] = call @basic$impl(%[[ARG0]], %[[ARG1]], %[[REST]], %[[ARG3]], %[[DICT]])
+// CHECK: return %[[RET]]


### PR DESCRIPTION
This pattern lowers `pyHIR.globalFunc` to `py.func` by creating two functions: Once the implementation function which corresponds more closely to the original python function, and the calling convention function. The latter has a universal calling convention to allow pythons extensive parameter passing and has the same logic as is currently implemented by `CodeGen` when generating `py` directly.

Throwing `TypeErrors` in the error cases has not been added due to the precise implementation likely changing in the future.