### PR TITLE
[ci] Fix GitHub actions deprecation warnings

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -33,7 +33,7 @@ runs:
   using: composite
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
 

--- a/.github/actions/llvm-checkout/action.yml
+++ b/.github/actions/llvm-checkout/action.yml
@@ -10,7 +10,7 @@ runs:
         "LLVM_REVISION=$(Get-Content -Path ./Pylir/.pinned-llvm-revision)" >> $Env:GITHUB_ENV
 
     - name: Checkout LLVM
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: llvm/llvm-project
         ref: ${{ env.LLVM_REVISION }}

--- a/.github/actions/llvm-fetch/action.yml
+++ b/.github/actions/llvm-fetch/action.yml
@@ -18,7 +18,7 @@ runs:
       uses:  ./Pylir/.github/actions/llvm-checkout
 
     - name: Restore LLVM Build
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: |
           llvm-build 

--- a/.github/workflows/build-and-lint.yml
+++ b/.github/workflows/build-and-lint.yml
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Checkout Pylir
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: Pylir
 
@@ -155,7 +155,7 @@ jobs:
           sudo apt-get install clang-tidy-$LLVM_LINT_VERSION
 
       - name: Checkout Pylir
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: Pylir
           # Depth 2 because we use git diff HEAD^ later.
@@ -239,7 +239,7 @@ jobs:
           python-version: 3.9
 
       - name: Checkout Pylir
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Depth 2 because we need the diff.
           fetch-depth: 2

--- a/.github/workflows/ccache-recompress-nightly.yml
+++ b/.github/workflows/ccache-recompress-nightly.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout Repo for Actions
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: Pylir
 

--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout Repo for Actions
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: Pylir
 
@@ -62,7 +62,7 @@ jobs:
 
       - name: Check LLVM Cache
         id: check-llvm-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             llvm-build 


### PR DESCRIPTION
See https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ A few actions (first-party from GitHub) are showing up with deprecation warnings due to still using node-16. Support for these will be dropped very soon, according to the blog post.