### PR TITLE
[CodeGenNew] Implement `const_export` of functions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -95,7 +95,6 @@ Checks: >
   cppcoreguidelines-pro-type-cstyle-cast,
   cppcoreguidelines-pro-type-member-init,
   cppcoreguidelines-pro-type-static-cast-downcast,
-  cppcoreguidelines-special-member-functions,
   cppcoreguidelines-virtual-class-destructor,
   google-default-arguments,
   google-runtime-operator,

--- a/test/CodeGenNew/const-export-function.py
+++ b/test/CodeGenNew/const-export-function.py
@@ -1,0 +1,20 @@
+# RUN: pylir %s -Xnew-codegen -emit-pylir -o - -S | FileCheck %s
+
+# CHECK: #[[$MAIN_FOO:.*]] = #py.globalValue<__main__.foo,
+# CHECK-SAME: const
+# CHECK-SAME: initializer = #py.function<@[[$MAIN_FOO_SYMBOL:[0-9a-zA-Z_.]+]]
+# CHECK-SAME: qual_name = #py.str<"__main__.foo">
+# CHECK-SAME: defaults = #py.tuple<(#py.int<3>)>
+# CHECK-SAME: kw_defaults = #py.dict<{#py.str<"b"> to #py.globalValue<builtins.None>}>
+
+# CHECK-LABEL: init "__main__"
+# CHECK: %[[FOO:.*]] = py.constant(#[[$MAIN_FOO]])
+# CHECK: py.dict_setItem %{{.*}}[{{.*}}] to %[[FOO]]
+@pylir.intr.const_export
+def foo(a=3, *, b=None):
+    return a + b
+
+# CHECK: globalFunc @[[$MAIN_FOO_SYMBOL]](%[[ARG0:.*]] "a" has_default, %[[ARG1:.*]] only "b" has_default) {
+# CHECK: binOp %[[ARG0]] __add__ %[[ARG1]]
+
+# CHECK: py.external @__main__.foo, #[[$MAIN_FOO]]


### PR DESCRIPTION
A function definition marked with `const_export` must be lowered to a `#py.globalValue` and a corresponding `pyHIR.globalFunc`.