### PR TITLE
[CodeGenNew] Fix accessing globals in `const_export` function

### DIFF
--- a/src/pylir/CodeGenNew/CodeGenNew.cpp
+++ b/src/pylir/CodeGenNew/CodeGenNew.cpp
@@ -31,7 +31,7 @@ class CodeGenNew {
   SymbolTable m_symbolTable;
   Diag::DiagnosticsDocManager<>* m_docManager;
   std::string m_qualifiers;
-  Value m_globalDictionary;
+  Py::GlobalValueAttr m_globalDictionary;
   llvm::DenseMap<llvm::StringRef, Py::GlobalValueAttr> m_builtinNamespace;
 
   /// Struct representing one instance of a scope in Python.
@@ -262,9 +262,10 @@ class CodeGenNew {
       }
     }
 
+    Value dictionary = create<Py::ConstantOp>(m_globalDictionary);
     Value string = create<Py::ConstantOp>(m_builder.getAttr<Py::StrAttr>(name));
     Value hash = create<Py::StrHashOp>(string);
-    create<Py::DictSetItemOp>(m_globalDictionary, string, hash, value);
+    create<Py::DictSetItemOp>(dictionary, string, hash, value);
   }
 
   /// Reads the identifier given by 'name' and returns its value. Generates code
@@ -303,10 +304,10 @@ class CodeGenNew {
       }
     }
 
+    Value dictionary = create<Py::ConstantOp>(m_globalDictionary);
     Value string = create<Py::ConstantOp>(m_builder.getAttr<Py::StrAttr>(name));
     Value hash = create<Py::StrHashOp>(string);
-    Value readValue =
-        create<Py::DictTryGetItemOp>(m_globalDictionary, string, hash);
+    Value readValue = create<Py::DictTryGetItemOp>(dictionary, string, hash);
 
     auto iter = m_builtinNamespace.find(name);
     if (iter != m_builtinNamespace.end()) {
@@ -497,16 +498,21 @@ public:
     init.getBody().push_back(entryBlock);
     m_builder.setInsertionPointToEnd(entryBlock);
 
-    auto dictionary =
+    m_globalDictionary =
         m_builder.getAttr<Py::GlobalValueAttr>(m_qualifiers + "$dict");
-    dictionary.setInitializer(m_builder.getAttr<Py::DictAttr>());
+    m_globalDictionary.setInitializer(m_builder.getAttr<Py::DictAttr>());
 
-    m_globalDictionary = create<Py::ConstantOp>(dictionary);
+    // Initialize builtins from main module.
+    if (m_options.qualifier.empty() && m_options.implicitBuiltinsImport) {
+      m_options.moduleLoadCallback("builtins", m_docManager,
+                                   /*location=*/{0, 1});
+      create<HIR::InitModuleOp>("builtins");
+    }
 
     visit(fileInput.input);
 
     if (m_builder.getInsertionBlock())
-      create<HIR::InitReturnOp>(m_globalDictionary);
+      create<HIR::InitReturnOp>(create<Py::ConstantOp>(m_globalDictionary));
 
     return m_module;
   }

--- a/src/pylir/CodeGenNew/CodeGenNew.cpp
+++ b/src/pylir/CodeGenNew/CodeGenNew.cpp
@@ -502,13 +502,6 @@ public:
         m_builder.getAttr<Py::GlobalValueAttr>(m_qualifiers + "$dict");
     m_globalDictionary.setInitializer(m_builder.getAttr<Py::DictAttr>());
 
-    // Initialize builtins from main module.
-    if (m_options.qualifier.empty() && m_options.implicitBuiltinsImport) {
-      m_options.moduleLoadCallback("builtins", m_docManager,
-                                   /*location=*/{0, 1});
-      create<HIR::InitModuleOp>("builtins");
-    }
-
     visit(fileInput.input);
 
     if (m_builder.getInsertionBlock())

--- a/test/CodeGenNew/call.py
+++ b/test/CodeGenNew/call.py
@@ -11,7 +11,7 @@ def x(*args, **kwargs):
 
 # CHECK: %[[STR:.*]] = py.constant(#py.str<"x">)
 # CHECK: %[[HASH:.*]] = py.str_hash %[[STR]]
-# CHECK: %[[X:.*]] = py.dict_tryGetItem %[[GLOBALS]][%[[STR]] hash(%[[HASH]])]
+# CHECK: %[[X:.*]] = py.dict_tryGetItem %{{.*}}[%[[STR]] hash(%[[HASH]])]
 # CHECK: %[[FIVE:.*]] = py.constant(#py.int<5>)
 # CHECK: %[[THREE:.*]] = py.constant(#py.int<3>)
 # CHECK: %[[SEVEN:.*]] = py.constant(#py.int<7>)

--- a/test/CodeGenNew/global-func-global-access.py
+++ b/test/CodeGenNew/global-func-global-access.py
@@ -1,0 +1,12 @@
+# RUN: pylir %s -Xnew-codegen -emit-pylir -o - -S | FileCheck %s
+
+a = 3
+
+# CHECK: globalFunc @__main__.test{{.*}}(
+@pylir.intr.const_export
+def test():
+    # CHECK: %[[DIC:.*]] = py.constant(#__main__$dict)
+    # CHECK: %[[STR:.*]] = py.constant(#py.str<"a">)
+    # CHECK: %[[ITEM:.*]] = py.dict_tryGetItem %[[DIC]][%[[STR]] hash(%{{.*}})]
+    # CHECK: return %[[ITEM]]
+    return a

