### PR TITLE
[ci] Add nightly runner testing MLIR trunk

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Whether only dependencies for build LLVM must be installed'
     required: false
     default: 'OFF'
+  cmake-version:
+    description: 'CMake version to install'
+    required: false
+    default: '3.20.6'
 
 outputs:
   key:
@@ -40,7 +44,7 @@ runs:
     - name: Install minimum required cmake and ninja
       uses: lukka/get-cmake@latest
       with:
-        cmakeVersion: 3.20.6
+        cmakeVersion: ${{inputs.cmake-version}}
 
     - name: Install Ubuntu dependencies
       if: ${{ runner.os == 'Linux' }}

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -27,6 +27,14 @@ inputs:
     description: 'CMake version to install'
     required: false
     default: '3.20.6'
+  ccache-size:
+    description: 'custom ccache size or calculate if empty'
+    required: false
+    default: ''
+  ccache-key-append:
+    description: 'text to append to the ccache key'
+    required: false
+    default: ''
 
 outputs:
   key:
@@ -96,6 +104,7 @@ runs:
         if ('${{inputs.shared_libs}}' -eq 'ON') {
           $key += '-shared'
         }
+        $key += '${{inputs.ccache-key-append}}'
 
         "key=$key" >> $Env:GITHUB_OUTPUT
 
@@ -114,7 +123,9 @@ runs:
       shell: pwsh
       id: calculate-cache-size
       run: |
