### PR TITLE
[CodeGenNew] Implement boolean operations

### DIFF
--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.cpp
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.cpp
@@ -106,8 +106,21 @@ void pylir::HIR::CallOp::build(OpBuilder& odsBuilder, OperationState& odsState,
         });
   }
 
-  build(odsBuilder, odsState, callable, argOperands,
-        odsBuilder.getArrayAttr(keywords), kindInternal);
+  odsState.addTypes(odsBuilder.getType<Py::DynamicType>());
+  odsState.addOperands(callable);
+  odsState.addOperands(argOperands);
+  odsState.getOrAddProperties<Properties>().keywords =
+      odsBuilder.getArrayAttr(keywords);
+  odsState.getOrAddProperties<Properties>().kind_internal =
+      odsBuilder.getDenseI32ArrayAttr(kindInternal);
+}
+
+void pylir::HIR::CallOp::build(OpBuilder& odsBuilder, OperationState& odsState,
+                               Value callable, ValueRange posArguments) {
+  return build(odsBuilder, odsState, callable,
+               llvm::map_to_vector(posArguments, [](Value value) {
+                 return CallArgument{value, CallArgument::PositionalTag{}};
+               }));
 }
 
 LogicalResult pylir::HIR::CallOp::verify() {

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
@@ -63,6 +63,7 @@ def PylirHIR_BinOp : PylirHIR_Op<"binOp", []> {
     $lhs $binaryOperation $rhs attr-dict
   }];
 }
+
 def PylirHIR_CallOp : PylirHIR_Op<"call"> {
   let arguments = (ins DynamicType:$callable,
     Variadic<DynamicType>:$arguments,
@@ -93,8 +94,12 @@ def PylirHIR_CallOp : PylirHIR_Op<"call"> {
 
   let builders = [
     OpBuilder<(ins "mlir::Value":$callable,
-                   "llvm::ArrayRef<CallArgument>":$arguments)>
+                   "llvm::ArrayRef<CallArgument>":$arguments)>,
+    OpBuilder<(ins "mlir::Value":$callable,
+                   "mlir::ValueRange":$posArguments)>
   ];
+
+  let skipDefaultBuilders = 1;
 
   let hasVerifier = 1;
 

--- a/test/CodeGenNew/operators.py
+++ b/test/CodeGenNew/operators.py
@@ -1,5 +1,7 @@
 # RUN: pylir %s -Xnew-codegen -emit-pylir -o - -c -S | FileCheck %s
 
+# CHECK: #[[$BOOL:.*]] = #py.globalValue<builtins.bool{{,|>}}
+
 # CHECK-LABEL: func "__main__.bin_ops"
 # CHECK-SAME: %[[A:[[:alnum:]]+]]
 # CHECK-SAME: %[[B:[[:alnum:]]+]]
@@ -36,3 +38,51 @@ def bin_ops(a, b):
 
     # CHECK: binOp %[[A]] __matmul__ %[[B]]
     a @ b
+
+
+# CHECK-LABEL: func "__main__.boolean_ops"
+# CHECK-SAME: %[[A:[[:alnum:]]+]]
+# CHECK-SAME: %[[B:[[:alnum:]]+]]
+def boolean_ops(a, b):
+    # CHECK: %[[A_CALL:.*]] = call %[[A]]()
+    # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
+    # CHECK: %[[TO_BOOL:.*]] = call %[[BOOL]](%[[A_CALL]])
+    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[TO_BOOL]]
+    # CHECK: cf.cond_br %[[I1]], ^[[BB1:.*]], ^[[BB2:.*]](%[[I1]] : i1)
+
+    # CHECK: ^[[BB1]]:
+    # CHECK: %[[B_CALL:.*]] = call %[[B]]()
+    # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
+    # CHECK: %[[TO_BOOL:.*]] = call %[[BOOL]](%[[B_CALL]])
+    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[TO_BOOL]]
+    # CHECK: cf.br ^[[BB2]](%[[I1]] : i1)
+
+    # CHECK: ^[[BB2]](%[[RES:.*]]: i1 loc({{.*}})):
+    # CHECK: py.bool_fromI1 %[[RES]]
+    c = a() and b()
+
+    # CHECK: %[[A_CALL:.*]] = call %[[A]]()
+    # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
+    # CHECK: %[[TO_BOOL:.*]] = call %[[BOOL]](%[[A_CALL]])
+    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[TO_BOOL]]
+    # CHECK: cf.cond_br %[[I1]], ^[[BB4:.*]](%[[I1]] : i1), ^[[BB3:[[:alnum:]]+]]
+
+    # CHECK: ^[[BB3]]:
+    # CHECK: %[[B_CALL:.*]] = call %[[B]]()
+    # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
+    # CHECK: %[[TO_BOOL:.*]] = call %[[BOOL]](%[[B_CALL]])
+    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[TO_BOOL]]
+    # CHECK: cf.br ^[[BB4]](%[[I1]] : i1)
+
+    # CHECK: ^[[BB4]](%[[RES:.*]]: i1 loc({{.*}})):
+    # CHECK: py.bool_fromI1 %[[RES]]
+    c = a() or b()
+
+    # CHECK: %[[A_CALL:.*]] = call %[[A]]()
+    # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
+    # CHECK: %[[TO_BOOL:.*]] = call %[[BOOL]](%[[A_CALL]])
+    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[TO_BOOL]]
+    # CHECK: %[[TRUE:.*]] = arith.constant true
+    # CHECK: %[[NOT:.*]] = arith.xori %[[I1]], %[[TRUE]]
+    # CHECK: py.bool_fromI1 %[[NOT]]
+    c = not a()


### PR DESCRIPTION
Boolean operations are special as they insert calls to the builtin `bool` type to perform the type casts before. This PR implements the boolean operators forcing such a cast which are `and`, `or` and `not`.