### PR TITLE
[CodeGenNew] Implement almost all comparison operators

### DIFF
--- a/src/pylir/CodeGenNew/CodeGenNew.cpp
+++ b/src/pylir/CodeGenNew/CodeGenNew.cpp
@@ -878,7 +878,7 @@ private:
 
   Value visitImpl(const Syntax::Comparison& comparison) {
     Value result;
-    PYLIR_ASSERT(comparison.rest.size() >= 1 &&
+    PYLIR_ASSERT(!comparison.rest.empty() &&
                  "comparison must have at least one operator");
 
     Value current = visit(comparison.first);

--- a/test/CodeGenNew/comparison.py
+++ b/test/CodeGenNew/comparison.py
@@ -1,0 +1,68 @@
+# RUN: pylir %s -Xnew-codegen -emit-pylir -o - -c -S | FileCheck %s
+
+# CHECK: #[[$BOOL:.*]] = #py.globalValue<builtins.bool{{>|,}}
+
+# CHECK-LABEL: func "__main__.binary_ops"
+# CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+# CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+def binary_ops(a, b):
+    # CHECK: binOp %[[ARG0]] __lt__ %[[ARG1]]
+    a < b
+
+    # CHECK: binOp %[[ARG0]] __le__ %[[ARG1]]
+    a <= b
+
+    # CHECK: binOp %[[ARG0]] __gt__ %[[ARG1]]
+    a > b
+
+    # CHECK: binOp %[[ARG0]] __ge__ %[[ARG1]]
+    a >= b
+
+    # CHECK: binOp %[[ARG0]] __eq__ %[[ARG1]]
+    a == b
+
+    # CHECK: binOp %[[ARG0]] __ne__ %[[ARG1]]
+    a != b
+
+    # CHECK: %[[IS:.*]] = py.is %[[ARG0]], %[[ARG1]]
+    # CHECK: py.bool_fromI1 %[[IS]]
+    a is b
+
+
+# CHECK-LABEL: func "__main__.chaining"
+# CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+# CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+# CHECK-SAME: %[[ARG2:[[:alnum:]]+]]
+def chaining(a, b, c):
+    # CHECK: %[[CARG0:.*]] = call %[[ARG0]]
+    # CHECK: %[[CARG1:.*]] = call %[[ARG1]]
+    # CHECK: %[[BIN1:.*]] = binOp %[[CARG0]] __lt__ %[[CARG1]]
+    # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
+    # CHECK: %[[CALL:.*]] = call %[[BOOL]](%[[BIN1]])
+    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[CALL]]
+    # CHECK: cf.cond_br %[[I1]], ^[[BB5:.*]], ^[[BB8:.*]](%[[BIN1]] : !py.dynamic)
+
+    # CHECK: ^[[BB5]]:
+    # CHECK: %[[CARG2:.*]] = call %[[ARG2]]
+    # CHECK: %[[BIN2:.*]] = binOp %[[CARG1]] __lt__ %[[CARG2]]
+    # CHECK: cf.br ^[[BB8]](%[[BIN2]] : !py.dynamic)
+
+    # CHECK: ^[[BB8]](%[[VALUE:.*]]: !py.dynamic loc({{.*}})):
+    # CHECK: return %[[VALUE]]
+    return a() < b() < c()
+
+
+# CHECK-LABEL: func "__main__.invert"
+# CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+# CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+def invert(a, b):
+    # CHECK: %[[IS:.*]] = py.is %[[ARG0]], %[[ARG1]]
+    # CHECK: %[[B:.*]] = py.bool_fromI1 %[[IS]]
+    # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
+    # CHECK: %[[CALL:.*]] = call %[[BOOL]](%[[B]])
+    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[CALL]]
+    # CHECK: %[[TRUE:.*]] = arith.constant true
+    # CHECK: %[[INV:.*]] = arith.xori %[[I1]], %[[TRUE]]
+    # CHECK: %[[B:.*]] = py.bool_fromI1 %[[INV]]
+    # CHECK: return %[[B]]
+    return a is not b


### PR DESCRIPTION
Comparison operators are not just binary operators like in most languages but can be chained which implicitly acts like `and` expressions of comparison operators. Additionally, `is` and `in` are implemented as comparison operators in python that can also be negated using `not`. This PR implements all of them except `in` as there isn't yet a lowering in `pyHIR`.