### PR TITLE
[Parser] Move `const_export` verification to semantic analysis

### DIFF
--- a/src/pylir/CodeGen/CodeGen.hpp
+++ b/src/pylir/CodeGen/CodeGen.hpp
@@ -192,19 +192,11 @@ class CodeGen {
 
   std::vector<ModuleImport> importModules(llvm::ArrayRef<ModuleSpec> specs);
 
-  struct Intrinsic {
-    std::string name;
-    std::vector<IdentifierToken> identifiers;
-  };
-
-  std::optional<Intrinsic>
-  checkForIntrinsic(const Syntax::Expression& expression);
-
-  mlir::Value callIntrinsic(Intrinsic&& intrinsic,
+  mlir::Value callIntrinsic(Syntax::Intrinsic&& intrinsic,
                             llvm::ArrayRef<Syntax::Argument> arguments,
                             const Syntax::Call& call);
 
-  mlir::Value intrinsicConstant(Intrinsic&& intrinsic);
+  mlir::Value intrinsicConstant(Syntax::Intrinsic&& intrinsic);
 
   std::optional<bool>
   checkDecoratorIntrinsics(llvm::ArrayRef<Syntax::Decorator> decorators,
@@ -313,7 +305,7 @@ class CodeGen {
                             llvm::StringRef funcName,
                             const Syntax::Scope& scope,
                             llvm::function_ref<void()> emitFunctionBody,
-                            const BaseToken& location);
+                            bool isConst, bool isExported);
 
   template <class T,
             std::enable_if_t<IsAbstractVariantConcrete<T>{}>* = nullptr>

--- a/src/pylir/Diagnostics/DiagnosticMessages.hpp
+++ b/src/pylir/Diagnostics/DiagnosticMessages.hpp
@@ -223,4 +223,12 @@ constexpr auto CONST_EXPORT_OBJECT_MUST_BE_DEFINED_IN_GLOBAL_SCOPE = FMT_STRING(
 constexpr auto DECORATORS_ON_A_CONST_EXPORT_OBJECT_ARE_NOT_SUPPORTED =
     FMT_STRING("Decorators on a 'const_export' object are not supported");
 
+constexpr auto EXPECTED_CONSTANT_EXPRESSION =
+    FMT_STRING("expected constant expression");
+
+constexpr auto
+    ONLY_POSITIONAL_ARGUMENTS_ALLOWED_IN_CONST_EXPORT_CLASS_INHERITANCE_LIST =
+        FMT_STRING("only positional arguments allowed in 'const_export' class "
+                   "inheritance list");
+
 } // namespace pylir::Diag

--- a/src/pylir/Parser/SemanticAnalysis.hpp
+++ b/src/pylir/Parser/SemanticAnalysis.hpp
@@ -22,6 +22,7 @@ class SemanticAnalysis : public Syntax::Visitor<SemanticAnalysis> {
   ScopeOwner m_currentScopeOwner;
   bool m_inFunc = false;
   bool m_inLoop = false;
+  bool m_inConstClass = false;
 
   [[nodiscard]] Syntax::Scope* getCurrentScope() const {
     if (!m_currentScopeOwner)
@@ -42,6 +43,18 @@ class SemanticAnalysis : public Syntax::Visitor<SemanticAnalysis> {
   void addToNamespace(pylir::Syntax::Target& target);
 
   void finishNamespace(ScopeOwner owner);
+
+  /// Checks whether 'decorators' contains intrinsics such as 'const_export'
+  /// and verifies extra constraints given by these intrinsics. 'nameLocation'
+  /// is used for any diagnostic and 'isExported' and 'isConst' are set
+  /// accordingly.
+  void verifyCommonConstDecorator(llvm::ArrayRef<Syntax::Decorator> decorators,
+                                  BaseToken nameLocation, bool& isExported,
+                                  bool& isConst);
+
+  /// Checks whether 'expression' is a constant expression, issuing a diagnostic
+  /// if not.
+  void verifyIsConstant(Syntax::Expression& expression);
 
 public:
   explicit SemanticAnalysis(Diag::DiagnosticsDocManager& manager)

--- a/src/pylir/Parser/Syntax.cpp
+++ b/src/pylir/Parser/Syntax.cpp
@@ -4,8 +4,40 @@
 
 #include "Syntax.hpp"
 
+#include <llvm/ADT/StringExtras.h>
+
+using namespace pylir;
 using namespace pylir::Diag;
 using namespace pylir::Syntax;
+
+std::optional<Intrinsic>
+Syntax::checkForIntrinsic(const Expression& expression) {
+  // Collect all the chained attribute references and their identifiers up until
+  // the atom.
+  llvm::SmallVector<IdentifierToken> identifiers;
+  const Expression* current = &expression;
+  while (const auto* ref = current->dyn_cast<AttributeRef>()) {
+    identifiers.push_back(ref->identifier);
+    current = ref->object.get();
+  }
+
+  // If its not an atom or not an identifier its not an intrinsic.
+  const auto* atom = current->dyn_cast<Atom>();
+  if (!atom || atom->token.getTokenType() != TokenType::Identifier)
+    return std::nullopt;
+
+  identifiers.emplace_back(atom->token);
+  std::reverse(identifiers.begin(), identifiers.end());
+  // Intrinsics always start with 'pylir' and 'intr'.
+  if (identifiers.size() < 2 || identifiers[0].getValue() != "pylir" ||
+      identifiers[1].getValue() != "intr")
+    return std::nullopt;
+
+  std::string name = llvm::join(
+      llvm::map_range(identifiers, std::mem_fn(&IdentifierToken::getValue)),
+      ".");
+  return Intrinsic{std::move(name), std::move(identifiers)};
+}
 
 std::pair<std::size_t, std::size_t> LocationProvider<TupleConstruct>::getRange(
     const TupleConstruct& value) noexcept {

--- a/test/CodeGen/intrinsics-errors.py
+++ b/test/CodeGen/intrinsics-errors.py
@@ -26,25 +26,3 @@ pylir.intr.int.cmp(args, d, args)
 # expected-error@below {{invalid enum value 'lol' for enum 'IntCmpKind' argument}}
 pylir.intr.int.cmp('lol', d, args)
 # expected-note@above {{valid values are: eq, ne, lt, le, gt, ge}}
-
-
-def foo():
-    @pylir.intr.const_export
-    # expected-error@below {{'pylir.intr.const_export' object must be defined in global scope}}
-    class Bar:
-        pass
-
-
-@pylir.intr.const_export
-# expected-error@below {{Decorators on a 'const_export' object are not supported}}
-@foo
-class Bar:
-    pass
-
-
-@pylir.intr.const_export
-class Bar:
-    # expected-error@below {{Decorators on a 'const_export' object are not supported}}
-    @foo
-    def bar(self):
-        pass

--- a/test/Parser/intrinsics-errors.py
+++ b/test/Parser/intrinsics-errors.py
@@ -1,0 +1,48 @@
+# RUN: pylir %s -fsyntax-only -verify
+
+def foo():
+    @pylir.intr.const_export
+    # expected-error@below {{'pylir.intr.const_export' object must be defined in global scope}}
+    class Bar:
+        pass
+
+
+@pylir.intr.const_export
+# expected-error@below {{Decorators on a 'const_export' object are not supported}}
+@foo
+class Bar:
+    pass
+
+
+@pylir.intr.const_export
+class Bar:
+    # expected-error@below {{Decorators on a 'const_export' object are not supported}}
+    @foo
+    def bar(self):
+        pass
+
+
+@pylir.intr.const_export
+# expected-error@below {{expected constant expression}}
+def foo(a=[]):
+    pass
+
+
+@pylir.intr.const_export
+# expected-error@+2 {{only positional arguments allowed in 'const_export' class inheritance list}}
+# expected-error@below {{expected constant expression}}
+class Foo(a=[]):
+    pass
+
+
+@pylir.intr.const_export
+# expected-error@+2 {{only positional arguments allowed in 'const_export' class inheritance list}}
+# expected-error@below {{expected constant expression}}
+class Foo(*[]):
+    pass
+
+
+@pylir.intr.const_export
+# expected-error@below {{expected constant expression}}
+class Foo([]):
+    pass


### PR DESCRIPTION
The verification of these and other intrinsics has so far been done in `CodeGen`. This was a mistake as ideally `CodeGen` should produce only code and should be able to rely on any invariants guaranteed by the frontend. This change further allows consistent handling of these intrinsics regardless of any backend details.