### PR TITLE
[PyHIRToPylirPy] Implement `pyHIR.call` lowering

### DIFF
--- a/src/pylir/CodeGen/CodeGen.hpp
+++ b/src/pylir/CodeGen/CodeGen.hpp
@@ -11,6 +11,7 @@
 #include <llvm/ADT/ScopeExit.h>
 
 #include <pylir/Diagnostics/DiagnosticsBuilder.hpp>
+#include <pylir/Optimizer/PylirPy/IR/PyBuilder.hpp>
 #include <pylir/Optimizer/PylirPy/IR/PylirPyOps.hpp>
 #include <pylir/Optimizer/Transforms/Util/SSABuilder.hpp>
 #include <pylir/Parser/Syntax.hpp>
@@ -21,7 +22,6 @@
 #include <unordered_map>
 
 #include "CodeGenOptions.hpp"
-#include "PyBuilder.hpp"
 
 namespace pylir {
 

--- a/src/pylir/Optimizer/PylirPy/IR/PyBuilder.hpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PyBuilder.hpp
@@ -7,8 +7,9 @@
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/IR/Builders.h>
 
-#include <pylir/Optimizer/PylirPy/IR/PylirPyOps.hpp>
 #include <pylir/Support/BigInt.hpp>
+
+#include "PylirPyOps.hpp"
 
 namespace pylir {
 class PyBuilder : public mlir::OpBuilder {

--- a/test/Optimizer/Conversion/PylirHIRToPylirPy/call.mlir
+++ b/test/Optimizer/Conversion/PylirHIRToPylirPy/call.mlir
@@ -1,0 +1,14 @@
+// RUN: pylir-opt %s --convert-pylirHIR-to-pylirPy --split-input-file | FileCheck %s
+
+// CHECK-LABEL: func @basic$impl
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+pyHIR.globalFunc @basic(%arg0) {
+  // CHECK: %[[K:.*]] = constant(#py.str<"k">)
+  // CHECK: %[[HASH:.*]] = str_hash %[[K]]
+  // CHECK: %[[TUPLE:.*]] = makeTuple (%[[ARG0]], *%[[ARG0]])
+  // CHECK: %[[DICT:.*]] = makeDict (%[[K]] hash(%[[HASH]]) : %[[ARG0]], **%[[ARG0]])
+  // CHECK: %[[RET:.*]] = call @pylir__call__(%[[ARG0]], %[[TUPLE]], %[[DICT]])
+  %0 = call %arg0(%arg0, "k"=%arg0, *%arg0, **%arg0)
+  // CHECK: return %[[RET]]
+  return %0
+}


### PR DESCRIPTION
In the general case, the lowering is implemented the same way as the old frontend: The call is lowered to the `pylir__call__` intrinsic which implements the method lookup. The implementation of `pylir__call__` is additionally generated during the conversion pass and not in the frontend like the old codegen. The implementation of `pylir__call__` was copy-pasted for now. It is likely that it will be simplified in the future by being able to use `pyHIR` operations. As soon as the new `CodeGen` is done we can also delete the old one.