### PR TITLE
[CodeGenNew] Implement reading builtins

### DIFF
--- a/src/pylir/CodeGenNew/CMakeLists.txt
+++ b/src/pylir/CodeGenNew/CMakeLists.txt
@@ -4,6 +4,17 @@
 
 include(PylirTablegen)
 
-add_library(CodeGenNew CodeGenNew.cpp)
-target_link_libraries(CodeGenNew PUBLIC PylirHIRDialect Parser
-  PRIVATE PylirTransformsUtils MLIRArithDialect MLIRControlFlowDialect)
+add_library(CodeGenNew
+  CodeGenNew.cpp
+)
+target_link_libraries(CodeGenNew
+  PUBLIC
+  Parser
+  PylirHIRDialect
+
+  PRIVATE
+  PylirTransformsUtils
+
+  MLIRArithDialect
+  MLIRControlFlowDialect
+)

--- a/test/CodeGenNew/builtins-namespace.py
+++ b/test/CodeGenNew/builtins-namespace.py
@@ -1,0 +1,22 @@
+#  // Licensed under the Apache License v2.0 with LLVM Exceptions.
+#  // See https://llvm.org/LICENSE.txt for license information.
+#  // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# RUN: pylir %s -Xnew-codegen -emit-pylir -o - -S | FileCheck %s
+
+# CHECK: #[[$BASE_EXCEPTION:.*]] = #py.globalValue<builtins.BaseException{{(,|>)}}
+
+# CHECK: %[[GLOBALS:.*]] = py.makeDict
+
+# CHECK: %[[STR:.*]] = py.constant(#py.str<"BaseException">)
+# CHECK: %[[HASH:.*]] = py.str_hash %[[STR]]
+# CHECK: %[[ITEM:.*]] = py.dict_tryGetItem %[[GLOBALS]][%[[STR]] hash(%[[HASH]])]
+# CHECK: %[[BUILTIN:.*]] = py.constant(#[[$BASE_EXCEPTION]])
+# CHECK: %[[IS_UNBOUND:.*]] = py.isUnboundValue %[[ITEM]]
+# CHECK: %[[SELECT:.*]] = arith.select %[[IS_UNBOUND:.*]], %[[BUILTIN]], %[[ITEM]]
+# CHECK: func "__main__.foo"(%{{.*}} "x" = %[[SELECT]])
+def foo(x=BaseException):
+    # CHECK: %[[FIVE:.*]] = py.constant(#py.int<5>)
+    # CHECK: return %[[FIVE]]
+    TypeError = 5
+    return TypeError


### PR DESCRIPTION
After attempting to lookup a symbol in the global scope failed, python requires it to be looked up in the builtins namespace. At this point in time this is implemented by using the builtins list in `Builtins.def`.