### PR TITLE
[ci] Don't use a source cache in trunk test

### DIFF
--- a/.github/workflows/llvm-trunk-test.yml
+++ b/.github/workflows/llvm-trunk-test.yml
@@ -53,7 +53,6 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache `
             -DPYLIR_ENABLE_ASSERTIONS=ON `
             -DPYLIR_INCLUDE_LLVM_BUILD=ON `
-            -DCPM_SOURCE_CACHE=~/cpm-cache `
             -S ${{github.workspace}}/Pylir
 
       - name: Build Pylir


### PR DESCRIPTION
Using a source cache disables the use of a shallow clone in CPM which makes cloning repositories and therefore the configure step slower than necessary.