### PR TITLE
[CodeGenNew] Implement constant evaluation of intrinsics

### DIFF
--- a/test/CodeGenNew/const-export-class.py
+++ b/test/CodeGenNew/const-export-class.py
@@ -9,6 +9,10 @@
 # CHECK-SAME: slots = {__init__ = #py.globalValue<__main__.SeqIter.__init__,
 # CHECK-SAME:          __name__ = #py.str<"SeqIter">}
 
+# CHECK: #py.globalValue<__main__.function,
+# CHECK-SAME: initializer = #py.type<
+# CHECK-SAME: instance_slots = <({{.*}})>,
+
 # CHECK-LABEL: init "__main__"
 
 @pylir.intr.const_export
@@ -18,6 +22,7 @@ class SeqIter:
     def __init__(self, seq) -> None:
         pass
 
+
 # CHECK: %[[MAIN_SEQ_ITER:.*]] = py.constant(#[[$MAIN_SEQ_ITER]])
 # CHECK: py.dict_setItem %{{.*}}[{{.*}}] to %[[MAIN_SEQ_ITER]]
 
@@ -25,3 +30,6 @@ class SeqIter:
 
 # CHECK: py.external @__main__.SeqIter, #[[$MAIN_SEQ_ITER]]
 
+@pylir.intr.const_export
+class function:
+    __slots__ = pylir.intr.function.__slots__


### PR DESCRIPTION
All the intrinsic constants in Pylir are meant to be constants with special names assigned to them to allow close cooperation of compiler and runtime. These had nevertheless only been implemented as expression evaluation, not constant expression evaluation until now.