### PR TITLE
[CodeGenNew] Initial implementation reading and writing locals and globals

### DIFF
--- a/src/pylir/CodeGenNew/CodeGenNew.cpp
+++ b/src/pylir/CodeGenNew/CodeGenNew.cpp
@@ -98,7 +98,7 @@ class CodeGenNew {
             [&](SSABuilder::DefinitionsMap& map) {
               map[m_builder.getInsertionBlock()] = value;
             },
-            [](...) { llvm_unreachable("not yet implemented"); });
+            [](auto) { llvm_unreachable("not yet implemented"); });
         return;
       }
     }

--- a/src/pylir/CodeGenNew/CodeGenNew.cpp
+++ b/src/pylir/CodeGenNew/CodeGenNew.cpp
@@ -123,7 +123,7 @@ class CodeGenNew {
                   m_builder.getLoc(), m_builder.getType<Py::DynamicType>(), map,
                   m_builder.getInsertionBlock());
             },
-            [](...) -> Value { llvm_unreachable("not yet implemented"); });
+            [](auto) -> Value { llvm_unreachable("not yet implemented"); });
       }
     }
 

--- a/test/CodeGenNew/locals-and-globals.py
+++ b/test/CodeGenNew/locals-and-globals.py
@@ -1,0 +1,30 @@
+# RUN: pylir %s -Xnew-codegen -emit-pylir -o - -S | FileCheck %s
+
+# CHECK-LABEL: init "__main__"
+# CHECK: %[[GLOBALS:.*]] = py.makeDict
+# CHECK: %[[TEST1:.*]] = func "__main__.test1"
+def test1():
+    # CHECK: %[[NESTED:.*]] = func "__main__.test1.<locals>.nested"
+    def nested():
+        pass
+
+    other = nested
+
+    # CHECK: func "__main__.test1.<locals>.has_default"(%[[A:.*]] "a" = %[[NESTED]])
+    def has_default(a=other):
+        # CHECK: func "__main__.test1.<locals>.has_default.<locals>.parameter_use"(%{{.*}} "b" = %[[A]])
+        def parameter_use(b=a):
+            pass
+
+
+# CHECK: %[[STR:.*]] = py.constant(#py.str<"test1">)
+# CHECK: %[[HASH:.*]] = py.str_hash %[[STR]]
+# CHECK: py.dict_setItem %[[GLOBALS]][%[[STR]] hash(%[[HASH]])] to %[[TEST1]]
+
+# CHECK: %[[STR:.*]] = py.constant(#py.str<"test1">)
+# CHECK: %[[HASH:.*]] = py.str_hash %[[STR]]
+# CHECK: %[[TEST1:.*]] = py.dict_tryGetItem %[[GLOBALS]][%[[STR]] hash(%[[HASH]])]
+# CHECK: func "__main__.test2"(%{{.*}} "arg" = %[[TEST1]])
+
+def test2(arg=test1):
+    pass


### PR DESCRIPTION
This implements the initial logic for name resolution. Local variables are immediately translate to SSA form using the `SSABuilder` while global variables are translated to reads and writes to the global dictionary. The code only implements the happy-path. No exceptions are currently thrown on lookup failure, nor is the fallback to builtins implemented yet.