### PR TITLE
[CodeGenNew] Implement intrinsic constants

### DIFF
--- a/src/pylir/CodeGenNew/CodeGenNew.cpp
+++ b/src/pylir/CodeGenNew/CodeGenNew.cpp
@@ -1337,9 +1337,57 @@ private:
     PYLIR_UNREACHABLE;
   }
 
-  Value visitImpl([[maybe_unused]] const Syntax::Intrinsic& intrinsic) {
-    // TODO:
-    PYLIR_UNREACHABLE;
+  Value visitImpl(const Syntax::Intrinsic& intrinsic) {
+    std::string_view intrName = intrinsic.name;
+    if (intrName == "pylir.intr.type.__slots__") {
+      SmallVector<Attribute> attrs;
+#define TYPE_SLOT(slot, ...) \
+  attrs.push_back(m_builder.getAttr<Py::StrAttr>(#slot));
+#include <pylir/Interfaces/Slots.def>
+      return create<Py::ConstantOp>(m_builder.getAttr<Py::TupleAttr>(attrs));
+    }
+    if (intrName == "pylir.intr.function.__slots__") {
+      SmallVector<Attribute> attrs;
+#define FUNCTION_SLOT(slot, ...) \
+  attrs.push_back(m_builder.getAttr<Py::StrAttr>(#slot));
+#include <pylir/Interfaces/Slots.def>
+      return create<Py::ConstantOp>(m_builder.getAttr<Py::TupleAttr>(attrs));
+    }
+    if (intrName == "pylir.intr.BaseException.__slots__") {
+      SmallVector<Attribute> attrs;
+#define BASEEXCEPTION_SLOT(slot, ...) \
+  attrs.push_back(m_builder.getAttr<Py::StrAttr>(#slot));
+#include <pylir/Interfaces/Slots.def>
+      return create<Py::ConstantOp>(m_builder.getAttr<Py::TupleAttr>(attrs));
+    }
+
+#define TYPE_SLOT(pySlotName, cppSlotName)                        \
+  if (intrName == "pylir.intr.type." #pySlotName)                 \
+    return create<Py::ConstantOp>(m_builder.getAttr<Py::IntAttr>( \
+        BigInt(static_cast<std::size_t>(Builtins::TypeSlots::cppSlotName))));
+
+#include <pylir/Interfaces/Slots.def>
+
+#define FUNCTION_SLOT(pySlotName, cppSlotName)                           \
+  if (intrName == "pylir.intr.function." #pySlotName)                    \
+    return create<Py::ConstantOp>(m_builder.getAttr<Py::IntAttr>(BigInt( \
+        static_cast<std::size_t>(Builtins::FunctionSlots::cppSlotName))));
+
+#include <pylir/Interfaces/Slots.def>
+
+#define BASEEXCEPTION_SLOT(pySlotName, cppSlotName)                     \
+  if (intrName == "pylir.intr.BaseException." #pySlotName)              \
+    return create<Py::ConstantOp>(                                      \
+        m_builder.getAttr<Py::IntAttr>(BigInt(static_cast<std::size_t>( \
+            Builtins::BaseExceptionSlots::cppSlotName))));
+
+#include <pylir/Interfaces/Slots.def>
+
+    createError(intrinsic.identifiers.front(), Diag::UNKNOWN_INTRINSIC_N,
+                intrName)
+        .addHighlight(intrinsic.identifiers.front(),
+                      intrinsic.identifiers.back());
+    return {};
   }
 
   Value visitImpl(const Syntax::Call& call) {

--- a/test/CodeGenNew/intrinsics.py
+++ b/test/CodeGenNew/intrinsics.py
@@ -29,3 +29,6 @@ pylir.intr.int.cmp("ne", 0, 1)
 # CHECK: %[[THREE:.*]] = py.constant(#py.int<3>)
 # CHECK: py.function_call %[[ZERO]](%[[ONE]], %[[TWO]], %[[THREE]])
 pylir.intr.function.call(0, 1, 2, 3)
+
+# CHECK: py.constant(#py.tuple<({{.*}})>)
+pylir.intr.function.__slots__


### PR DESCRIPTION
These are taken directly from the old `CodeGen` to get these to parity. The plan is to nevertheless move verification of these to the frontend in the future.