### PR TITLE
[CodeGenNew] Implement simple tuple and list constructs

### DIFF
--- a/test/CodeGenNew/list.py
+++ b/test/CodeGenNew/list.py
@@ -1,0 +1,28 @@
+# RUN: pylir %s -Xnew-codegen -emit-pylir -o - -S | FileCheck %s
+
+# CHECK-LABEL: init "__main__"
+
+[]
+
+# CHECK: makeList
+# CHECK-SAME: ()
+
+[7]
+
+# CHECK: %[[OP1:.*]] = py.constant(#py.int<7>)
+# CHECK: makeList
+# CHECK-SAME: %[[OP1]]
+
+[5, 3]
+
+# CHECK: %[[OP1:.*]] = py.constant(#py.int<5>)
+# CHECK: %[[OP2:.*]] = py.constant(#py.int<3>)
+# CHECK: makeList
+# CHECK-SAME: %[[OP1]], %[[OP2]]
+
+[*(), 3]
+
+# CHECK: %[[OP1:.*]] = py.makeTuple ()
+# CHECK: %[[OP2:.*]] = py.constant(#py.int<3>)
+# CHECK: makeList
+# CHECK-SAME: *%[[OP1]], %[[OP2]]

--- a/test/CodeGenNew/tuple.py
+++ b/test/CodeGenNew/tuple.py
@@ -1,0 +1,27 @@
+# RUN: pylir %s -Xnew-codegen -emit-pylir -o - -S | FileCheck %s
+
+# CHECK-LABEL: init "__main__"
+
+()
+
+# CHECK: makeTuple ()
+
+(7,)
+
+# CHECK: %[[OP1:.*]] = py.constant(#py.int<7>)
+# CHECK: makeTuple
+# CHECK-SAME: %[[OP1]]
+
+(5, 3)
+
+# CHECK: %[[OP1:.*]] = py.constant(#py.int<5>)
+# CHECK: %[[OP2:.*]] = py.constant(#py.int<3>)
+# CHECK: makeTuple
+# CHECK-SAME: %[[OP1]], %[[OP2]]
+
+(*(), 3)
+
+# CHECK: %[[OP1:.*]] = py.makeTuple ()
+# CHECK: %[[OP2:.*]] = py.constant(#py.int<3>)
+# CHECK: makeTuple
+# CHECK-SAME: *%[[OP1]], %[[OP2]]


### PR DESCRIPTION
This PR implements the most common syntax to create tuples and lists which nicely map to `py.makeTuple` and `py.makeList` respectively. Left as a TODO is the implementation of comprehensions for list construction. Tuples can only be constructed using the item syntax.