### PR TITLE
[CodeGen][Main] Refactor import logic

### DIFF
--- a/src/pylir/CodeGen/CodeGen.cpp
+++ b/src/pylir/CodeGen/CodeGen.cpp
@@ -69,7 +69,8 @@ pylir::CodeGen::visit(const pylir::Syntax::FileInput& fileInput) {
 
     // Initialize builtins from main module.
     if (m_qualifiers.empty() && m_options.implicitBuiltinsImport) {
-      importModules({ModuleSpec({ModuleSpec::Component{"builtins", {0, 1}}})});
+      m_options.moduleLoadCallback("builtins", m_docManager,
+                                   /*location=*/{0, 1});
       m_builder.create<Py::CallOp>(mlir::TypeRange{}, "builtins.__init__");
     }
 
@@ -2276,8 +2277,6 @@ void pylir::CodeGen::visit(const Syntax::DelStmt& delStmt) {
 }
 
 void pylir::CodeGen::visit(const Syntax::ImportStmt& importStmt) {
-  std::vector<ModuleSpec> specs;
-
   auto moduleIsIntrinsic = [](const Syntax::ImportStmt::Module& module) {
     if (module.identifiers.size() < 2) {
       return false;
@@ -2286,183 +2285,70 @@ void pylir::CodeGen::visit(const Syntax::ImportStmt& importStmt) {
            module.identifiers[1].getValue() == "intr";
   };
 
-  pylir::match(
+  struct ModuleSpec {
+    std::size_t dots = 0;
+    std::vector<IdentifierToken> identifiers;
+  };
+
+  llvm::SmallVector<ModuleSpec> specs;
+  match(
       importStmt.variant,
       [&](const Syntax::ImportStmt::ImportAs& importAs) {
         for (const auto& iter : importAs.modules) {
           if (!iter.second && moduleIsIntrinsic(iter.first))
             continue;
-          specs.emplace_back(iter.first);
+          specs.push_back({0, iter.first.identifiers});
         }
       },
-      [&](const Syntax::ImportStmt::FromImport& fromImport) {
-        specs.emplace_back(fromImport.relativeModule);
+      [&](const Syntax::ImportStmt::FromImport&) {
+        // TODO:
+        PYLIR_UNREACHABLE;
       },
-      [&](const Syntax::ImportStmt::ImportAll& importAll) {
-        specs.emplace_back(importAll.relativeModule);
+      [&](const Syntax::ImportStmt::ImportAll&) {
+        // TODO:
+        PYLIR_UNREACHABLE;
       });
 
-  auto result = importModules(specs);
-  for (auto& iter : result) {
-    if (!iter.successful) {
-      // TODO: throw ModuleNotFoundError
-      continue;
+  for (const ModuleSpec& moduleSpec : specs) {
+    llvm::SmallVector<std::string> moduleParts;
+
+    if (moduleSpec.dots != 0) {
+      llvm::SmallVector<llvm::StringRef> split;
+      llvm::StringRef(m_qualifiers).split(split, '.');
+      if (split.size() < moduleSpec.dots) {
+        // exceeding package level.
+        // TODO: diagnostic?
+        return;
+      }
+      llvm::append_range(moduleParts,
+                         llvm::ArrayRef(split).drop_back(moduleSpec.dots - 1));
     }
-    // TODO: throw ImportError on init failure
-    // TODO: somehow handle that modules aren't initialized multiple times
-    //  (best via sys.modules once we have that)
-    m_builder.create<Py::CallOp>(mlir::TypeRange{},
-                                 iter.moduleSymbolName + ".__init__");
+    llvm::append_range(
+        moduleParts, llvm::map_range(moduleSpec.identifiers,
+                                     std::mem_fn(&IdentifierToken::getValue)));
+
+    std::string moduleQualifier;
+    for (llvm::StringRef part : moduleParts) {
+      if (moduleQualifier.empty())
+        moduleQualifier = part;
+      else
+        moduleQualifier.append(".").append(part);
+
+      m_options.moduleLoadCallback(moduleQualifier, m_docManager,
+                                   Diag::rangeLoc(moduleSpec.identifiers));
+
+      // TODO: throw ImportError on init failure
+      // TODO: somehow handle that modules aren't initialized multiple times
+      //  (best via sys.modules once we have that)
+      m_builder.create<Py::CallOp>(mlir::TypeRange{},
+                                   moduleQualifier + ".__init__");
+    }
   }
 }
 
 void pylir::CodeGen::visit(const Syntax::FutureStmt&) {
   // TODO:
   PYLIR_UNREACHABLE;
-}
-
-std::vector<pylir::CodeGen::ModuleImport>
-pylir::CodeGen::importModules(llvm::ArrayRef<ModuleSpec> specs) {
-  std::vector<pylir::CodeGen::ModuleImport> imports;
-  for (const auto& iter : specs) {
-    llvm::SmallString<100> relativePathSS(
-        m_docManager->getDocument().getFilename());
-    llvm::sys::fs::make_absolute(relativePathSS);
-    for (std::size_t i = 0; i < iter.dots; i++) {
-      llvm::sys::path::append(relativePathSS, "..");
-    }
-    std::string relativePath{relativePathSS};
-
-    std::pair<std::size_t, std::size_t> location;
-    std::string moduleQualifier;
-    llvm::ArrayRef<std::string> importPathsToCheck;
-    if (iter.dots != 0) {
-      importPathsToCheck = relativePath;
-      location = iter.dotsLocation;
-      llvm::SmallVector<llvm::StringRef> split;
-      llvm::StringRef{m_options.qualifier}.split(split, '.');
-      // Amount of dots exceed package level
-      if (split.size() < iter.dots) {
-        imports.push_back({"", false, location});
-        continue;
-      }
-      moduleQualifier =
-          llvm::join(llvm::ArrayRef(split).drop_back(iter.dots - 1), ".");
-    } else {
-      importPathsToCheck = m_options.importPaths;
-      PYLIR_ASSERT(!iter.components.empty());
-      moduleQualifier = iter.components.front().name;
-      location = iter.components.front().location;
-    }
-
-    // When importing submodules, they need to be subdirectories/files from the
-    // parent package. Hence, we do the following here: We search only for the
-    // most top level module first to find the path we'll be working with, and
-    // only then attempt to find submodules relative to that path.
-
-    std::optional<llvm::StringRef> topLevelModule;
-    if (!iter.components.empty()) {
-      topLevelModule = iter.components.front().name;
-    }
-
-    bool lastWasPackage = false;
-
-    auto testPathForImport = [&](llvm::StringRef path)
-        -> std::optional<std::pair<llvm::sys::fs::file_t, std::string>> {
-      // First check if this is a package import by trying to open a contained
-      // __init__.py
-      llvm::SmallString<100> initFilePath = path;
-      llvm::sys::path::append(initFilePath, "__init__.py");
-
-      auto fs = llvm::sys::fs::openNativeFileForRead(initFilePath);
-      if (fs) {
-        lastWasPackage = true;
-        return std::pair{fs.get(), std::string(initFilePath)};
-      }
-      llvm::consumeError(fs.takeError());
-
-      // Otherwise try module import a source file.
-      fs = llvm::sys::fs::openNativeFileForRead((path + ".py").str());
-      if (fs) {
-        return std::pair{fs.get(), (path + ".py").str()};
-      }
-      llvm::consumeError(fs.takeError());
-      return std::nullopt;
-    };
-
-    llvm::SmallString<100> successPath;
-    bool success = false;
-    for (const auto& path : importPathsToCheck) {
-      successPath = path;
-      if (topLevelModule) {
-        llvm::sys::path::append(successPath, *topLevelModule);
-      }
-      if (auto opt = testPathForImport(successPath)) {
-        auto [fs, filePath] = std::move(*opt);
-        m_options.moduleLoadCallback(
-            {fs, moduleQualifier, location, m_docManager, std::move(filePath)});
-        imports.push_back({moduleQualifier, true, location});
-        success = true;
-        break;
-      }
-    }
-
-    if (!success) {
-      imports.push_back({moduleQualifier, false, location});
-      continue;
-    }
-
-    // Early exit for pure relative path
-    if (iter.components.empty())
-      continue;
-
-    for (const auto& subModule : llvm::drop_begin(iter.components)) {
-      moduleQualifier += ".";
-      moduleQualifier += subModule.name;
-      if (!lastWasPackage) {
-        imports.push_back({moduleQualifier, false, location});
-        break;
-      }
-
-      llvm::sys::path::append(successPath, subModule.name);
-      if (auto opt = testPathForImport(successPath)) {
-        auto [fs, filePath] = std::move(*opt);
-        m_options.moduleLoadCallback(
-            {fs, moduleQualifier, location, m_docManager, std::move(filePath)});
-        imports.push_back({moduleQualifier, true, location});
-        continue;
-      }
-      imports.push_back({moduleQualifier, false, location});
-      break;
-    }
-  }
-  return imports;
-}
-
-pylir::CodeGen::ModuleSpec::ModuleSpec(
-    const pylir::Syntax::ImportStmt::Module& module)
-    : dots{}, dotsLocation{}, components(module.identifiers.size()) {
-  llvm::transform(
-      module.identifiers, components.begin(), [](const IdentifierToken& token) {
-        return Component{std::string(token.getValue()), Diag::rangeLoc(token)};
-      });
-}
-
-pylir::CodeGen::ModuleSpec::ModuleSpec(
-    const pylir::Syntax::ImportStmt::RelativeModule& relativeModule)
-    : dots(relativeModule.dots.size()),
-      dotsLocation(Diag::rangeLoc(relativeModule.dots.front()).first,
-                   Diag::rangeLoc(relativeModule.dots.back()).second),
-      components(relativeModule.module
-                     ? relativeModule.module->identifiers.size()
-                     : 0) {
-  if (relativeModule.module) {
-    llvm::transform(relativeModule.module->identifiers, components.begin(),
-                    [](const IdentifierToken& token) {
-                      return Component{std::string(token.getValue()),
-                                       Diag::rangeLoc(token)};
-                    });
-  }
 }
 
 mlir::Value

--- a/src/pylir/CodeGen/CodeGen.hpp
+++ b/src/pylir/CodeGen/CodeGen.hpp
@@ -165,35 +165,6 @@ class CodeGen {
                     mlir::ValueRange endArgs,
                     llvm::function_ref<void(mlir::Value)> iterationCallback);
 
-  /*
-  struct ModuleSpec {
-    std::size_t dots;
-    std::pair<std::size_t, std::size_t> dotsLocation;
-
-    struct Component {
-      std::string name;
-      std::pair<std::size_t, std::size_t> location;
-    };
-    std::vector<Component> components;
-
-    explicit ModuleSpec(const Syntax::ImportStmt::Module& module);
-
-    explicit ModuleSpec(
-        const Syntax::ImportStmt::RelativeModule& relativeModule);
-
-    explicit ModuleSpec(std::vector<Component> components)
-        : dots{}, dotsLocation{}, components(std::move(components)) {}
-  };
-
-  struct ModuleImport {
-    std::string moduleSymbolName;
-    bool successful;
-    std::pair<std::size_t, std::size_t> location;
-  };
-
-  std::vector<ModuleImport> importModules(llvm::ArrayRef<ModuleSpec> specs);
-*/
-
   mlir::Value callIntrinsic(const Syntax::Intrinsic& intrinsic,
                             llvm::ArrayRef<Syntax::Argument> arguments,
                             const Syntax::Call& call);

--- a/src/pylir/CodeGen/CodeGen.hpp
+++ b/src/pylir/CodeGen/CodeGen.hpp
@@ -165,6 +165,7 @@ class CodeGen {
                     mlir::ValueRange endArgs,
                     llvm::function_ref<void(mlir::Value)> iterationCallback);
 
+  /*
   struct ModuleSpec {
     std::size_t dots;
     std::pair<std::size_t, std::size_t> dotsLocation;
@@ -191,6 +192,7 @@ class CodeGen {
   };
 
   std::vector<ModuleImport> importModules(llvm::ArrayRef<ModuleSpec> specs);
+*/
 
   mlir::Value callIntrinsic(const Syntax::Intrinsic& intrinsic,
                             llvm::ArrayRef<Syntax::Argument> arguments,

--- a/src/pylir/CodeGen/CodeGenOptions.hpp
+++ b/src/pylir/CodeGen/CodeGenOptions.hpp
@@ -17,16 +17,10 @@
 namespace pylir {
 
 struct CodeGenOptions {
-  std::vector<std::string> importPaths;
-
-  struct LoadRequest {
-    llvm::sys::fs::file_t handle;
-    std::string qualifier;
-    std::pair<std::size_t, std::size_t> location;
-    Diag::DiagnosticsDocManager* diagnosticsDocManager;
-    std::string filePath;
-  };
-  std::function<void(LoadRequest&&)> moduleLoadCallback;
+  std::function<void(llvm::StringRef absoluteModule,
+                     Diag::DiagnosticsDocManager* diagnostics,
+                     std::pair<std::size_t, std::size_t> location)>
+      moduleLoadCallback;
   std::string qualifier;
   bool implicitBuiltinsImport;
 };

--- a/src/pylir/Main/CompilerInvocation.hpp
+++ b/src/pylir/Main/CompilerInvocation.hpp
@@ -13,6 +13,7 @@
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/Option/Arg.h>
 #include <llvm/Support/FileSystem.h>
+#include <llvm/Support/ThreadPool.h>
 #include <llvm/Support/ToolOutputFile.h>
 #include <llvm/Target/TargetMachine.h>
 
@@ -32,6 +33,7 @@ namespace pylir {
 struct CodeGenOptions;
 
 class CompilerInvocation {
+  std::optional<llvm::ThreadPool> m_threadPool;
   std::optional<mlir::MLIRContext> m_mlirContext;
   std::unique_ptr<llvm::LLVMContext> m_llvmContext;
   std::list<Diag::Document> m_documents;
@@ -50,7 +52,7 @@ public:
   enum Action { SyntaxOnly, ObjectFile, Assembly, Link };
 
 private:
-  void ensureMLIRContext(const llvm::opt::InputArgList& args);
+  void ensureMLIRContext();
 
   mlir::LogicalResult ensureLLVMInit(const llvm::opt::InputArgList& args,
                                      const pylir::Toolchain& toolchain);

--- a/src/pylir/Main/DiagnosticMessages.hpp
+++ b/src/pylir/Main/DiagnosticMessages.hpp
@@ -30,6 +30,9 @@ constexpr auto FAILED_TO_OPEN_OUTPUT_FILE_N_FOR_WRITING =
 constexpr auto FAILED_TO_ACCESS_FILE_N =
     FMT_STRING("failed to access file '{}'");
 
+constexpr auto FAILED_TO_FIND_MODULE_N =
+    FMT_STRING("failed to find module '{}'");
+
 constexpr auto FAILED_TO_READ_FILE_N = FMT_STRING("failed to read file '{}'");
 
 constexpr auto FAILED_TO_CREATE_TEMPORARY_FILE_N =

--- a/src/pylir/Parser/Parser.hpp
+++ b/src/pylir/Parser/Parser.hpp
@@ -496,13 +496,17 @@ public:
   std::optional<Syntax::AssertStmt> parseAssertStmt();
 
   /**
-   * import_stmt     ::=  "import" module ["as" identifier] { "," module ["as"
-   * identifier] } |  "from" relative_module "import" identifier ["as"
-   * identifier] { "," identifier ["as" identifier] } |  "from" relative_module
-   * "import" "(" identifier ["as" identifier] { "," identifier ["as"
-   * identifier] } [","] ")" |  "from" relative_module "import" "*" module ::=
-   * { identifier "." } identifier relative_module ::=  { "." } module |  "." {
-   * "." }
+   * import_stmt     ::= "import" module ["as" identifier]
+   *                     { "," module ["as" identifier] }
+   *                   | "from" relative_module "import" identifier
+   *                     ["as" identifier] { "," identifier ["as" identifier] }
+   *                   | "from" relative_module "import"
+   *                     "(" identifier ["as" identifier] { "," identifier
+   *                         ["as" identifier] } [","] ")"
+   *                   | "from" relative_module "import" "*"
+   *
+   * module ::= { identifier "." } identifier
+   * relative_module ::=  { "." } module |  "." { "." }
    */
   std::optional<Syntax::ImportStmt> parseImportStmt();
 

--- a/src/pylir/Parser/Syntax.hpp
+++ b/src/pylir/Parser/Syntax.hpp
@@ -281,20 +281,29 @@ struct RaiseStmt : SimpleStmt::Base<RaiseStmt> {
 };
 
 struct ImportStmt : SimpleStmt::Base<ImportStmt> {
+  /// module ::= { identifier "." } identifier
   struct Module {
     std::vector<IdentifierToken> identifiers;
   };
 
+  /// relative_module ::=  { "." } module |  "." { "." }
   struct RelativeModule {
     std::vector<BaseToken> dots;
     std::optional<Module> module;
   };
 
+  /// "import" module ["as" identifier] { "," module ["as" identifier] }
   struct ImportAs {
     BaseToken import;
     std::vector<std::pair<Module, std::optional<IdentifierToken>>> modules;
   };
 
+  /// "from" relative_module "import" identifier ["as" identifier]
+  ///       { "," identifier ["as" identifier] }
+  /// | "from" relative_module "import"
+  ///   "(" identifier ["as" identifier]
+  ///     { "," identifier ["as" identifier] }
+  ///   [","] ")"
   struct FromImport {
     BaseToken from;
     RelativeModule relativeModule;
@@ -303,6 +312,7 @@ struct ImportStmt : SimpleStmt::Base<ImportStmt> {
         imports;
   };
 
+  /// "from" relative_module "import" "*"
   struct ImportAll {
     BaseToken from;
     RelativeModule relativeModule;


### PR DESCRIPTION
The previous import logic had an odd split of responsibilities where the codegen was performing the I/O operations of finding the module and then handed the file handle to the frontend invocation performing the module load. The frontend would then return the module qualifier to use by codegen for the import, creating an odd dependency and back-and-forth.

This PR therefore refactors this logic a bit and makes the callback used by the codegen a pure "notifier" so-to say. The codegen constructs the qualifier used to denote the module notifies the frontend of requiring the module to be loaded. It uses the same qualifier to call the modules initialization function. The frontend receives the qualifier and performs the whole logic starting from finding the python source file to then spawning the codegen task.

The threading logic was also simplified in the process by using an explicit `llvm::ThreadPool` and a `llvm::ThreadPoolTaskGroup`.