### PR TITLE
[PyHIR] Add `call` op

### DIFF
--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.hpp
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.hpp
@@ -169,7 +169,41 @@ public:
   }
 };
 
+/// Struct representing an argument of a call operation.
+struct CallArgument {
+  struct PositionalTag {};
+  struct PosExpansionTag {};
+  struct MapExpansionTag {};
+
+  mlir::Value value;
+  std::variant<PositionalTag, PosExpansionTag, MapExpansionTag,
+               mlir::StringAttr>
+      kind;
+};
+
 } // namespace pylir::HIR
 
 #define GET_OP_CLASSES
 #include "pylir/Optimizer/PylirHIR/IR/PylirHIROps.h.inc"
+
+namespace pylir::HIR {
+
+/// Range adaptor allowing easy iteration over the arguments of a call op.
+class CallArgumentRange
+    : public llvm::indexed_accessor_range<
+          CallArgumentRange, CallOp, CallArgument, CallArgument, CallArgument> {
+  using Base =
+      llvm::indexed_accessor_range<CallArgumentRange, CallOp, CallArgument,
+                                   CallArgument, CallArgument>;
+
+  friend Base;
+
+  // dereference function required by indexed_accessor_range.
+  static CallArgument dereference(CallOp function, std::ptrdiff_t index);
+
+public:
+  explicit CallArgumentRange(CallOp call)
+      : Base(call, 0, call.getArguments().size()) {}
+};
+
+} // namespace pylir::HIR

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.hpp
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.hpp
@@ -199,7 +199,7 @@ class CallArgumentRange
   friend Base;
 
   // dereference function required by indexed_accessor_range.
-  static CallArgument dereference(CallOp function, std::ptrdiff_t index);
+  static CallArgument dereference(CallOp call, std::ptrdiff_t index);
 
 public:
   explicit CallArgumentRange(CallOp call)

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
@@ -25,6 +25,72 @@ class PylirHIR_Op<string mneomic, list<Trait> traits = []>
 // Basics
 //===----------------------------------------------------------------------===//
 
+def PylirHIR_CallOp : PylirHIR_Op<"call"> {
+  let arguments = (ins DynamicType:$callable,
+    Variadic<DynamicType>:$arguments,
+    DefaultValuedAttr<StrArrayAttr, "{}">:$keywords,
+    DefaultValuedAttr<DenseI32ArrayAttr, "{}">:$kind_internal
+  );
+
+  let results = (outs DynamicType:$result);
+
+  let description = [{
+    Operation representing a call operation in Python.
+
+    TODO: Explain call resolution.
+
+    Syntax:
+    ```
+    arg ::= [`*` | `**` | string-attr `=`] value-use
+    global_func ::= `pyHIR.call` value-use `(` [ <arg> { `,` <arg> } ] `)`
+    ```
+  }];
+
+  let assemblyFormat = [{
+    $callable `(` (`)`) : ( ``
+      custom<CallArguments>($keywords,
+                            $arguments,
+                            $kind_internal)^ `)` )? attr-dict
+  }];
+
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+  private:
+    friend mlir::ParseResult parseCallArguments(mlir::OpAsmParser& parser,
+      mlir::ArrayAttr& keywords,
+      llvm::SmallVectorImpl<mlir::OpAsmParser::UnresolvedOperand>& arguments,
+      mlir::DenseI32ArrayAttr& kindInternal);
+
+    enum Kind {
+      Positional = 1,
+      PosExpansion = 2,
+      MapExpansion = 3,
+      Keyword = 0, // zero and any kind of negative value in reality.
+    };
+
+  public:
+
+    /// Returns true if the argument at the given index is a positional
+    /// expansion.
+    bool isPosExpansion(std::size_t index) {
+      return getKindInternal()[index] == Kind::PosExpansion;
+    }
+
+    /// Returns true if the argument at the given index is a map expansion.
+    bool isMapExpansion(std::size_t index) {
+      return getKindInternal()[index] == Kind::MapExpansion;
+    }
+
+    /// Returns the keyword of the argument at the given index.
+    /// Returns a null attribute if the argument is not a keyword argument.
+    mlir::StringAttr getKeyword(std::size_t index) {
+      if (getKindInternal()[index] > 0)
+        return nullptr;
+      return mlir::cast<mlir::StringAttr>(getKeywords()[-getKindInternal()[index]]);
+    }
+  }];
+}
 
 //===----------------------------------------------------------------------===//
 // Functions