--- a/test/CodeGenNew/intrinsics.py
+++ b/test/CodeGenNew/intrinsics.py
@@ -3,7 +3,6 @@
 import pylir.intr.object
 
 # CHECK-LABEL: init "__main__"
-# CHECK: %[[DICT:.*]] = py.constant(#__main__$dict)
 
 def foo():
     pass
@@ -12,11 +11,11 @@ def foo():
 # CHECK: py.dict_setItem
 # CHECK: %[[STR:.*]] = py.constant(#py.str<"foo">)
 # CHECK: %[[HASH:.*]] = py.str_hash %[[STR]]
-# CHECK: %[[FOO:.*]] = py.dict_tryGetItem %[[DICT]][%[[STR]] hash(%[[HASH]])]
+# CHECK: %[[FOO:.*]] = py.dict_tryGetItem %{{.*}}[%[[STR]] hash(%[[HASH]])]
 # CHECK: %[[T:.*]] = py.typeOf %[[FOO]]
 # CHECK: %[[STR:.*]] = py.constant(#py.str<"t">)
 # CHECK: %[[HASH:.*]] = py.str_hash %[[STR]]
-# CHECK: py.dict_setItem %[[DICT]][%[[STR]] hash(%[[HASH]])] to %[[T]]
+# CHECK: py.dict_setItem %{{.*}}[%[[STR]] hash(%[[HASH]])] to %[[T]]
 t = pylir.intr.typeOf(foo)
 
 # CHECK: %[[ZERO:.*]] = py.constant(#py.int<0>)

--- a/test/CodeGenNew/locals-and-globals.py
+++ b/test/CodeGenNew/locals-and-globals.py
@@ -1,7 +1,6 @@
 # RUN: pylir %s -Xnew-codegen -emit-pylir -o - -S | FileCheck %s
 
 # CHECK-LABEL: init "__main__"
-# CHECK: %[[GLOBALS:.*]] = py.constant(#__main__$dict)
 # CHECK: %[[TEST1:.*]] = func "__main__.test1"
 def test1():
     # CHECK: %[[NESTED:.*]] = func "__main__.test1.<locals>.nested"
@@ -19,11 +18,11 @@ def test1():
 
 # CHECK: %[[STR:.*]] = py.constant(#py.str<"test1">)
 # CHECK: %[[HASH:.*]] = py.str_hash %[[STR]]
-# CHECK: py.dict_setItem %[[GLOBALS]][%[[STR]] hash(%[[HASH]])] to %[[TEST1]]
+# CHECK: py.dict_setItem %{{.*}}[%[[STR]] hash(%[[HASH]])] to %[[TEST1]]
 
 # CHECK: %[[STR:.*]] = py.constant(#py.str<"test1">)
 # CHECK: %[[HASH:.*]] = py.str_hash %[[STR]]
-# CHECK: %[[TEST1:.*]] = py.dict_tryGetItem %[[GLOBALS]][%[[STR]] hash(%[[HASH]])]
+# CHECK: %[[TEST1:.*]] = py.dict_tryGetItem %{{.*}}[%[[STR]] hash(%[[HASH]])]
 # CHECK: func "__main__.test2"(%{{.*}} "arg" = %[[TEST1]])
 
 def test2(arg=test1):

--- a/test/CodeGenNew/read-identifier-exceptions.py
+++ b/test/CodeGenNew/read-identifier-exceptions.py
@@ -4,7 +4,6 @@
 # CHECK-DAG: #[[$UNBOUND_LOCAL_ERROR:.*]] = #py.globalValue<builtins.UnboundLocalError{{>|,}}
 
 # CHECK-LABEL: init "__main__"
-# CHECK: %[[$GLOBALS:.*]] = py.constant(#__main__$dict)
 
 # CHECK-LABEL: func "__main__.foo"
 # CHECK-SAME: %[[A:[[:alnum:]]+]]
@@ -23,7 +22,7 @@ def foo(a):
 
 # CHECK: %[[STR:.*]] = py.constant(#py.str<"foo">)
 # CHECK: %[[HASH:.*]] = py.str_hash %[[STR]]
-# CHECK: %[[FOO:.*]] = py.dict_tryGetItem %[[$GLOBALS]][%[[STR]] hash(%[[HASH]])]
+# CHECK: %[[FOO:.*]] = py.dict_tryGetItem %{{.*}}[%[[STR]] hash(%[[HASH]])]
 # CHECK: %[[UNBOUND:.*]] = py.isUnboundValue %[[FOO]]
 # CHECK: cf.cond_br %[[UNBOUND]], ^[[BB1:.*]], ^[[BB2:[[:alnum:]]+]]
 


### PR DESCRIPTION
The current code incorrectly accessed the global dictionary through a `py.constant` referencing the global dictionary of the module. This causes issues within `globalFunc` as it does not have access to any SSA value defined within `init`.

This PR fixes that by simply creating a `py.constant` importing the global dictionary each time.