### PR TITLE
[Parser] Verify body of `const_export` classes

### DIFF
--- a/src/pylir/Diagnostics/DiagnosticMessages.hpp
+++ b/src/pylir/Diagnostics/DiagnosticMessages.hpp
@@ -231,4 +231,9 @@ constexpr auto
         FMT_STRING("only positional arguments allowed in 'const_export' class "
                    "inheritance list");
 
+constexpr auto
+    ONLY_SINGLE_ASSIGNMENTS_AND_FUNCTION_DEFINITIONS_ALLOWED_IN_CONST_EXPORT_CLASS =
+        FMT_STRING("only single assignments and function definitions allowed "
+                   "in 'const_export' class");
+
 } // namespace pylir::Diag

--- a/src/pylir/Parser/Syntax.hpp
+++ b/src/pylir/Parser/Syntax.hpp
@@ -446,8 +446,9 @@ struct ClassDef : CompoundStmt::Base<ClassDef> {
 };
 
 struct Suite {
-  std::vector<std::variant<IntrVarPtr<SimpleStmt>, IntrVarPtr<CompoundStmt>>>
-      statements;
+  using Variant =
+      std::variant<IntrVarPtr<SimpleStmt>, IntrVarPtr<CompoundStmt>>;
+  std::vector<Variant> statements;
 };
 
 struct FileInput {

--- a/test/Parser/intrinsics-errors.py
+++ b/test/Parser/intrinsics-errors.py
@@ -46,3 +46,25 @@ class Foo(*[]):
 # expected-error@below {{expected constant expression}}
 class Foo([]):
     pass
+
+
+@pylir.intr.const_export
+class Foo:
+    # expected-error@below {{only single assignments and function definitions allowed in 'const_export' class}}
+    a, b = 1, 2
+
+    # expected-error@below {{only single assignments and function definitions allowed in 'const_export' class}}
+    a += 3
+
+    # expected-error@below {{only single assignments and function definitions allowed in 'const_export' class}}
+    if True:
+        pass
+
+    # expected-error@below {{only single assignments and function definitions allowed in 'const_export' class}}
+    a + b
+
+    # expected-error@below {{expected constant expression}}
+    a = b
+
+    valid = ("a", "b")
+    valid = pylir.intr.type.__slots__


### PR DESCRIPTION
Class bodies in python are normal code used to construct the namespace. This is too permissive for the purpose of the `const_export` macro which tries to create constant instances of the type.

Classes annotated with the intrinsic must therefore only contain very few allowed statements and verified by the semantic analysis that this is the case. This most importantly serves as an invariant for later `CodeGen` phases.