@@ -143,7 +209,7 @@ def PylirHIR_GlobalFuncOp : PylirHIR_Op<"globalFunc",
 def PylirHIR_FuncOp : PylirHIR_Op<"func", [OpAsmOpInterface,
   PylirHIR_FunctionInterface]> {
 
-  let arguments = (ins StrAttr:$name, Variadic<AnyType>:$default_values,
+  let arguments = (ins StrAttr:$name, Variadic<DynamicType>:$default_values,
              DenseI32ArrayAttr:$default_values_mapping,
              TypeAttrOf<PylirHIR_FunctionType>:$function_type,
              OptionalAttr<DictArrayAttr>:$arg_attrs,

--- a/src/pylir/Parser/Parser.hpp
+++ b/src/pylir/Parser/Parser.hpp
@@ -260,10 +260,11 @@ public:
    *                        |  keywords_arguments
    * positional_arguments ::=  positional_item { "," positional_item }
    * positional_item      ::=  assignment_expression | "*" expression
-   * starred_and_keywords ::=  ("*" expression | keyword_item) { "," "*"
-   * expression | "," keyword_item } keywords_arguments   ::=  (keyword_item |
-   * "**" expression) { "," keyword_item | "," "**" expression } keyword_item
-   * ::=  identifier "=" expression
+   * starred_and_keywords ::=  ("*" expression | keyword_item)
+   *                           { "," "*" expression | "," keyword_item }
+   * keywords_arguments   ::=  (keyword_item | "**" expression)
+   *                           { "," keyword_item | "," "**" expression }
+   * keyword_item ::=  identifier "=" expression
    */
   std::optional<std::vector<Syntax::Argument>>
   parseArgumentList(IntrVarPtr<Syntax::Expression>&& firstAssignment = nullptr);

--- a/test/Optimizer/PylirHIR/IR/invalid.mlir
+++ b/test/Optimizer/PylirHIR/IR/invalid.mlir
@@ -2,12 +2,42 @@
 
 // expected-error@below {{only one positional rest parameter allowed}}
 pyHIR.globalFunc @two_pos_rest(*%arg0, *%arg1) {
-    return
+  return
 }
 
 // -----
 
 // expected-error@below {{only one keyword rest parameter allowed}}
 pyHIR.globalFunc @two_keyword_rest(**%arg0, **%arg1) {
-    return
+  return
+}
+
+// -----
+
+pyHIR.globalFunc @call_kind_arguments_mismatch(%arg0) {
+  // expected-error@below {{"kind_internal" must be the same size as argument operands}}
+  %0 = "pyHIR.call"(%arg0, %arg0)
+    <{ kind_internal = array<i32>, keywords = ["rest"] }>
+    : (!py.dynamic, !py.dynamic) -> !py.dynamic
+  return %0
+}
+
+// -----
+
+pyHIR.globalFunc @call_invalid_kind_value(%arg0) {
+  // expected-error@below {{invalid value 4 in "kind_internal" array}}
+  %0 = "pyHIR.call"(%arg0, %arg0)
+    <{ kind_internal = array<i32: 4>, keywords = ["rest"] }>
+    : (!py.dynamic, !py.dynamic) -> !py.dynamic
+  return %0
+}
+
+// -----
+
+pyHIR.globalFunc @call_invalid_kind_index(%arg0) {
+  // expected-error@below {{out-of-bounds index 1 into keywords array with size 1}}
+  %0 = "pyHIR.call"(%arg0, %arg0)
+    <{ kind_internal = array<i32: -1>, keywords = ["rest"] }>
+    : (!py.dynamic, !py.dynamic) -> !py.dynamic
+  return %0
 }

--- a/test/Optimizer/PylirHIR/IR/roundtrip.mlir
+++ b/test/Optimizer/PylirHIR/IR/roundtrip.mlir
@@ -9,26 +9,39 @@
 // CHECK-NEXT: %{{.*}} = func "foo"(%{{.*}} "rest" = %[[ARG1]]) {
 
 pyHIR.globalFunc @test(%arg0, *%arg1, %arg2 "keyword", %arg3 { test.name = 0 : i32 }, %arg4 only "lol" has_default) {
-    %0 = func "foo"(%ff0 "rest" = %arg1) {
-        return %ff0
-    }
-    return %0
+  %0 = func "foo"(%ff0 "rest" = %arg1) {
+      return %ff0
+  }
+  return %0
 }
 
 // CHECK-LABEL: pyHIR.globalFunc @res_attr()
 // CHECK-SAME: -> {test.name = 0 : i32}
 pyHIR.globalFunc @res_attr() -> { test.name = 0 : i32 } {
-    %0 = func "foo"(%ff0 "rest") {
-        return %ff0
-    }
-    return %0
+  %0 = func "foo"(%ff0 "rest") {
+      return %ff0
+  }
+  return %0
 }
 
 // CHECK-LABEL: pyHIR.init "__main__" {
 // CHECK: init_return
 pyHIR.init "__main__" {
-    %0 = func "foo"(%ff0 "rest") {
-        return %ff0
-    }
-    init_return %0
+  %0 = func "foo"(%ff0 "rest") {
+      return %ff0
+  }
+  init_return %0
+}
+
+// CHECK-LABEL: pyHIR.globalFunc @call(
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+pyHIR.globalFunc @call(%0) {
+  // CHECK: call %[[ARG0]](%[[ARG0]], *%[[ARG0]], "rest"=%[[ARG0]], **%[[ARG0]])
+  %1 = call %0(%0, *%0, "rest"=%0, **%0)
+  // CHECK: call %[[ARG0]](%[[ARG0]])
+  %2 = call %0(%0)
+  // CHECK: call %[[ARG0]]()
+  %3 = call %0()
+
+  return %1
 }


### PR DESCRIPTION
This op is designe to exactly mirror the way call expressions work in python but relaxes the syntax a bit to allow future optimizations such as inline expansions.

This PR only includes the dialect changes itself with frontend and lowering changes coming later. Given that elaborating on the semantics would require explaining python's call sequence in full, the documentation of the op has been left close to empty as well.