-        if ('${{inputs.sanitizers}}') {
+        if ('${{inputs.cccache-size}}') {
+          "size=${{inputs.cccache-size}}" >> $Env:GITHUB_OUTPUT
+        } elseif ('${{inputs.sanitizers}}') {
           if ($IsWindows) {
             "size=120M" >> $Env:GITHUB_OUTPUT
           } else {

--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -104,7 +104,9 @@ runs:
         if ('${{inputs.shared_libs}}' -eq 'ON') {
           $key += '-shared'
         }
-        $key += '${{inputs.ccache-key-append}}'
+        if ('${{inputs.ccache-key-append}}') {
+          $key += '-${{inputs.ccache-key-append}}'
+        }
 
         "key=$key" >> $Env:GITHUB_OUTPUT
 
@@ -123,8 +125,8 @@ runs:
       shell: pwsh
       id: calculate-cache-size
       run: |
-        if ('${{inputs.cccache-size}}') {
-          "size=${{inputs.cccache-size}}" >> $Env:GITHUB_OUTPUT
+        if ('${{inputs.ccache-size}}') {
+          "size=${{inputs.ccache-size}}" >> $Env:GITHUB_OUTPUT
         } elseif ('${{inputs.sanitizers}}') {
           if ($IsWindows) {
             "size=120M" >> $Env:GITHUB_OUTPUT

--- a/.github/workflows/llvm-trunk-test.yml
+++ b/.github/workflows/llvm-trunk-test.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           c-compiler: clang
           cpp-compiler: clang++
-          cmake-version: 3.25.3
+          cmake-version: 3.23.5
 
       - name: Set .pinned-llvm-revision to main
         run: |

--- a/.github/workflows/llvm-trunk-test.yml
+++ b/.github/workflows/llvm-trunk-test.yml
@@ -1,8 +1,6 @@
 name: LLVM Trunk Test
 
 on:
-  # TODO: Remove before merge.
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0'
@@ -43,12 +41,6 @@ jobs:
           echo "main" `
           | Out-File -FilePath "${{github.workspace}}/Pylir/.pinned-llvm-revision" -Encoding utf8
 
-      - name: Restore CPM-Cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/cpm-cache
-          key: ${{ runner.os }}-cpm
-
       - name: Configure Pylir
         run: |
           cmake -GNinja -Bpylir-build `
@@ -63,12 +55,6 @@ jobs:
             -DPYLIR_INCLUDE_LLVM_BUILD=ON `
             -DCPM_SOURCE_CACHE=~/cpm-cache `
             -S ${{github.workspace}}/Pylir
-
-      - name: Save CPM-Cache
-        uses: actions/cache/save@v4
-        with:
-          path: ~/cpm-cache
-          key: ${{ runner.os }}-cpm
 
       - name: Build Pylir
         run: |

--- a/.github/workflows/llvm-trunk-test.yml
+++ b/.github/workflows/llvm-trunk-test.yml
@@ -32,7 +32,7 @@ jobs:
           cpp-compiler: clang++
           cmake-version: 3.21.7
           ccache-key-append: trunk
-          ccache-size: 100M
+          ccache-size: 150M
 
       - name: Install Python depends
         run: |

--- a/.github/workflows/llvm-trunk-test.yml
+++ b/.github/workflows/llvm-trunk-test.yml
@@ -2,7 +2,6 @@ name: LLVM Trunk Test
 
 on:
   workflow_dispatch:
-  pull_request:
   schedule:
     - cron: '0 0 * * 0'
 

--- a/.github/workflows/llvm-trunk-test.yml
+++ b/.github/workflows/llvm-trunk-test.yml
@@ -1,0 +1,71 @@
+name: LLVM Trunk Test
+
+on:
+  # TODO: Remove before merge
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  llvm-trunk-test:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - name: Checkout Pylir
+        uses: actions/checkout@v4
+        with:
+          path: Pylir
+
+      - name: Install Dependencies
+        id: dep-install
+        uses: ./Pylir/.github/actions/dependencies
+        with:
+          c-compiler: clang
+          cpp-compiler: clang++
+
+      - id: lastcommit
+        name: Get LLVM main commit hash
+        uses: nmbgeek/github-action-get-latest-commit@v0.1.0
+        with:
+          owner: llvm-project
+          repo: llvm
+          branch: main
+
+      - name: Update .pinned-llvm-revision
+        run: |
+          echo "${{steps.lastcommit.outputs.hash}}" `
+          | Out-File -FilePath "${{github.workspace}}/Pylir/.pinned-llvm-revision" -Encoding utf8
+
+      - name: Configure Pylir
+        run: |
+          cmake -GNinja -Bpylir-build `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_CXX_COMPILER=clang++ `
+            -DCMAKE_C_COMPILER=clang `
+            -DPython3_ROOT_DIR="$Env:pythonLocation" -DPython3_FIND_STRATEGY=LOCATION `
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache `
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache `
+            -DPYLIR_ENABLE_ASSERTIONS=ON `
+            -DPYLIR_INCLUDE_LLVM_BUILD=ON `
+            -S ${{github.workspace}}/Pylir
+
+      - name: Build Pylir
+        run: |
+          cmake --build pylir-build
+
+      - name: Test
+        working-directory: ${{github.workspace}}/pylir-build
+        run: ctest --extra-verbose
+
+      - name: Cleanup disk space
+        if: always()
+        run: |
+          Remove-Item -Recurse -Force pylir-build -ErrorAction Ignore

--- a/.github/workflows/llvm-trunk-test.yml
+++ b/.github/workflows/llvm-trunk-test.yml
@@ -31,7 +31,7 @@ jobs:
           cpp-compiler: clang++
           cmake-version: 3.21.7
           ccache-key-append: trunk
-          ccache-size: 200M
+          ccache-size: 250M
 
       - name: Install Python depends
         run: |

--- a/.github/workflows/llvm-trunk-test.yml
+++ b/.github/workflows/llvm-trunk-test.yml
@@ -32,6 +32,10 @@ jobs:
           cpp-compiler: clang++
           cmake-version: 3.21.7
 
+      - name: Install Python depends
+        run: |
+          Invoke-expression "$Env:pythonLocation\python -m pip install -r ${{github.workspace}}/Pylir/test/requirements.txt"
+
       - name: Set .pinned-llvm-revision to main
         run: |
           echo "main" `

--- a/.github/workflows/llvm-trunk-test.yml
+++ b/.github/workflows/llvm-trunk-test.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           c-compiler: clang
           cpp-compiler: clang++
+          cmake-version: 3.25.3
 
       - name: Set .pinned-llvm-revision to main
         run: |

--- a/.github/workflows/llvm-trunk-test.yml
+++ b/.github/workflows/llvm-trunk-test.yml
@@ -32,7 +32,7 @@ jobs:
           cpp-compiler: clang++
           cmake-version: 3.21.7
           ccache-key-append: trunk
-          ccache-size: 150M
+          ccache-size: 200M
 
       - name: Install Python depends
         run: |
@@ -42,6 +42,12 @@ jobs:
         run: |
           echo "main" `
           | Out-File -FilePath "${{github.workspace}}/Pylir/.pinned-llvm-revision" -Encoding utf8
+
+      - name: Restore CPM-Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/cpm-cache
+          key: ${{ runner.os }}-cpm
 
       - name: Configure Pylir
         run: |
@@ -55,7 +61,14 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache `
             -DPYLIR_ENABLE_ASSERTIONS=ON `
             -DPYLIR_INCLUDE_LLVM_BUILD=ON `
+            -DCPM_SOURCE_CACHE=~/cpm-cache `
             -S ${{github.workspace}}/Pylir
+
+      - name: Save CPM-Cache
+        uses: actions/cache/save@v4
+        with:
+          path: ~/cpm-cache
+          key: ${{ runner.os }}-cpm
 
       - name: Build Pylir
         run: |

--- a/.github/workflows/llvm-trunk-test.yml
+++ b/.github/workflows/llvm-trunk-test.yml
@@ -31,6 +31,8 @@ jobs:
           c-compiler: clang
           cpp-compiler: clang++
           cmake-version: 3.21.7
+          ccache-key-append: trunk
+          ccache-size: 100M
 
       - name: Install Python depends
         run: |

--- a/.github/workflows/llvm-trunk-test.yml
+++ b/.github/workflows/llvm-trunk-test.yml
@@ -31,17 +31,9 @@ jobs:
           c-compiler: clang
           cpp-compiler: clang++
 
-      - id: lastcommit
-        name: Get LLVM main commit hash
-        uses: nmbgeek/github-action-get-latest-commit@v0.1.0
-        with:
-          owner: llvm
-          repo: llvm-project
-          branch: main
-
-      - name: Update .pinned-llvm-revision
+      - name: Set .pinned-llvm-revision to main
         run: |
-          echo "${{steps.lastcommit.outputs.hash}}" `
+          echo "main" `
           | Out-File -FilePath "${{github.workspace}}/Pylir/.pinned-llvm-revision" -Encoding utf8
 
       - name: Configure Pylir
@@ -52,6 +44,7 @@ jobs:
             -DCMAKE_C_COMPILER=clang `
             -DPython3_ROOT_DIR="$Env:pythonLocation" -DPython3_FIND_STRATEGY=LOCATION `
             -DCMAKE_C_COMPILER_LAUNCHER=ccache `
+            -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" `
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache `
             -DPYLIR_ENABLE_ASSERTIONS=ON `
             -DPYLIR_INCLUDE_LLVM_BUILD=ON `

--- a/.github/workflows/llvm-trunk-test.yml
+++ b/.github/workflows/llvm-trunk-test.yml
@@ -1,7 +1,7 @@
 name: LLVM Trunk Test
 
 on:
-  # TODO: Remove before merge
+  # TODO: Remove before merge.
   pull_request:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/llvm-trunk-test.yml
+++ b/.github/workflows/llvm-trunk-test.yml
@@ -35,8 +35,8 @@ jobs:
         name: Get LLVM main commit hash
         uses: nmbgeek/github-action-get-latest-commit@v0.1.0
         with:
-          owner: llvm-project
-          repo: llvm
+          owner: llvm
+          repo: llvm-project
           branch: main
 
       - name: Update .pinned-llvm-revision

--- a/.github/workflows/llvm-trunk-test.yml
+++ b/.github/workflows/llvm-trunk-test.yml
@@ -2,6 +2,7 @@ name: LLVM Trunk Test
 
 on:
   workflow_dispatch:
+  pull_request:
   schedule:
     - cron: '0 0 * * 0'
 

--- a/.github/workflows/llvm-trunk-test.yml
+++ b/.github/workflows/llvm-trunk-test.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           c-compiler: clang
           cpp-compiler: clang++
-          cmake-version: 3.23.5
+          cmake-version: 3.21.7
 
       - name: Set .pinned-llvm-revision to main
         run: |

--- a/cmake/PylirLLVMBuild.cmake
+++ b/cmake/PylirLLVMBuild.cmake
@@ -6,6 +6,10 @@
 function(add_required_llvm_build llvm_revision)
   include(CPM)
 
+  if (CMAKE_VERSION VERSION_LESS "3.21")
+    message(FATAL_ERROR "Building LLVM as part of Pylir requires at least version 3.21")
+  endif ()
+
   # Set the default value of the MSVC runtime library to the same as CMake
   # as is documented here: https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html
   # This is required to make the LLVM build use the same runtime library


### PR DESCRIPTION
Having a CI runner that tests against LLVM trunk has many benefits:
* If an upstream refactor breaks the build we notice early and can bump asap
* If an upstream change leads to a miscompile we can notify the author asap

The implementation reuses the logic to automatically build MLIR as part of Pylir which has so far been untested with CI and only used locally. This builder therefore also gives us test coverage for that cmake path. 
Bisection support may be added in the future to automatically determine problematic upstream commits.