### PR TITLE
[CodeGenNew] Implement simple `raise`

### DIFF
--- a/test/CodeGenNew/raise.py
+++ b/test/CodeGenNew/raise.py
@@ -1,0 +1,20 @@
+# RUN: pylir %s -Xnew-codegen -emit-pylir -o - -c -S | FileCheck %s
+
+# CHECK: #[[$IS_INSTANCE:.*]] = #py.globalValue<builtins.isinstance{{>|,}}
+# CHECK: #[[$TYPE:.*]] = #py.globalValue<builtins.type{{>|,}}
+
+# CHECK-LABEL: init "__main__"
+# CHECK: %[[TYPE_ERROR:.*]] = arith.select
+# CHECK: %[[IS_INSTANCE:.*]] = py.constant(#[[$IS_INSTANCE]])
+# CHECK: %[[TYPE:.*]] = py.constant(#[[$TYPE]])
+# CHECK: %[[CHECK:.*]] = call %[[IS_INSTANCE]](%[[TYPE_ERROR]], %[[TYPE]])
+# CHECK: %[[I1:.*]] = py.bool_toI1 %[[CHECK]]
+# CHECK: cf.cond_br %[[I1]], ^[[BB1:.*]], ^[[BB2:.*]](%[[TYPE_ERROR]] : !py.dynamic)
+
+# CHECK: ^[[BB1]]:
+# CHECK: %[[EXC:.*]] = call %[[TYPE_ERROR]]()
+# CHECK: cf.br ^[[BB2]](%[[EXC]] : !py.dynamic)
+
+# CHECK: ^[[BB2]](%[[EXC:.*]]: !py.dynamic loc({{.*}})):
+# CHECK: py.raise %[[EXC]]
+raise TypeError


### PR DESCRIPTION
This PR implements the most common form of `raise` with a single expression. Depending on whether the expression evaluates to a type object or not an instance of an exception is constructed and subsequently raised via `py.raise`. Implementing just `raise` as well as attaching the cause and context are left as future TODOs.