### PR TITLE
[CodeGenNew] Implement intrinsic calls

### DIFF
--- a/src/pylir/CodeGenNew/CMakeLists.txt
+++ b/src/pylir/CodeGenNew/CMakeLists.txt
@@ -18,3 +18,4 @@ target_link_libraries(CodeGenNew
   MLIRArithDialect
   MLIRControlFlowDialect
 )
+add_dependencies(CodeGenNew CodeGenIntrIncGen)

--- a/test/CodeGenNew/intrinsics-errors.py
+++ b/test/CodeGenNew/intrinsics-errors.py
@@ -1,0 +1,26 @@
+# RUN: pylir %s -Xnew-codegen -emit-pylir -o - -S -verify
+
+# expected-error@below {{unknown intrinsic 'pylir.intr.thing.doesnt.exist'}}
+pylir.intr.thing.doesnt.exist()
+
+args = 1
+d = 2
+
+# expected-error@+3 {{intrinsics do not support keyword arguments}}
+# expected-error@+2 {{intrinsics do not support iterable unpacking arguments}}
+# expected-error@+1 {{intrinsics do not support dictionary unpacking arguments}}
+pylir.intr.typeOf(k=3, *args, **d)
+
+# expected-error@below {{intrinsics do not support comprehension arguments}}
+pylir.intr.typeOf(i for i in d)
+
+# expected-error@below {{intrinsic 'pylir.intr.typeOf' expects 1 argument(s) not 0}}
+pylir.intr.typeOf()
+
+# expected-error@below {{argument 1 of intrinsic 'pylir.intr.int.cmp' has to be a constant string}}
+pylir.intr.int.cmp(args, d, args)
+
+# expected-error@below {{invalid enum value 'lol' for enum 'IntCmpKind' argument}}
+pylir.intr.int.cmp('lol', d, args)
+# expected-note@above {{valid values are: eq, ne, lt, le, gt, ge}}
+

--- a/test/CodeGenNew/intrinsics.py
+++ b/test/CodeGenNew/intrinsics.py
@@ -1,0 +1,31 @@
+# RUN: pylir %s -Xnew-codegen -emit-pylir -o - -S | FileCheck %s
+
+# CHECK-LABEL: init "__main__"
+# CHECK: %[[DICT:.*]] = py.makeDict ()
+
+def foo():
+    pass
+
+
+# CHECK: py.dict_setItem
+# CHECK: %[[STR:.*]] = py.constant(#py.str<"foo">)
+# CHECK: %[[HASH:.*]] = py.str_hash %[[STR]]
+# CHECK: %[[FOO:.*]] = py.dict_tryGetItem %[[DICT]][%[[STR]] hash(%[[HASH]])]
+# CHECK: %[[T:.*]] = py.typeOf %[[FOO]]
+# CHECK: %[[STR:.*]] = py.constant(#py.str<"t">)
+# CHECK: %[[HASH:.*]] = py.str_hash %[[STR]]
+# CHECK: py.dict_setItem %[[DICT]][%[[STR]] hash(%[[HASH]])] to %[[T]]
+t = pylir.intr.typeOf(foo)
+
+# CHECK: %[[ZERO:.*]] = py.constant(#py.int<0>)
+# CHECK: %[[ONE:.*]] = py.constant(#py.int<1>)
+# CHECK: %[[CMP:.*]] = py.int_cmp ne %[[ZERO]], %[[ONE]]
+# CHECK: %[[BOOL:.*]] = py.bool_fromI1 %[[CMP]]
+pylir.intr.int.cmp("ne", 0, 1)
+
+# CHECK: %[[ZERO:.*]] = py.constant(#py.int<0>)
+# CHECK: %[[ONE:.*]] = py.constant(#py.int<1>)
+# CHECK: %[[TWO:.*]] = py.constant(#py.int<2>)
+# CHECK: %[[THREE:.*]] = py.constant(#py.int<3>)
+# CHECK: py.function_call %[[ZERO]](%[[ONE]], %[[TWO]], %[[THREE]])
+pylir.intr.function.call(0, 1, 2, 3)


### PR DESCRIPTION
Intrinsic calls are a very important part of the builtins implementation as they make it possible to directly create MLIR implementations implementing semantics that are impossible in pure python code. The kinds of intrinsics are all automatically generated using TableGen from the `py` dialect.

This PR hooks these intrinsics up to the new codegen. The code is mostly taken from the old but adjusted for the evolved style.