### PR TITLE
[PyHIR] Add `pyHIR.initModule` op

### DIFF
--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
@@ -412,13 +412,13 @@ def PylirHIR_ReturnOp : PylirHIR_Op<"return", [Pure, ReturnLike, Terminator,
 //===----------------------------------------------------------------------===//
 
 def PylirHIR_InitOp : PylirHIR_Op<"init", [NoRegionArguments, IsolatedFromAbove,
-  OpAsmOpInterface]> {
+  OpAsmOpInterface, Symbol]> {
 
-  let arguments = (ins StrAttr:$name);
+  let arguments = (ins StrAttr:$sym_name);
 
   let regions = (region MinSizedRegion<1>:$body);
 
-  let assemblyFormat = "$name attr-dict-with-keyword $body";
+  let assemblyFormat = "$sym_name attr-dict-with-keyword $body";
 
   let description = [{
     This op represents the initializer body of a module `$name`, or in other
@@ -456,6 +456,27 @@ def PylirHIR_InitReturnOp : PylirHIR_Op<"init_return", [HasParent<"InitOp">,
   }];
 
   let assemblyFormat = "$global_dict attr-dict";
+}
+
+def PylirHIR_InitModuleOp : PylirHIR_Op<"initModule",
+  [AddableExceptionHandling<"InitModuleExOp">,
+   DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+  let arguments = (ins FlatSymbolRefAttr:$module);
+
+  let description = [{
+    Op used to call an `pyHIR.init` operation by executing its body.
+    `$module` must be a reference to a `pyHIR.init` operation with the given name.
+    As a special case, it is not possible to initialize the `__main__` module.
+  }];
+
+  let assemblyFormat = "$module attr-dict";
+
+  let hasVerifier = 1;
+}
+
+def PylirHIR_InitModuleExOp
+  : CreateExceptionHandlingVariant<PylirHIR_InitModuleOp> {
+  let hasVerifier = 1;
 }
 
 #endif

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyTraits.hpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyTraits.hpp
@@ -77,6 +77,9 @@ struct AddableExceptionHandling {
                         mlir::OpTrait::VariadicOperands>())
         return {};
       else if constexpr (ConcreteType::template hasTrait<
+                             mlir::OpTrait::ZeroOperands>())
+        return 0;
+      else if constexpr (ConcreteType::template hasTrait<
                              mlir::OpTrait::OneOperand>())
         return 1;
       else

--- a/test/Optimizer/PylirHIR/IR/invalid.mlir
+++ b/test/Optimizer/PylirHIR/IR/invalid.mlir
@@ -41,3 +41,12 @@ pyHIR.globalFunc @call_invalid_kind_index(%arg0) {
     : (!py.dynamic, !py.dynamic) -> !py.dynamic
   return %0
 }
+
+// -----
+
+pyHIR.init "__main__" {
+  %0 = py.constant(#py.dict<{}>)
+  // expected-error@below {{cannot initialize '__main__' module}}
+  initModule @__main__
+  init_return %0
+}

--- a/test/Optimizer/PylirHIR/IR/roundtrip.mlir
+++ b/test/Optimizer/PylirHIR/IR/roundtrip.mlir
@@ -150,3 +150,16 @@ pyHIR.globalFunc @binAssignOp(%0, %1) {
   %19 = binAssignOp %0 __imatmul__ %1
   return %19
 }
+
+pyHIR.init "foo" {
+  %0 = py.constant(#py.dict<{}>)
+  init_return %0
+}
+
+// CHECK-LABEL: pyHIR.globalFunc @initModule(
+pyHIR.globalFunc @initModule() {
+  %0 = py.constant(#py.dict<{}>)
+  // CHECK: initModule @foo
+  initModule @foo
+  return %0
+}


### PR DESCRIPTION
This operation is used to call the `init` op body of any module that is not the main module and is required for the purpose of module import. Right now it only calls the init method without 1) creating the module object, 2) raising import errors or 3) ensuring the module hasn't been initialized previously. These are left as future tasks