### PR TITLE
[CodeGenNew] Implement exception on reading invalid identifier

### DIFF
--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
@@ -96,7 +96,7 @@ def PylirHIR_CallOp : PylirHIR_Op<"call"> {
     OpBuilder<(ins "mlir::Value":$callable,
                    "llvm::ArrayRef<CallArgument>":$arguments)>,
     OpBuilder<(ins "mlir::Value":$callable,
-                   "mlir::ValueRange":$posArguments)>
+                   CArg<"mlir::ValueRange", "std::nullopt">:$posArguments)>
   ];
 
   let skipDefaultBuilders = 1;

--- a/test/CodeGenNew/read-identifier-exceptions.py
+++ b/test/CodeGenNew/read-identifier-exceptions.py
@@ -1,0 +1,34 @@
+# RUN: pylir %s -Xnew-codegen -emit-pylir -o - -S | FileCheck %s
+
+# CHECK-DAG: #[[$NAME_ERROR:.*]] = #py.globalValue<builtins.NameError{{>|,}}
+# CHECK-DAG: #[[$UNBOUND_LOCAL_ERROR:.*]] = #py.globalValue<builtins.UnboundLocalError{{>|,}}
+
+# CHECK-LABEL: init "__main__"
+# CHECK: %[[$GLOBALS:.*]] = py.makeDict ()
+
+# CHECK-LABEL: func "__main__.foo"
+# CHECK-SAME: %[[A:[[:alnum:]]+]]
+def foo(a):
+    # CHECK: %[[UNBOUND:.*]] = py.isUnboundValue %[[A]]
+    # CHECK: cf.cond_br %[[UNBOUND]], ^[[BB1:.*]], ^[[BB2:[[:alnum:]]+]]
+
+    # CHECK: ^[[BB1]]:
+    # CHECK: %[[TYPE:.*]] = py.constant(#[[$UNBOUND_LOCAL_ERROR]])
+    # CHECK: %[[OBJ:.*]] = call %[[TYPE]]()
+    # CHECK: raise %[[OBJ]]
+    return a
+
+
+# CHECK: dict_setItem
+
+# CHECK: %[[STR:.*]] = py.constant(#py.str<"foo">)
+# CHECK: %[[HASH:.*]] = py.str_hash %[[STR]]
+# CHECK: %[[FOO:.*]] = py.dict_tryGetItem %[[$GLOBALS]][%[[STR]] hash(%[[HASH]])]
+# CHECK: %[[UNBOUND:.*]] = py.isUnboundValue %[[FOO]]
+# CHECK: cf.cond_br %[[UNBOUND]], ^[[BB1:.*]], ^[[BB2:[[:alnum:]]+]]
+
+# CHECK: ^[[BB1]]:
+# CHECK: %[[TYPE:.*]] = py.constant(#[[$NAME_ERROR]])
+# CHECK: %[[OBJ:.*]] = call %[[TYPE]]()
+# CHECK: raise %[[OBJ]]
+foo(0)


### PR DESCRIPTION
If either a global or a local are not bound a `NameError` or `UnboundLocalError` have to be raised respectively. `addBlock` was changed and `implementBlock` added to also ensure that any basic blocks created are present in the region in the order that they are implemented.