### PR TITLE
[CodeGenNew] Make the global dictionary global

### DIFF
--- a/src/pylir/CodeGenNew/CodeGenNew.cpp
+++ b/src/pylir/CodeGenNew/CodeGenNew.cpp
@@ -496,7 +496,11 @@ public:
     init.getBody().push_back(entryBlock);
     m_builder.setInsertionPointToEnd(entryBlock);
 
-    m_globalDictionary = create<Py::MakeDictOp>();
+    auto dictionary =
+        m_builder.getAttr<Py::GlobalValueAttr>(m_qualifiers + "$dict");
+    dictionary.setInitializer(m_builder.getAttr<Py::DictAttr>());
+
+    m_globalDictionary = create<Py::ConstantOp>(dictionary);
 
     visit(fileInput.input);
 

--- a/test/CodeGenNew/builtins-namespace.py
+++ b/test/CodeGenNew/builtins-namespace.py
@@ -2,7 +2,7 @@
 
 # CHECK: #[[$BASE_EXCEPTION:.*]] = #py.globalValue<builtins.BaseException{{(,|>)}}
 
-# CHECK: %[[GLOBALS:.*]] = py.makeDict
+# CHECK: %[[GLOBALS:.*]] = py.constant(#__main__$dict)
 
 # CHECK: %[[STR:.*]] = py.constant(#py.str<"BaseException">)
 # CHECK: %[[HASH:.*]] = py.str_hash %[[STR]]

--- a/test/CodeGenNew/call.py
+++ b/test/CodeGenNew/call.py
@@ -1,7 +1,7 @@
 # RUN: pylir %s -Xnew-codegen -emit-pylir -o - -c -S | FileCheck %s
 
 # CHECK-LABEL: init "__main__"
-# CHECK: %[[GLOBALS:.*]] = py.makeDict
+# CHECK: %[[GLOBALS:.*]] = py.constant(#__main__$dict)
 
 def x(*args, **kwargs):
     pass

--- a/test/CodeGenNew/intrinsics.py
+++ b/test/CodeGenNew/intrinsics.py
@@ -1,7 +1,7 @@
 # RUN: pylir %s -Xnew-codegen -emit-pylir -o - -S | FileCheck %s
 
 # CHECK-LABEL: init "__main__"
-# CHECK: %[[DICT:.*]] = py.makeDict ()
+# CHECK: %[[DICT:.*]] = py.constant(#__main__$dict)
 
 def foo():
     pass

--- a/test/CodeGenNew/locals-and-globals.py
+++ b/test/CodeGenNew/locals-and-globals.py
@@ -1,7 +1,7 @@
 # RUN: pylir %s -Xnew-codegen -emit-pylir -o - -S | FileCheck %s
 
 # CHECK-LABEL: init "__main__"
-# CHECK: %[[GLOBALS:.*]] = py.makeDict
+# CHECK: %[[GLOBALS:.*]] = py.constant(#__main__$dict)
 # CHECK: %[[TEST1:.*]] = func "__main__.test1"
 def test1():
     # CHECK: %[[NESTED:.*]] = func "__main__.test1.<locals>.nested"

--- a/test/CodeGenNew/read-identifier-exceptions.py
+++ b/test/CodeGenNew/read-identifier-exceptions.py
@@ -4,7 +4,7 @@
 # CHECK-DAG: #[[$UNBOUND_LOCAL_ERROR:.*]] = #py.globalValue<builtins.UnboundLocalError{{>|,}}
 
 # CHECK-LABEL: init "__main__"
-# CHECK: %[[$GLOBALS:.*]] = py.makeDict ()
+# CHECK: %[[$GLOBALS:.*]] = py.constant(#__main__$dict)
 
 # CHECK-LABEL: func "__main__.foo"
 # CHECK-SAME: %[[A:[[:alnum:]]+]]


### PR DESCRIPTION
Having it local would otherwise needlessly require all functions to capture the global dictionary as a non-local, which is undesirable. Having it global is potentially better for optimization as well.