### PR TITLE
[Parser] add intrinsic AST node

### DIFF
--- a/src/pylir/CodeGen/CodeGen.hpp
+++ b/src/pylir/CodeGen/CodeGen.hpp
@@ -192,11 +192,11 @@ class CodeGen {
 
   std::vector<ModuleImport> importModules(llvm::ArrayRef<ModuleSpec> specs);
 
-  mlir::Value callIntrinsic(Syntax::Intrinsic&& intrinsic,
+  mlir::Value callIntrinsic(const Syntax::Intrinsic& intrinsic,
                             llvm::ArrayRef<Syntax::Argument> arguments,
                             const Syntax::Call& call);
 
-  mlir::Value intrinsicConstant(Syntax::Intrinsic&& intrinsic);
+  mlir::Value intrinsicConstant(const Syntax::Intrinsic& intrinsic);
 
   std::optional<bool>
   checkDecoratorIntrinsics(llvm::ArrayRef<Syntax::Decorator> decorators,
@@ -509,6 +509,8 @@ public:
   mlir::Value visit(const Syntax::UnaryOp& unaryOp);
 
   mlir::Value visit(const Syntax::AttributeRef& attributeRef);
+
+  mlir::Value visit(const Syntax::Intrinsic& intrinsic);
 
   mlir::Value visit(const Syntax::Slice& slice);
 

--- a/src/pylir/CodeGenNew/CodeGenNew.cpp
+++ b/src/pylir/CodeGenNew/CodeGenNew.cpp
@@ -1313,9 +1313,13 @@ private:
     PYLIR_UNREACHABLE;
   }
 
+  Value visitImpl([[maybe_unused]] const Syntax::Intrinsic& intrinsic) {
+    // TODO:
+    PYLIR_UNREACHABLE;
+  }
+
   Value visitImpl(const Syntax::Call& call) {
-    if (std::optional<Syntax::Intrinsic> intr =
-            checkForIntrinsic(*call.expression)) {
+    if (auto* intr = call.expression->dyn_cast<Syntax::Intrinsic>()) {
       const auto* args =
           std::get_if<std::vector<Syntax::Argument>>(&call.variant);
       if (!args) {
@@ -1361,7 +1365,7 @@ private:
 
   /// Performs the associated action for calling 'intrinsic' using 'arguments'.
   /// Returns a null value if an error occurred.
-  Value callIntrinsic(Syntax::Intrinsic&& intrinsic,
+  Value callIntrinsic(const Syntax::Intrinsic& intrinsic,
                       ArrayRef<Syntax::Argument> arguments,
                       const Syntax::Call& call) {
     std::string_view intrName = intrinsic.name;

--- a/src/pylir/Parser/Dumper.cpp
+++ b/src/pylir/Parser/Dumper.cpp
@@ -687,6 +687,10 @@ std::string pylir::Dumper::dump(const Syntax::TupleConstruct& tupleConstruct) {
   return builder.emit();
 }
 
+std::string pylir::Dumper::dump(const Syntax::Intrinsic& intrinsic) {
+  return createBuilder("intrinsic {}", intrinsic.name).emit();
+}
+
 std::string pylir::Dumper::dump(const Syntax::DictDisplay& dictDisplay) {
   auto builder = createBuilder("dict display");
   pylir::match(

--- a/src/pylir/Parser/Dumper.hpp
+++ b/src/pylir/Parser/Dumper.hpp
@@ -141,6 +141,8 @@ public:
 
   std::string dump(const Syntax::TupleConstruct& tupleConstruct);
 
+  std::string dump(const Syntax::Intrinsic& intrinsic);
+
   std::string dump(const Syntax::CompIf& compIf);
 
   std::string dump(const Syntax::CompFor& compFor);

--- a/src/pylir/Parser/ParserStatements.cpp
+++ b/src/pylir/Parser/ParserStatements.cpp
@@ -386,6 +386,12 @@ struct Visitor {
     visit(pylir::get<std::vector<Syntax::StarredItem>>(expression.variant));
   }
 
+  void visit(const Syntax::Intrinsic& intrinsic) {
+    parser.createError(intrinsic, Diag::CANNOT_ASSIGN_TO_N, "intrinsic")
+        .addHighlight(intrinsic)
+        .addHighlight(assignOp, Diag::flags::secondaryColour);
+  }
+
   void visit(const Syntax::Yield& expression) {
     parser.createError(expression, Diag::CANNOT_ASSIGN_TO_N, "yield expression")
         .addHighlight(expression)

--- a/src/pylir/Parser/Syntax.cpp
+++ b/src/pylir/Parser/Syntax.cpp
@@ -4,40 +4,9 @@
 
 #include "Syntax.hpp"
 
-#include <llvm/ADT/StringExtras.h>
-
 using namespace pylir;
 using namespace pylir::Diag;
 using namespace pylir::Syntax;
-
-std::optional<Intrinsic>
-Syntax::checkForIntrinsic(const Expression& expression) {
-  // Collect all the chained attribute references and their identifiers up until
-  // the atom.
-  llvm::SmallVector<IdentifierToken> identifiers;
-  const Expression* current = &expression;
-  while (const auto* ref = current->dyn_cast<AttributeRef>()) {
-    identifiers.push_back(ref->identifier);
-    current = ref->object.get();
-  }
-
-  // If its not an atom or not an identifier its not an intrinsic.
-  const auto* atom = current->dyn_cast<Atom>();
-  if (!atom || atom->token.getTokenType() != TokenType::Identifier)
-    return std::nullopt;
-
-  identifiers.emplace_back(atom->token);
-  std::reverse(identifiers.begin(), identifiers.end());
-  // Intrinsics always start with 'pylir' and 'intr'.
-  if (identifiers.size() < 2 || identifiers[0].getValue() != "pylir" ||
-      identifiers[1].getValue() != "intr")
-    return std::nullopt;
-
-  std::string name = llvm::join(
-      llvm::map_range(identifiers, std::mem_fn(&IdentifierToken::getValue)),
-      ".");
-  return Intrinsic{std::move(name), std::move(identifiers)};
-}
 
 std::pair<std::size_t, std::size_t> LocationProvider<TupleConstruct>::getRange(
     const TupleConstruct& value) noexcept {

--- a/src/pylir/Parser/Syntax.hpp
+++ b/src/pylir/Parser/Syntax.hpp
@@ -18,7 +18,7 @@ struct Expression
           struct Conditional, struct Call, struct Lambda, struct UnaryOp,
           struct Yield, struct Generator, struct TupleConstruct,
           struct ListDisplay, struct SetDisplay, struct DictDisplay,
-          struct Comparison> {
+          struct Comparison, struct Intrinsic> {
   using AbstractIntrusiveVariant::AbstractIntrusiveVariant;
 };
 
@@ -97,6 +97,15 @@ struct Conditional : Expression::Base<Conditional> {
   IntrVarPtr<Expression> condition;
   BaseToken elseToken;
   IntrVarPtr<Expression> elseValue;
+};
+
+struct Intrinsic : Expression::Base<Intrinsic> {
+  /// Name of the intrinsic. These are all identifier joined with dots.
+  /// Includes the 'pylir.intr' prefix.
+  std::string name;
+  /// All identifier tokens making up the name. Main use-case is for the
+  /// purpose of the location in the source code.
+  llvm::SmallVector<IdentifierToken> identifiers;
 };
 
 struct Argument {
@@ -455,22 +464,6 @@ struct FileInput {
   Suite input;
   IdentifierSet globals;
 };
-
-struct Intrinsic {
-  /// Name of the intrinsic. These are all identifier joined with dots.
-  /// Includes the 'pylir.intr' prefix.
-  std::string name;
-  /// All identifier tokens making up the name. Main use-case is for the
-  /// purpose of the location in the source code.
-  llvm::SmallVector<IdentifierToken> identifiers;
-};
-
-/// Checks whether 'expression' is a reference to an intrinsic. An intrinsic
-/// consists of a series of attribute references resulting in the syntax:
-/// "pylir" `.` "intr" { `.` identifier }.
-/// Returns an empty optional if the expression is not an intrinsic reference.
-std::optional<Intrinsic>
-checkForIntrinsic(const Syntax::Expression& expression);
 
 } // namespace pylir::Syntax
 

--- a/src/pylir/Parser/Visitor.hpp
+++ b/src/pylir/Parser/Visitor.hpp
@@ -150,6 +150,8 @@ public:
       getImpl()->visit(iter);
   }
 
+  void visit(Intrinsic&) {}
+
   void visit(CompFor& compFor) {
     getImpl()->visit(*compFor.targets);
     getImpl()->visit(*compFor.test);

--- a/test/Parser/primaries.py
+++ b/test/Parser/primaries.py
@@ -108,11 +108,21 @@ a(b,c = 3, *b)
 # CHECK-NEXT: |     `-atom b
 
 a(**b,c = 3)
-# CHECK-NEXT: `-call
-# CHECK-NEXT:   |-callable: atom a
-# CHECK-NEXT:   |-argument
-# CHECK-NEXT:   | `-mapped
-# CHECK-NEXT:   |   `-atom b
-# CHECK-NEXT:   `-argument
-# CHECK-NEXT:     `-keyword item c
-# CHECK-NEXT:       `-atom 3
+# CHECK-NEXT: |-call
+# CHECK-NEXT: | |-callable: atom a
+# CHECK-NEXT: | |-argument
+# CHECK-NEXT: | | `-mapped
+# CHECK-NEXT: | |   `-atom b
+# CHECK-NEXT: | `-argument
+# CHECK-NEXT: |   `-keyword item c
+# CHECK-NEXT: |     `-atom 3
+
+pylir.intr.const_export
+# CHECK-NEXT: |-intrinsic pylir.intr.const_export
+pylir.intr.const_export()
+# CHECK-NEXT: |-call
+# CHECK-NEXT: | `-callable: intrinsic pylir.intr.const_export
+pylir.intr.const_export[0]
+# CHECK-NEXT: `-subscription
+# CHECK-NEXT:   |-object: intrinsic pylir.intr.const_export
+# CHECK-NEXT:   `-index: atom 0

--- a/test/Parser/target-error.py
+++ b/test/Parser/target-error.py
@@ -65,3 +65,6 @@ del [*a]
 # expected-error@below {{only one iterable unpacking possible in assignment}}
 *a, b, *c = 3
 # expected-note@above {{previous occurrence here}}
+
+# expected-error@below {{cannot assign to intrinsic}}
+pylir.intr.const_export = 3


### PR DESCRIPTION
To avoid requiring all consumers to check whether something is an intrinsic, an AST node was added for intrinsic references. This makes subsequent visitors simpler as they just dispatch based on the type. Furthermore, its a step torwards verifying intrinsic use in the parser rather than during `CodeGen`