### PR TITLE
[CodeGenNew][PyHIR] Implement subscription operator

### DIFF
--- a/src/pylir/CodeGenNew/CodeGenNew.cpp
+++ b/src/pylir/CodeGenNew/CodeGenNew.cpp
@@ -1294,9 +1294,10 @@ private:
     }
   }
 
-  mlir::Value visitImpl(
-      [[maybe_unused]] const Syntax::Subscription& subscription) { // TODO:
-    PYLIR_UNREACHABLE;
+  Value visitImpl(const Syntax::Subscription& subscription) {
+    Value object = visit(subscription.object);
+    Value index = visit(subscription.index);
+    return create<HIR::GetItemOp>(object, index);
   }
 
   Value visitImpl(const Syntax::Assignment& assignment) {
@@ -1599,10 +1600,10 @@ private:
     writeToIdentifier(value, get<std::string>(atom.token.getValue()));
   }
 
-  void visitImpl([[maybe_unused]] const Syntax::Subscription& subscription,
-                 [[maybe_unused]] Value value) {
-    // TODO:
-    PYLIR_UNREACHABLE;
+  void visitImpl(const Syntax::Subscription& subscription, Value value) {
+    Value object = visit(subscription.object);
+    Value index = visit(subscription.index);
+    create<HIR::SetItemOp>(object, index, value);
   }
 
   void visitImpl([[maybe_unused]] const Syntax::Slice& slice,

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
@@ -106,6 +106,51 @@ def PylirHIR_BinAssignExOp
   : CreateExceptionHandlingVariant<PylirHIR_BinAssignOp>;
 
 //===----------------------------------------------------------------------===//
+// Subscription Operations
+//===----------------------------------------------------------------------===//
+
+def PylirHIR_GetItemOp : PylirHIR_Op<"getItem",
+  [AddableExceptionHandling<"GetItemExOp">]> {
+  let arguments = (ins DynamicType:$object, DynamicType:$index);
+  let results = (outs DynamicType:$result);
+
+  let assemblyFormat = [{
+    $object `[` $index `]` attr-dict
+  }];
+}
+
+def PylirHIR_GetItemExOp
+  : CreateExceptionHandlingVariant<PylirHIR_GetItemOp>;
+
+def PylirHIR_SetItemOp : PylirHIR_Op<"setItem",
+  [AddableExceptionHandling<"SetItemExOp">]> {
+  let arguments = (ins DynamicType:$object,
+                       DynamicType:$index,
+                       DynamicType:$value);
+  let results = (outs DynamicType:$result);
+
+  let assemblyFormat = [{
+    $object `[` $index `]` `to` $value attr-dict
+  }];
+}
+
+def PylirHIR_SetItemExOp
+  : CreateExceptionHandlingVariant<PylirHIR_SetItemOp>;
+
+def PylirHIR_DelItemOp : PylirHIR_Op<"delItem",
+  [AddableExceptionHandling<"DelItemExOp">]> {
+  let arguments = (ins DynamicType:$object, DynamicType:$index);
+  let results = (outs DynamicType:$result);
+
+  let assemblyFormat = [{
+    $object `[` $index `]` attr-dict
+  }];
+}
+
+def PylirHIR_DelItemExOp
+  : CreateExceptionHandlingVariant<PylirHIR_DelItemOp>;
+
+//===----------------------------------------------------------------------===//
 // Call Operations
 //===----------------------------------------------------------------------===//
 

--- a/test/CodeGenNew/subscription.py
+++ b/test/CodeGenNew/subscription.py
@@ -1,0 +1,10 @@
+# RUN: pylir %s -Xnew-codegen -emit-pylir -o - -c -S | FileCheck %s
+
+# CHECK-LABEL: func "__main__.test"
+# CHECK-SAME: %[[A:[[:alnum:]]+]]
+# CHECK-SAME: %[[B:[[:alnum:]]+]]
+# CHECK-SAME: %[[C:[[:alnum:]]+]]
+def test(a, b, c):
+    # CHECK: %[[A_C:.*]] = getItem %[[A]][%[[C]]]
+    # CHECK: setItem %[[A]][%[[B]]] to %[[A_C]]
+    a[b] = a[c]

--- a/test/Optimizer/Conversion/PylirHIRToPylirPy/subscription.mlir
+++ b/test/Optimizer/Conversion/PylirHIRToPylirPy/subscription.mlir
@@ -1,0 +1,14 @@
+// RUN: pylir-opt %s --convert-pylirHIR-to-pylirPy --split-input-file | FileCheck %s
+
+// CHECK-LABEL: func @test$impl
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+pyHIR.globalFunc @test(%0, %1) {
+  // CHECK: %[[ITEM:.*]] = call @pylir__getitem__(%[[ARG0]], %[[ARG1]])
+  %2 = getItem %0[%1]
+  // CHECK: call @pylir__setitem__(%[[ARG0]], %[[ITEM]], %[[ARG1]])
+  setItem %0[%2] to %1
+  // CHECK: call @pylir__delitem__(%[[ARG1]], %[[ARG0]])
+  delItem %1[%0]
+  return %2
+}

--- a/test/Optimizer/PylirHIR/IR/roundtrip.mlir
+++ b/test/Optimizer/PylirHIR/IR/roundtrip.mlir
@@ -163,3 +163,16 @@ pyHIR.globalFunc @initModule() {
   initModule @foo
   return %0
 }
+
+// CHECK-LABEL: pyHIR.globalFunc @subscription(
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+pyHIR.globalFunc @subscription(%0, %1) {
+  // CHECK: %[[ITEM:.*]] = getItem %[[ARG0]][%[[ARG1]]]
+  %2 = getItem %0[%1]
+  // CHECK: setItem %[[ARG0]][%[[ITEM]]] to %[[ARG1]]
+  setItem %0[%2] to %1
+  // CHECK: delItem %[[ARG1]][%[[ARG0]]]
+  delItem %1[%0]
+  return %2
+}


### PR DESCRIPTION
This PR implements python subscription operators, both assignment and reading, by lowering them to `getItem` and `setItem` ops of the `pyHIR` dialect, also introduced with this PR. A more general `specialMethod` op was considered instead of `getItem` and `setItem` but specific ops for subscription were chosen instead for better syntax and assigning proper meaning to each operand.