### PR TITLE
[CodeGenNew] Fix definition of `NotImplemented`

### DIFF
--- a/src/pylir/CodeGenNew/CodeGenNew.cpp
+++ b/src/pylir/CodeGenNew/CodeGenNew.cpp
@@ -515,8 +515,8 @@ public:
 
       auto builtinNotImplemented =
           m_builder.getAttr<Py::GlobalValueAttr>(Builtins::NotImplemented.name);
-      builtinNone.setConstant(true);
-      builtinNone.setInitializer(m_builder.getAttr<Py::ObjectAttr>(
+      builtinNotImplemented.setConstant(true);
+      builtinNotImplemented.setInitializer(m_builder.getAttr<Py::ObjectAttr>(
           m_builder.getAttr<Py::GlobalValueAttr>(
               Builtins::NotImplementedType.name)));
 

--- a/test/CodeGenNew/builtins-namespace.py
+++ b/test/CodeGenNew/builtins-namespace.py
@@ -1,8 +1,8 @@
 # RUN: pylir %s -Xnew-codegen -emit-pylir -o - -S | FileCheck %s
 
 # CHECK-DAG: #[[$BASE_EXCEPTION:.*]] = #py.globalValue<builtins.BaseException{{(,|>)}}
-# CHECK-DAG: #[[$NONE:.*]] = #py.globalValue<builtins.None{{(,|>)}}
-# CHECK-DAG: #[[$NOT_IMPLEMENTED:.*]] = #py.globalValue<builtins.NotImplemented{{(,|>)}}
+# CHECK-DAG: #[[$NONE:.*]] = #py.globalValue<builtins.None,
+# CHECK-DAG: #[[$NOT_IMPLEMENTED:.*]] = #py.globalValue<builtins.NotImplemented,
 
 # CHECK: init "__main__"
 # CHECK: initModule @builtins


### PR DESCRIPTION
Due to a copy and paste error the `NotImplemented` type was exported but not defined. This PR properly defines `NotImplemented`