### PR TITLE
[CodeGenNew] Fix inheriting instance slots of `const_export` class

### DIFF
--- a/src/pylir/CodeGenNew/CodeGenNew.cpp
+++ b/src/pylir/CodeGenNew/CodeGenNew.cpp
@@ -912,7 +912,8 @@ private:
     SetVector<Attribute> instanceSlots;
     for (Attribute base : bases)
       if (auto interface = dyn_cast<Py::TypeAttrInterface>(base)) {
-        instanceSlots.insert(interface.getInstanceSlots());
+        Py::TupleAttrInterface slots = interface.getInstanceSlots();
+        instanceSlots.insert(slots.begin(), slots.end());
       }
 
     // Slots are the slots of this class due to being an instance of type.

--- a/test/CodeGenNew/builtins-instance-slots-error.py
+++ b/test/CodeGenNew/builtins-instance-slots-error.py
@@ -1,0 +1,3 @@
+# RUN: pylir %s -Xnew-codegen -emit-pylir -o - -S | FileCheck %s
+
+# CHECK-NOT: instance_slots = <(#py.tuple<(


### PR DESCRIPTION
The `instance_slots` were incorrectly being inherited by adding the tuple of the base class to the list of instance slots, rather than the elements of the tuple. This PR fixes that issue.