### PR TITLE
[PyHIRToPylirPy] Implement `binOp` lowering

### DIFF
--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIRAttributes.hpp
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIRAttributes.hpp
@@ -1,0 +1,16 @@
+//  Licensed under the Apache License v2.0 with LLVM Exceptions.
+//  See https://llvm.org/LICENSE.txt for license information.
+//  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <mlir/IR/BuiltinAttributes.h>
+#include <mlir/IR/DialectImplementation.h>
+
+#include <llvm/ADT/DenseMapInfo.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/Support/raw_ostream.h>
+
+#include <optional>
+
+#include "pylir/Optimizer/PylirHIR/IR/PylirHIREnums.h.inc"

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIRDialect.cpp
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIRDialect.cpp
@@ -13,12 +13,14 @@
 
 #include <pylir/Optimizer/PylirPy/IR/PylirPyDialect.hpp>
 
+#include "PylirHIRAttributes.hpp"
 #include "PylirHIROps.hpp"
 
 #define GET_TYPEDEF_CLASSES
 #define GET_ATTRDEF_CLASSES
 #include "pylir/Optimizer/PylirHIR/IR/PylirHIRAttributes.cpp.inc"
 #include "pylir/Optimizer/PylirHIR/IR/PylirHIRDialect.cpp.inc"
