### PR TITLE
[PyHIR] Add exception handling variants

### DIFF
--- a/src/pylir/Optimizer/PylirHIR/IR/CMakeLists.txt
+++ b/src/pylir/Optimizer/PylirHIR/IR/CMakeLists.txt
@@ -17,6 +17,7 @@ add_dependencies(PylirHIRDialect
 target_link_libraries(PylirHIRDialect
   PUBLIC
   PylirPyDialect
+  PylirPyExceptionHandlingInterface
   
   MLIRControlFlowInterfaces
   MLIRIR

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.cpp
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.cpp
@@ -64,8 +64,8 @@ ParseResult pylir::HIR::parseCallArguments(
 }
 
 namespace {
-
-void printCallArguments(OpAsmPrinter& printer, CallOp callOp, ArrayAttr,
+template <class OpT>
+void printCallArguments(OpAsmPrinter& printer, OpT callOp, ArrayAttr,
                         ValueRange, DenseI32ArrayAttr) {
   llvm::interleaveComma(
       CallArgumentRange(callOp), printer.getStream(),
@@ -146,18 +146,6 @@ LogicalResult pylir::HIR::CallOp::verify() {
   }
 
   return success();
-}
-
-CallArgument CallArgumentRange::dereference(CallOp call, std::ptrdiff_t index) {
-  Value value = call.getArguments()[index];
-  if (call.isPosExpansion(index))
-    return CallArgument{value, CallArgument::PosExpansionTag{}};
-  if (call.isMapExpansion(index))
-    return CallArgument{value, CallArgument::MapExpansionTag{}};
-  if (StringAttr keyword = call.getKeyword(index))
-    return CallArgument{value, keyword};
-
-  return CallArgument{value, CallArgument::PositionalTag{}};
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
@@ -18,6 +18,7 @@ include "pylir/Optimizer/PylirHIR/IR/PylirHIRDialect.td"
 include "pylir/Optimizer/PylirHIR/IR/PylirHIRFunctionInterface.td"
 
 include "pylir/Optimizer/PylirPy/IR/PylirPyTypes.td"
+include "pylir/Optimizer/PylirPy/Interfaces/ExceptionHandlingInterface.td"
 
 class PylirHIR_Op<string mneomic, list<Trait> traits = []>
   : Op<PylirHIR_Dialect, mneomic, traits>;
@@ -50,7 +51,8 @@ def PylirHIR_BinaryOperationAttr : I32EnumAttr<"BinaryOperation",
   let cppNamespace = "pylir::HIR";
 }
 
-def PylirHIR_BinOp : PylirHIR_Op<"binOp", []> {
+def PylirHIR_BinOp : PylirHIR_Op<"binOp",
+  [AddableExceptionHandling<"BinExOp">]> {
   let arguments = (ins PylirHIR_BinaryOperationAttr:$binaryOperation,
                        DynamicType:$lhs, DynamicType:$rhs);
   let results = (outs DynamicType:$result);
@@ -64,7 +66,10 @@ def PylirHIR_BinOp : PylirHIR_Op<"binOp", []> {
   }];
 }
 
-def PylirHIR_CallOp : PylirHIR_Op<"call"> {
+def PylirHIR_BinExOp : CreateExceptionHandlingVariant<PylirHIR_BinOp>;
+
+def PylirHIR_CallOp : PylirHIR_Op<"call",
+  [AddableExceptionHandling<"CallExOp", ["Single", "Variadic"]>]> {
   let arguments = (ins DynamicType:$callable,
     Variadic<DynamicType>:$arguments,
     DefaultValuedAttr<StrArrayAttr, "{}">:$keywords,
@@ -139,6 +144,8 @@ def PylirHIR_CallOp : PylirHIR_Op<"call"> {
     }
   }];
 }
+
+def PylirHIR_CallExOp : CreateExceptionHandlingVariant<PylirHIR_CallOp>;
 
 //===----------------------------------------------------------------------===//
 // Functions

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyOps.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyOps.td
@@ -33,61 +33,6 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 class PylirPy_Op<string mneomic, list<Trait> traits = []>
   : Op<PylirPy_Dialect, mneomic, traits>;
 
-/// Creates a new Op as a variant of the existing Op 'op', adding the required
-/// arguments, successors, traits, interface implementations and syntax
-/// automatically.
-/// If 'opName' is empty, its mnemonic is the mnemonic of 'op' with 'Ex' as
-/// suffix.
-class CreateExceptionHandlingVariant<Op op, string opName = "">
-  : PylirPy_Op<!if(!empty(opName), !strconcat(op.opName, "Ex"), opName),
-    !listconcat(!filter(x, op.traits, !not(!isa<AddableExceptionHandling>(x))),
-      [Terminator, AttrSizedOperandSegments,
-        DeclareOpInterfaceMethods<BranchOpInterface>,
-        DeclareOpInterfaceMethods<ExceptionHandlingInterface>])> {
-
-  assert !eq(!size(op.successors), 0), "Op mustn't already have successors";
-
-  let results = op.results;
-  let regions = op.regions;
-  let arguments = !con(op.arguments,
-            (ins Variadic<AnyType>:$normal_dest_operands,
-                 Variadic<AnyType>:$unwind_dest_operands));
-  let successors = (successor AnySuccessor:$happy_path,
-                              AnySuccessor:$exception_path);
-
-  let assemblyFormat = !strconcat(op.assemblyFormat, [{
-    `\n` ` ` ` ` `label` $happy_path ( `(` $normal_dest_operands^ `:` type($normal_dest_operands) `)`)?
-           `unwind` $exception_path ( `(` $unwind_dest_operands^ `:` type($unwind_dest_operands) `)`)?
-  }]);
-
-  let extraClassDeclaration = op.extraClassDeclaration;
-
-  let extraClassDefinition = [{
-
-    //===------------------------------------------------------------------===//
-    // BranchOpInterface implementation
-    //===------------------------------------------------------------------===//
-
-    mlir::SuccessorOperands
-    $cppClass::getSuccessorOperands(unsigned int index) {
-      if (index == 0)
-        return mlir::SuccessorOperands(getNormalDestOperandsMutable());
-      return mlir::SuccessorOperands(1, getUnwindDestOperandsMutable());
-    }
-
-    //===------------------------------------------------------------------===//
-    // ExceptionHandlingInterface implementation
-    //===------------------------------------------------------------------===//
-
-    mlir::Operation*
-    $cppClass::cloneWithoutExceptionHandling(::mlir::OpBuilder& builder)
-    {
-      return ::cloneWithoutExceptionHandlingImpl(builder, *this, "}]
-        # op.opDialect.name # "." # op.opName #[{");
-    }
-  }];
-}
-
 /// Resource declarations in ODS. See PylirPyOps.hpp for definition.
 def GlobalResource : Resource<"::pylir::Py::GlobalResource">;
 def ObjectResource : Resource<"::pylir::Py::ObjectResource">;

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyTraits.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyTraits.td
@@ -52,8 +52,8 @@ class KnownType<string type>
 /// for every ith operand of the op.
 class AddableExceptionHandling<string clazz, list<string> shape = []>
   : ParamNativeOpTrait<"AddableExceptionHandling",
-	"::pylir::Py::" # clazz # !foldl("", shape, acc, var,
-	    !strconcat(acc, ", ::pylir::Py::OperandShape::" # var))> {
+	    clazz # !foldl("", shape, acc, var,
+	      !strconcat(acc, ", ::pylir::Py::OperandShape::" # var))> {
   let cppNamespace = "pylir::Py";
 }
 

--- a/src/pylir/Optimizer/PylirPy/Interfaces/ExceptionHandlingInterface.hpp
+++ b/src/pylir/Optimizer/PylirPy/Interfaces/ExceptionHandlingInterface.hpp
@@ -4,9 +4,66 @@
 
 #pragma once
 
+#include <mlir/IR/Builders.h>
 #include <mlir/IR/OpDefinition.h>
 
 #include "pylir/Optimizer/PylirPy/Interfaces/ExceptionHandlingInterface.h.inc"
+
+namespace pylir::Py {
+/// Helper function called by 'CreateExceptionHandlingVariant' in TableGen to
+/// create the non-exception handling version from 'exceptionOp'.
+template <class T>
+mlir::Operation*
+cloneWithoutExceptionHandlingImpl(mlir::OpBuilder& builder, T exceptionOp,
+                                  llvm::StringRef normalOpName) {
+  using namespace mlir;
+  StringAttr operandSegmentSizeAttrName =
+      exceptionOp.getOperandSegmentSizesAttrName();
+
+  auto operationName = OperationName(normalOpName, builder.getContext());
+
+  // Operands and result types can be copied except that the normal and unwind
+  // operands must be removed. 'CreateExceptionHandlingVariant' guarantees their
+  // position at the back.
+  OperationState state(exceptionOp->getLoc(), operationName);
+  state.addTypes(exceptionOp->getResultTypes());
+  state.addOperands(exceptionOp->getOperands().drop_back(
+      exceptionOp.getNormalDestOperandsMutable().size() +
+      exceptionOp.getUnwindDestOperandsMutable().size()));
+
+  // Go through all the inherent attributes and copy them except
+  // 'AttrSizedOperandSegments'. It must be removed or adjusted depending on
+  // whether 'operationName' requires is.
+  ArrayRef<NamedAttribute> attrs = exceptionOp->getAttrs();
+  SmallVector<NamedAttribute> attributes;
+  attributes.reserve(attrs.size());
+  if (!operationName.hasTrait<OpTrait::AttrSizedOperandSegments>()) {
+    // If the normal version does not have 'AttrSizedOperandSegments' remove it
+    // from the attributes.
+    llvm::copy_if(attrs, std::back_inserter(attributes),
+                  [&](NamedAttribute attribute) {
+                    return attribute.getName() != operandSegmentSizeAttrName;
+                  });
+  } else {
+    llvm::transform(attrs, std::back_inserter(attributes),
+                    [&](NamedAttribute attribute) {
+                      if (attribute.getName() == operandSegmentSizeAttrName) {
+                        // Pop the last two entries. These corresponded to
+                        // '$normal_dest_operands' and '$unwind_dest_operands'
+                        // respectively.
+                        attribute.setValue(builder.getDenseI32ArrayAttr(
+                            cast<DenseI32ArrayAttr>(attribute.getValue())
+                                .asArrayRef()
+                                .drop_back(2)));
+                      }
+                      return attribute;
+                    });
+  }
+
+  state.addAttributes(attributes);
+  return builder.create(state);
+}
+} // namespace pylir::Py
 
 template <>
 struct llvm::PointerLikeTypeTraits<pylir::Py::ExceptionHandlingInterface> {

--- a/src/pylir/Optimizer/PylirPy/Interfaces/ExceptionHandlingInterface.td
+++ b/src/pylir/Optimizer/PylirPy/Interfaces/ExceptionHandlingInterface.td
@@ -6,35 +6,52 @@
 #define PYLIR_PY_INTERFACES_EXCEPTION_HANDLING
 
 include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
+include "pylir/Optimizer/PylirPy/IR/PylirPyTraits.td"
 
 def ExceptionHandlingInterface : OpInterface<"ExceptionHandlingInterface"> {
   let cppNamespace = "::pylir::Py";
 
-  let methods = [
-    InterfaceMethod<[{}], "::mlir::Block*", "getHappyPath", (ins)>,
-    InterfaceMethod<[{}], "::mlir::Block*", "getExceptionPath", (ins)>,
-    InterfaceMethod<[{
+  let description = [{
+    Interface implemented by any operation performing CFG-base exception
+    handling.
+    Every such operation is a terminator that has two successors that are
+    branched to if an exception was thrown or not.
+    The unwind successor additionally reserves the first block argument of the
+    successor block and sets it to the exception object that was thrown. It
+    must be of type `!py.dynamic`.
+  }];
 
+  let methods = [
+    InterfaceMethod<[{
+      Returns the successor used if no exception was thrown.
+    }], "::mlir::Block*", "getHappyPath", (ins)>,
+    InterfaceMethod<[{
+      Returns the successor used if an exception was thrown.
+    }], "::mlir::Block*", "getExceptionPath", (ins)>,
+    InterfaceMethod<[{
+      Returns the operands passed to the block arguments of the block returned
+      by `getHappyPath`.
     }], "::mlir::MutableOperandRange", "getNormalDestOperandsMutable", (ins)>,
     InterfaceMethod<[{
-
+      Returns the operands passed to the block arguments of the block returned
+      by `getExceptionPath`.
     }], "::mlir::MutableOperandRange", "getUnwindDestOperandsMutable", (ins)>,
     InterfaceMethod<[{
-
+      Creates a non-exception handling version copy of this operation using
+      `builder`.
     }],
     "::mlir::Operation*",
     "cloneWithoutExceptionHandling", (ins "::mlir::OpBuilder&":$builder)>,
   ];
 
   let extraSharedClassDeclaration = [{
-    ::mlir::OperandRange getNormalDestOperands()
-    {
+    ::mlir::OperandRange getNormalDestOperands() {
       return static_cast<mlir::OperandRange>(
         this->getNormalDestOperandsMutable());
     }
 
-    ::mlir::OperandRange getUnwindDestOperands()
-    {
+    ::mlir::OperandRange getUnwindDestOperands() {
       return static_cast<mlir::OperandRange>(
         this->getUnwindDestOperandsMutable());
     }
@@ -44,13 +61,84 @@ def ExceptionHandlingInterface : OpInterface<"ExceptionHandlingInterface"> {
 def AddableExceptionHandlingInterface : OpInterface<"AddableExceptionHandlingInterface"> {
   let cppNamespace = "::pylir::Py";
 
+  let description = [{
+    Interface implemented by any operation for which an exception handling
+    version exists. The exception handling version must be identical to the
+    normal version but have the successors and extra operands required by
+    `ExceptionHandlingInterface` added.
+
+    See `CreateExceptionHandlingVariant` in `ExceptionHandlingInterface.td`
+    for a macro to easily create such operations.
+  }];
+
   let methods = [
-    InterfaceMethod<[{}], "::mlir::Operation*", "cloneWithExceptionHandling",
+    InterfaceMethod<[{
+
+    }], "::mlir::Operation*", "cloneWithExceptionHandling",
       (ins "::mlir::OpBuilder&":$builder,
            "::mlir::Block*":$happy_path,
            "::mlir::Block*":$exception_path,
            "::mlir::ValueRange":$unwind_operands)>,
   ];
+}
+
+/// Creates a new Op as a variant of the existing Op 'op', adding the required
+/// arguments, successors, traits, interface implementations and syntax
+/// automatically.
+/// If 'opName' is empty, its mnemonic is the mnemonic of 'op' with 'Ex' as
+/// suffix.
+class CreateExceptionHandlingVariant<Op op, string opName = "">
+  : Op<op.opDialect, !if(!empty(opName), !strconcat(op.opName, "Ex"), opName),
+    !listconcat(!filter(x, op.traits, !not(!isa<AddableExceptionHandling>(x))),
+      [Terminator, AttrSizedOperandSegments,
+        DeclareOpInterfaceMethods<BranchOpInterface>,
+        DeclareOpInterfaceMethods<ExceptionHandlingInterface>])> {
+
+  assert !eq(!size(op.successors), 0), "Op mustn't already have successors";
+
+  let summary = "Exception-handling variant of `" # op.opDialect.name # "."
+    # op.opName # "`";
+  let description = "";
+
+  let results = op.results;
+  let regions = op.regions;
+  let arguments = !con(op.arguments,
+            (ins Variadic<AnyType>:$normal_dest_operands,
+                 Variadic<AnyType>:$unwind_dest_operands));
+  let successors = (successor AnySuccessor:$happy_path,
+                              AnySuccessor:$exception_path);
+
+  let assemblyFormat = !strconcat(op.assemblyFormat, [{
+    `\n` ` ` ` ` `label` $happy_path ( `(` $normal_dest_operands^ `:` type($normal_dest_operands) `)`)?
+           `unwind` $exception_path ( `(` $unwind_dest_operands^ `:` type($unwind_dest_operands) `)`)?
+  }]);
+
+  let extraClassDeclaration = op.extraClassDeclaration;
+
+  let extraClassDefinition = [{
+
+    //===------------------------------------------------------------------===//
+    // BranchOpInterface implementation
+    //===------------------------------------------------------------------===//
+
+    mlir::SuccessorOperands
+    $cppClass::getSuccessorOperands(unsigned index) {
+      if (index == 0)
+        return mlir::SuccessorOperands(getNormalDestOperandsMutable());
+      return mlir::SuccessorOperands(/*exception object*/1,
+              getUnwindDestOperandsMutable());
+    }
+
+    //===------------------------------------------------------------------===//
+    // ExceptionHandlingInterface implementation
+    //===------------------------------------------------------------------===//
+
+    mlir::Operation*
+    $cppClass::cloneWithoutExceptionHandling(::mlir::OpBuilder& builder) {
+      return pylir::Py::cloneWithoutExceptionHandlingImpl(builder, *this, "}]
+        # op.opDialect.name # "." # op.opName #[{");
+    }
+  }];
 }
 
 #endif

--- a/test/Optimizer/PylirHIR/IR/roundtrip.mlir
+++ b/test/Optimizer/PylirHIR/IR/roundtrip.mlir
@@ -46,6 +46,21 @@ pyHIR.globalFunc @call(%0) {
   return %1
 }
 
+// CHECK-LABEL: pyHIR.globalFunc @callEx(
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+pyHIR.globalFunc @callEx(%0) {
+  // CHECK: callEx %[[ARG0]]()
+  // CHECK-NEXT: label ^{{.*}}(%[[ARG0]] : !py.dynamic) unwind ^{{.*}}(%[[ARG0]] : !py.dynamic)
+  %2 = callEx %0()
+    label ^bb1(%0 : !py.dynamic) unwind ^bb2(%0 : !py.dynamic)
+
+^bb1(%arg0 : !py.dynamic):
+  return %0
+
+^bb2(%e : !py.dynamic, %arg1 : !py.dynamic):
+  return %arg1
+}
+
 // CHECK-LABEL: pyHIR.globalFunc @binOp(
 // CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
 // CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
@@ -87,4 +102,20 @@ pyHIR.globalFunc @binOp(%0, %1) {
   // CHECK: binOp %[[ARG0]] __matmul__ %[[ARG1]]
   %19 = binOp %0 __matmul__ %1
   return %2
+}
+
+// CHECK-LABEL: pyHIR.globalFunc @binExOp(
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+pyHIR.globalFunc @binExOp(%0, %1) {
+  // CHECK: binOpEx %[[ARG0]] __eq__ %[[ARG1]]
+  // CHECK-NEXT: label ^[[BB1:.*]](%[[ARG0]] : !py.dynamic) unwind ^[[BB2:.*]](%[[ARG1]] : !py.dynamic)
+  %2 = binOpEx %0 __eq__ %1
+    label ^bb1(%0 : !py.dynamic) unwind ^bb2(%1 : !py.dynamic)
+
+^bb1(%arg0 : !py.dynamic):
+  return %0
+
+^bb2(%e : !py.dynamic, %arg1 : !py.dynamic):
+  return %arg1
 }


### PR DESCRIPTION
This PR adds exception handling versions of `call` and `binOp`, called `callEx` and `binOpEx` respectively. This is implemented via the `CreateExceptionHandlingVariant` TableGen class which has been ported to be usable in `pyHIR`. This also makes it convenient to add more variants in the future.