### PR TITLE
[CodeGenNew] Implement `try` statement

### DIFF
--- a/src/pylir/CodeGenNew/CodeGenNew.cpp
+++ b/src/pylir/CodeGenNew/CodeGenNew.cpp
@@ -230,7 +230,7 @@ class CodeGenNew {
       Block* happyPath = addBlock();
       Operation* newOp = op.cloneWithExceptionHandling(
           m_builder, happyPath, m_exceptionHandler,
-          /*unwind_operands=*/ValueRange());
+          /*unwindOperands=*/ValueRange());
       op.erase();
 
       // Continue on the happy path.

--- a/test/CodeGenNew/finally.py
+++ b/test/CodeGenNew/finally.py
@@ -1,0 +1,125 @@
+# RUN: pylir %s -Xnew-codegen -emit-pylir -o - -S | FileCheck %s
+
+# CHECK-LABEL: func "__main__.foo"
+def foo():
+    global x
+    try:
+        # CHECK: cf.br ^[[ELSE:[[:alnum:]]+]]
+        pass
+    # CHECK: ^[[ELSE]]:
+    finally:
+        # CHECK: %[[THREE:.*]] = py.constant(#py.int<3>)
+        # CHECK: %[[STR:.*]] = py.constant(#py.str<"x">)
+        # CHECK: dict_setItem
+        # CHECK: cf.br ^[[THEN:[[:alnum:]]+]]
+        x = 3
+    # CHECK: ^[[THEN]]:
+    # CHECK: return
+
+
+# CHECK-LABEL: func "__main__.foo2"
+def foo2():
+    global x
+    try:
+        # CHECK-DAG: %[[FIVE:.*]] = py.constant(#py.int<5>)
+        # CHECK-DAG: %[[THREE:.*]] = py.constant(#py.int<3>)
+        # CHECK-DAG: %[[STR:.*]] = py.constant(#py.str<"x">)
+        # CHECK: dict_setItem %{{.*}}[%[[STR]] hash(%{{.*}})] to %[[THREE]]
+        # CHECK-NEXT: return %[[FIVE]]
+        return 5
+    finally:
+        x = 3
+
+
+# CHECK-LABEL: func "__main__.foo3"
+def foo3():
+    global x
+    try:
+        try:
+            # CHECK: cf.br ^[[ELSE:[[:alnum:]]+]]
+            pass
+        finally:
+            # CHECK: ^[[ELSE]]:
+            # CHECK-DAG: %[[FIVE:.*]] = py.constant(#py.int<5>)
+            # CHECK-DAG: %[[STR:.*]] = py.constant(#py.str<"x">)
+            # CHECK: dict_setItem %{{.*}}[%[[STR]] hash(%{{.*}})] to %[[FIVE]]
+            # CHECK: cf.br ^[[THEN:[[:alnum:]]+]]
+            x = 5
+        # CHECK: ^[[THEN]]:
+        # CHECK: cf.br ^[[ELSE:[[:alnum:]]+]]
+        # CHECK: ^[[ELSE]]:
+    finally:
+        # CHECK-DAG: %[[THREE:.*]] = py.constant(#py.int<3>)
+        # CHECK-DAG: %[[STR:.*]] = py.constant(#py.str<"x">)
+        # CHECK: dict_setItem %{{.*}}[%[[STR]] hash(%{{.*}})] to %[[THREE]]
+        # CHECK: cf.br ^[[THEN:[[:alnum:]]+]]
+        x = 3
+    # CHECK: ^[[THEN]]:
+    # CHECK: return
+
+
+# CHECK-LABEL: func "__main__.foo4"
+def foo4():
+    global x
+    try:
+        # CHECK: cf.cond_br %{{.*}}, ^[[BODY:[[:alnum:]]+]], ^[[ELSE:[[:alnum:]]+]]
+        while True:
+            # CHECK: ^[[BODY]]:
+            try:
+                break
+            finally:
+                # CHECK-DAG: %[[FIVE:.*]] = py.constant(#py.int<5>)
+                # CHECK-DAG: %[[STR:.*]] = py.constant(#py.str<"x">)
+                # CHECK: dict_setItem %{{.*}}[%[[STR]] hash(%{{.*}})] to %[[FIVE]]
+                # CHECK: cf.br ^[[THEN:[[:alnum:]]+]]
+                x = 5
+        # CHECK: ^[[ELSE]]:
+        # CHECK: cf.br ^[[THEN]]
+        # CHECK: ^[[THEN]]:
+        # CHECK: cf.br ^[[FINALLY:[[:alnum:]]+]]
+    finally:
+        # CHECK: ^[[FINALLY]]:
+        # CHECK-DAG: %[[THREE:.*]] = py.constant(#py.int<3>)
+        # CHECK-DAG: %[[STR:.*]] = py.constant(#py.str<"x">)
+        # CHECK: dict_setItem %{{.*}}[%[[STR]] hash(%{{.*}})] to %[[THREE]]
+        # CHECK: cf.br ^[[THEN:[[:alnum:]]+]]
+        x = 3
+    # CHECK: ^[[THEN]]:
+    # CHECK: return
+
+
+# CHECK-LABEL: func "__main__.foo5"
+def foo5():
+    global x
+    try:
+        try:
+            # cf.br ^[[FINALLY:[[:alnum:]]+]]
+            pass
+        finally:
+            # ^[[FINALLY]]:
+            # CHECK-DAG: %[[THREE:.*]] = py.constant(#py.int<3>)
+            # CHECK-DAG: %[[STR:.*]] = py.constant(#py.str<"x">)
+            # CHECK: dict_setItem %{{.*}}[%[[STR]] hash(%{{.*}})] to %[[THREE]]
+            # CHECK-NEXT: return
+            return
+    finally:
+        x = 3
+
+
+# CHECK-LABEL: func "__main__.foo6"
+def foo6():
+    global x
+    try:
+        try:
+            # CHECK-DAG: %[[FIVE:.*]] = py.constant(#py.int<5>)
+            # CHECK-DAG: %[[STR:.*]] = py.constant(#py.str<"x">)
+            # CHECK: dict_setItem %{{.*}}[%[[STR]] hash(%{{.*}})] to %[[FIVE]]
+            # CHECK-DAG: %[[THREE:.*]] = py.constant(#py.int<3>)
+            # CHECK-DAG: %[[STR:.*]] = py.constant(#py.str<"x">)
+            # CHECK: dict_setItem %{{.*}}[%[[STR]] hash(%{{.*}})] to %[[THREE]]
+            # CHECK-NEXT: return
+            return
+        finally:
+            x = 5
+    finally:
+        x = 3

