### PR TITLE
[PyHIR] Add `binAssignOp`

### DIFF
--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
@@ -68,6 +68,47 @@ def PylirHIR_BinOp : PylirHIR_Op<"binOp",
 
 def PylirHIR_BinExOp : CreateExceptionHandlingVariant<PylirHIR_BinOp>;
 
+// Enums values kept in sync with 'PylirHIR_BinaryOperationAttr'.
+def PylirHIR_BinaryAssignmentAttr : I32EnumAttr<"BinaryAssignment",
+  "Binary assignment operations in python", [
+  I32EnumAttrCase<"Add", 6, "__iadd__">,
+  I32EnumAttrCase<"Sub", 7, "__isub__">,
+  I32EnumAttrCase<"Or", 8, "__ior__">,
+  I32EnumAttrCase<"Xor", 9, "__ixor__">,
+  I32EnumAttrCase<"And", 10, "__iand__">,
+  I32EnumAttrCase<"LShift", 11, "__ilshift__">,
+  I32EnumAttrCase<"RShift", 12, "__irshift__">,
+  I32EnumAttrCase<"Mul", 13, "__imul__">,
+  I32EnumAttrCase<"Div", 14, "__idiv__">,
+  I32EnumAttrCase<"FloorDiv", 15, "__ifloordiv__">,
+  I32EnumAttrCase<"Mod", 16, "__imod__">,
+  I32EnumAttrCase<"MatMul", 17, "__imatmul__">,
+]> {
+  let cppNamespace = "pylir::HIR";
+}
+
+def PylirHIR_BinAssignOp : PylirHIR_Op<"binAssignOp",
+  [AddableExceptionHandling<"BinAssignExOp">]> {
+  let arguments = (ins PylirHIR_BinaryAssignmentAttr:$binaryAssignment,
+                       DynamicType:$lhs, DynamicType:$rhs);
+  let results = (outs DynamicType:$result);
+
+  let description = [{
+    Operation representing compound assignment operators in python.
+  }];
+
+  let assemblyFormat = [{
+    $lhs $binaryAssignment $rhs attr-dict
+  }];
+}
+
+def PylirHIR_BinAssignExOp
+  : CreateExceptionHandlingVariant<PylirHIR_BinAssignOp>;
+
+//===----------------------------------------------------------------------===//
+// Call Operations
+//===----------------------------------------------------------------------===//
+
 def PylirHIR_CallOp : PylirHIR_Op<"call",
   [AddableExceptionHandling<"CallExOp", ["Single", "Variadic"]>]> {
   let arguments = (ins DynamicType:$callable,

--- a/test/Optimizer/PylirHIR/IR/roundtrip.mlir
+++ b/test/Optimizer/PylirHIR/IR/roundtrip.mlir
@@ -119,3 +119,34 @@ pyHIR.globalFunc @binExOp(%0, %1) {
 ^bb2(%e : !py.dynamic, %arg1 : !py.dynamic):
   return %arg1
 }
+
+// CHECK-LABEL: pyHIR.globalFunc @binAssignOp(
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+pyHIR.globalFunc @binAssignOp(%0, %1) {
+  // CHECK: binAssignOp %[[ARG0]] __iadd__ %[[ARG1]]
+  %8 = binAssignOp %0 __iadd__ %1
+  // CHECK: binAssignOp %[[ARG0]] __isub__ %[[ARG1]]
+  %9 = binAssignOp %0 __isub__ %1
+  // CHECK: binAssignOp %[[ARG0]] __ior__ %[[ARG1]]
+  %10 = binAssignOp %0 __ior__ %1
+  // CHECK: binAssignOp %[[ARG0]] __ixor__ %[[ARG1]]
+  %11 = binAssignOp %0 __ixor__ %1
+  // CHECK: binAssignOp %[[ARG0]] __iand__ %[[ARG1]]
+  %12 = binAssignOp %0 __iand__ %1
+  // CHECK: binAssignOp %[[ARG0]] __ilshift__ %[[ARG1]]
+  %13 = binAssignOp %0 __ilshift__ %1
+  // CHECK: binAssignOp %[[ARG0]] __irshift__ %[[ARG1]]
+  %14 = binAssignOp %0 __irshift__ %1
+  // CHECK: binAssignOp %[[ARG0]] __imul__ %[[ARG1]]
+  %15 = binAssignOp %0 __imul__ %1
+  // CHECK: binAssignOp %[[ARG0]] __idiv__ %[[ARG1]]
+  %16 = binAssignOp %0 __idiv__ %1
+  // CHECK: binAssignOp %[[ARG0]] __ifloordiv__ %[[ARG1]]
+  %17 = binAssignOp %0 __ifloordiv__ %1
+  // CHECK: binAssignOp %[[ARG0]] __imod__ %[[ARG1]]
+  %18 = binAssignOp %0 __imod__ %1
+  // CHECK: binAssignOp %[[ARG0]] __imatmul__ %[[ARG1]]
+  %19 = binAssignOp %0 __imatmul__ %1
+  return %19
+}


### PR DESCRIPTION
This op mirrors the various compound assignment operations in Python (e.g. `+=`) and the associated lookup procedures.