### PR TITLE
[Py] Verify result types of `py.call`

### DIFF
--- a/src/pylir/Optimizer/Conversion/PylirHIRToPylirPy/PylirHIRToPylirPy.cpp
+++ b/src/pylir/Optimizer/Conversion/PylirHIRToPylirPy/PylirHIRToPylirPy.cpp
@@ -579,8 +579,10 @@ struct InitModuleOpConversionPattern
 
   template <class OpT>
   LogicalResult matchAndRewrite(OpT op, ExceptionRewriter& rewriter) const {
-    rewriter.replaceOpWithNewOp<Py::CallOp>(
-        op, TypeRange(), (op.getModule() + ".__init__").str());
+    rewriter.create<Py::CallOp>(op.getLoc(),
+                                rewriter.getType<Py::DynamicType>(),
+                                (op.getModule() + ".__init__").str());
+    rewriter.eraseOp(op);
     return success();
   }
 };

--- a/test/Optimizer/Conversion/PylirHIRToPylirPy/init.mlir
+++ b/test/Optimizer/Conversion/PylirHIRToPylirPy/init.mlir
@@ -11,7 +11,7 @@ pyHIR.init "foo" {
 // CHECK-LABEL: py.func @__init__() -> !py.dynamic
 pyHIR.init "__main__" {
   %0 = py.makeDict ()
-  // CHECK: call @foo.__init__()
+  // CHECK: call @foo.__init__() : () -> !py.dynamic
   initModule @foo
   init_return %0
 }

--- a/test/Optimizer/PylirPy/IR/invalid.mlir
+++ b/test/Optimizer/PylirPy/IR/invalid.mlir
@@ -73,3 +73,13 @@ py.func @test() -> !py.dynamic {
   %0 = constant(#py.type<instance_slots = <(#py.int<5>)>>)
   return %0 : !py.dynamic
 }
+
+// -----
+
+py.func private @foo() -> !py.dynamic
+
+py.func @test() {
+  // expected-error@below {{call result types '' are not compatible with output types '!py.dynamic' of '@foo'}}
+  call @foo() : () -> ()
+  return
+}


### PR DESCRIPTION
The result types of `py.call` must match the ones of the callee. This is currently enforced by the lowering and the intention was to do the same for the operation itself.