--- a/test/CodeGenNew/try.py
+++ b/test/CodeGenNew/try.py
@@ -1,0 +1,46 @@
+# RUN: pylir %s -Xnew-codegen -emit-pylir -o - -S | FileCheck %s
+
+# CHECK: #[[$INSTANCE_OF:.*]] = #py.globalValue<builtins.isinstance{{>|,}}
+
+# CHECK-LABEL: func "__main__.a_call"
+def a_call():
+    try:
+        # CHECK: callEx %{{.*}}()
+        # CHECK-NEXT: label ^[[NORMAL:[[:alnum:]]+]] unwind ^[[EXCEPT:[[:alnum:]]+]]
+        print()
+    # CHECK: ^[[NORMAL]]:
+    # CHECK: cf.br ^[[ELSE:[[:alnum:]]+]]
+
+    # CHECK: ^[[EXCEPT]](%[[EXC:[[:alnum:]]+]]: !py.dynamic {{.*}}):
+    # CHECK: %[[FILTER:.*]] = arith.select
+    # CHECK: %[[INSTANCE_OF:.*]] = py.constant(#[[$INSTANCE_OF]])
+    # CHECK: %[[BOOL:.*]] = call %[[INSTANCE_OF]](%[[EXC]], %[[FILTER]])
+    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[BOOL]]
+    # CHECK: cf.cond_br %[[I1]], ^[[BODY:.*]], ^[[CONTINUE:[[:alnum:]]+]]
+    except StopIteration:
+        # CHECK: ^[[BODY:.*]]
+        # CHECK: cf.br ^[[THEN:[[:alnum:]]+]]
+        pass
+    # CHECK: ^[[CONTINUE]]:
+    except:
+        # CHECK: call
+        # CHECK: cf.br ^[[THEN]]
+        print()
+    # CHECK: ^[[ELSE]]:
+    # CHECK: cf.br ^[[THEN]]
+    # CHECK: ^[[THEN]]:
+    # CHECK: return
+
+
+# CHECK-LABEL: func "__main__.should_rethrow"
+def should_rethrow():
+    try:
+        # CHECK: callEx %{{.*}}()
+        # CHECK-NEXT: unwind ^[[EXCEPT:[[:alnum:]]+]]
+        print()
+    # CHECK: ^[[EXCEPT]](%[[EXC:[[:alnum:]]+]]: !py.dynamic {{.*}}):
+    # CHECK: cf.cond_br %{{.*}}, ^{{.*}}, ^[[CONTINUE:[[:alnum:]]+]]
+    except StopIteration:
+        pass
+    # CHECK: ^[[CONTINUE]]:
+    # CHECK: raise %[[EXC]]


### PR DESCRIPTION
This PR implements codegen support for python's `try` statement, including `finally` blocks. The implementation works by using a custom `create` method which creates exception handling versions of operations within `try` sections. A finally stack keeps track of all `finally` sections and generates more or less of them when leaving the `try` statement, executing `break`, `continue` or `return`.