+#include "pylir/Optimizer/PylirHIR/IR/PylirHIREnums.cpp.inc"
 #include "pylir/Optimizer/PylirHIR/IR/PylirHIRTypes.cpp.inc"
 
 void pylir::HIR::PylirHIRDialect::initialize() {

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.hpp
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.hpp
@@ -18,6 +18,7 @@
 
 #include <pylir/Optimizer/PylirPy/IR/PylirPyTypes.hpp>
 
+#include "PylirHIRAttributes.hpp"
 #include "PylirHIRDialect.hpp"
 
 #include "pylir/Optimizer/PylirHIR/IR/PylirHIRFunctionInterface.h.inc"

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
@@ -5,6 +5,7 @@
 #ifndef PYLIR_HIR_OPS_TABLEGEN
 #define PYLIR_HIR_OPS_TABLEGEN
 
+include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpBase.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
@@ -22,9 +23,46 @@ class PylirHIR_Op<string mneomic, list<Trait> traits = []>
   : Op<PylirHIR_Dialect, mneomic, traits>;
 
 //===----------------------------------------------------------------------===//
-// Basics
+// Basic Operations
 //===----------------------------------------------------------------------===//
 
+def PylirHIR_BinaryOperationAttr : I32EnumAttr<"BinaryOperation",
+  "Binary operations in python", [
+  I32EnumAttrCase<"Eq", 0, "__eq__">,
+  I32EnumAttrCase<"Ne", 1, "__ne__">,
+  I32EnumAttrCase<"Lt", 2, "__lt__">,
+  I32EnumAttrCase<"Le", 3, "__le__">,
+  I32EnumAttrCase<"Gt", 4, "__gt__">,
+  I32EnumAttrCase<"Ge", 5, "__ge__">,
+  I32EnumAttrCase<"Add", 6, "__add__">,
+  I32EnumAttrCase<"Sub", 7, "__sub__">,
+  I32EnumAttrCase<"Or", 8, "__or__">,
+  I32EnumAttrCase<"Xor", 9, "__xor__">,
+  I32EnumAttrCase<"And", 10, "__and__">,
+  I32EnumAttrCase<"LShift", 11, "__lshift__">,
+  I32EnumAttrCase<"RShift", 12, "__rshift__">,
+  I32EnumAttrCase<"Mul", 13, "__mul__">,
+  I32EnumAttrCase<"Div", 14, "__div__">,
+  I32EnumAttrCase<"FloorDiv", 15, "__floordiv__">,
+  I32EnumAttrCase<"Mod", 16, "__mod__">,
+  I32EnumAttrCase<"MatMul", 17, "__matmul__">,
+]> {
+  let cppNamespace = "pylir::HIR";
+}
+
+def PylirHIR_BinOp : PylirHIR_Op<"binOp", []> {
+  let arguments = (ins PylirHIR_BinaryOperationAttr:$binaryOperation,
+                       DynamicType:$lhs, DynamicType:$rhs);
+  let results = (outs DynamicType:$result);
+
+  let description = [{
+    Operation representing a reversible binary operator in python.
+  }];
+
+  let assemblyFormat = [{
+    $lhs $binaryOperation $rhs attr-dict
+  }];
+}
 def PylirHIR_CallOp : PylirHIR_Op<"call"> {
   let arguments = (ins DynamicType:$callable,
     Variadic<DynamicType>:$arguments,

--- a/test/Optimizer/Conversion/PylirHIRToPylirPy/binOp.mlir
+++ b/test/Optimizer/Conversion/PylirHIRToPylirPy/binOp.mlir
@@ -1,0 +1,44 @@
+// RUN: pylir-opt %s --convert-pylirHIR-to-pylirPy --split-input-file | FileCheck %s
+
+// CHECK-LABEL: func @binOp$impl
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+pyHIR.globalFunc @binOp(%0, %1) {
+  // CHECK: call @pylir__eq__(%[[ARG0]], %[[ARG1]])
+  %2 = binOp %0 __eq__ %1
+  // CHECK: call @pylir__ne__(%[[ARG0]], %[[ARG1]])
+  %3 = binOp %0 __ne__ %1
+  // CHECK: call @pylir__lt__(%[[ARG0]], %[[ARG1]])
+  %4 = binOp %0 __lt__ %1
+  // CHECK: call @pylir__le__(%[[ARG0]], %[[ARG1]])
+  %5 = binOp %0 __le__ %1
+  // CHECK: call @pylir__gt__(%[[ARG0]], %[[ARG1]])
+  %6 = binOp %0 __gt__ %1
+  // CHECK: call @pylir__ge__(%[[ARG0]], %[[ARG1]])
+  %7 = binOp %0 __ge__ %1
+  // CHECK: call @pylir__add__(%[[ARG0]], %[[ARG1]])
+  %8 = binOp %0 __add__ %1
+  // CHECK: call @pylir__sub__(%[[ARG0]], %[[ARG1]])
+  %9 = binOp %0 __sub__ %1
+  // CHECK: call @pylir__or__(%[[ARG0]], %[[ARG1]])
+  %10 = binOp %0 __or__ %1
+  // CHECK: call @pylir__xor__(%[[ARG0]], %[[ARG1]])
+  %11 = binOp %0 __xor__ %1
+  // CHECK: call @pylir__and__(%[[ARG0]], %[[ARG1]])
+  %12 = binOp %0 __and__ %1
+  // CHECK: call @pylir__lshift__(%[[ARG0]], %[[ARG1]])
+  %13 = binOp %0 __lshift__ %1
+  // CHECK: call @pylir__rshift__(%[[ARG0]], %[[ARG1]])
+  %14 = binOp %0 __rshift__ %1
+  // CHECK: call @pylir__mul__(%[[ARG0]], %[[ARG1]])
+  %15 = binOp %0 __mul__ %1
+  // CHECK: call @pylir__div__(%[[ARG0]], %[[ARG1]])
+  %16 = binOp %0 __div__ %1
+  // CHECK: call @pylir__floordiv__(%[[ARG0]], %[[ARG1]])
+  %17 = binOp %0 __floordiv__ %1
+  // CHECK: call @pylir__mod__(%[[ARG0]], %[[ARG1]])
+  %18 = binOp %0 __mod__ %1
+  // CHECK: call @pylir__matmul__(%[[ARG0]], %[[ARG1]])
+  %19 = binOp %0 __matmul__ %1
+  return %2
+}

--- a/test/Optimizer/PylirHIR/IR/roundtrip.mlir
+++ b/test/Optimizer/PylirHIR/IR/roundtrip.mlir
@@ -45,3 +45,46 @@ pyHIR.globalFunc @call(%0) {
 
   return %1
 }
+
+// CHECK-LABEL: pyHIR.globalFunc @binOp(
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+pyHIR.globalFunc @binOp(%0, %1) {
+  // CHECK: binOp %[[ARG0]] __eq__ %[[ARG1]]
+  %2 = binOp %0 __eq__ %1
+  // CHECK: binOp %[[ARG0]] __ne__ %[[ARG1]]
+  %3 = binOp %0 __ne__ %1
+  // CHECK: binOp %[[ARG0]] __lt__ %[[ARG1]]
+  %4 = binOp %0 __lt__ %1
+  // CHECK: binOp %[[ARG0]] __le__ %[[ARG1]]
+  %5 = binOp %0 __le__ %1
+  // CHECK: binOp %[[ARG0]] __gt__ %[[ARG1]]
+  %6 = binOp %0 __gt__ %1
+  // CHECK: binOp %[[ARG0]] __ge__ %[[ARG1]]
+  %7 = binOp %0 __ge__ %1
+  // CHECK: binOp %[[ARG0]] __add__ %[[ARG1]]
+  %8 = binOp %0 __add__ %1
+  // CHECK: binOp %[[ARG0]] __sub__ %[[ARG1]]
+  %9 = binOp %0 __sub__ %1
+  // CHECK: binOp %[[ARG0]] __or__ %[[ARG1]]
+  %10 = binOp %0 __or__ %1
+  // CHECK: binOp %[[ARG0]] __xor__ %[[ARG1]]
+  %11 = binOp %0 __xor__ %1
+  // CHECK: binOp %[[ARG0]] __and__ %[[ARG1]]
+  %12 = binOp %0 __and__ %1
+  // CHECK: binOp %[[ARG0]] __lshift__ %[[ARG1]]
+  %13 = binOp %0 __lshift__ %1
+  // CHECK: binOp %[[ARG0]] __rshift__ %[[ARG1]]
+  %14 = binOp %0 __rshift__ %1
+  // CHECK: binOp %[[ARG0]] __mul__ %[[ARG1]]
+  %15 = binOp %0 __mul__ %1
+  // CHECK: binOp %[[ARG0]] __div__ %[[ARG1]]
+  %16 = binOp %0 __div__ %1
+  // CHECK: binOp %[[ARG0]] __floordiv__ %[[ARG1]]
+  %17 = binOp %0 __floordiv__ %1
+  // CHECK: binOp %[[ARG0]] __mod__ %[[ARG1]]
+  %18 = binOp %0 __mod__ %1
+  // CHECK: binOp %[[ARG0]] __matmul__ %[[ARG1]]
+  %19 = binOp %0 __matmul__ %1
+  return %2
+}


### PR DESCRIPTION
The existing builtins that are generated by `CodeGen` are reused and generated by the conversion pass to allow any occurrences of `binOp` to call them in the general case.