### PR TITLE
[PyHIR] Fix incorrect lowering of `initModule`

### DIFF
--- a/src/pylir/Optimizer/Conversion/PylirHIRToPylirPy/PylirHIRToPylirPy.cpp
+++ b/src/pylir/Optimizer/Conversion/PylirHIRToPylirPy/PylirHIRToPylirPy.cpp
@@ -579,8 +579,10 @@ struct InitModuleOpConversionPattern
 
   template <class OpT>
   LogicalResult matchAndRewrite(OpT op, ExceptionRewriter& rewriter) const {
-    rewriter.replaceOpWithNewOp<Py::CallOp>(
-        op, TypeRange(), (op.getModule() + ".__init__").str());
+    rewriter.create<Py::CallOp>(op.getLoc(),
+                                rewriter.getType<Py::DynamicType>(),
+                                (op.getModule() + ".__init__").str());
+    rewriter.eraseOp(op);
     return success();
   }
 };

--- a/test/Optimizer/Conversion/PylirHIRToPylirPy/init.mlir
+++ b/test/Optimizer/Conversion/PylirHIRToPylirPy/init.mlir
@@ -11,7 +11,7 @@ pyHIR.init "foo" {
 // CHECK-LABEL: py.func @__init__() -> !py.dynamic
 pyHIR.init "__main__" {
   %0 = py.makeDict ()
-  // CHECK: call @foo.__init__()
+  // CHECK: call @foo.__init__() : () -> !py.dynamic
   initModule @foo
   init_return %0
 }


### PR DESCRIPTION
The lowering of `initModule` cannot be further lowered to LLVM at the moment as it produces an incorrect `py.call` operation with no results despite the init function having a result type. This is not yet verifier in `py.call` but incorrect and will be fixed in a subsequent PR.