### PR TITLE
[CodeGenNew] Prevent infinite `bool` recursion

### DIFF
--- a/test/CodeGenNew/comparison.py
+++ b/test/CodeGenNew/comparison.py
@@ -39,7 +39,9 @@ def chaining(a, b, c):
     # CHECK: %[[BIN1:.*]] = binOp %[[CARG0]] __lt__ %[[CARG1]]
     # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
     # CHECK: %[[CALL:.*]] = call %[[BOOL]](%[[BIN1]])
-    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[CALL]]
+    # CHECK: cf.br ^[[IS_BOOL_BB:.*]](%[[CALL]] : !py.dynamic)
+    # CHECK: ^[[IS_BOOL_BB]](%[[BOOL:.*]]: !py.dynamic loc({{.*}})):
+    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[BOOL]]
     # CHECK: cf.cond_br %[[I1]], ^[[BB5:.*]], ^[[BB8:.*]](%[[BIN1]] : !py.dynamic)
 
     # CHECK: ^[[BB5]]:
@@ -60,7 +62,9 @@ def invert(a, b):
     # CHECK: %[[B:.*]] = py.bool_fromI1 %[[IS]]
     # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
     # CHECK: %[[CALL:.*]] = call %[[BOOL]](%[[B]])
-    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[CALL]]
+    # CHECK: cf.br ^[[IS_BOOL_BB:.*]](%[[CALL]] : !py.dynamic)
+    # CHECK: ^[[IS_BOOL_BB]](%[[BOOL:.*]]: !py.dynamic loc({{.*}})):
+    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[BOOL]]
     # CHECK: %[[TRUE:.*]] = arith.constant true
     # CHECK: %[[INV:.*]] = arith.xori %[[I1]], %[[TRUE]]
     # CHECK: %[[B:.*]] = py.bool_fromI1 %[[INV]]

--- a/test/CodeGenNew/conditionals.py
+++ b/test/CodeGenNew/conditionals.py
@@ -7,7 +7,9 @@
 # CHECK: %[[ZERO:.*]] = py.constant(#py.int<0>)
 # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
 # CHECK: %[[B:.*]] = call %[[BOOL]](%[[ZERO]])
-# CHECK: %[[I1:.*]] = py.bool_toI1 %[[B]]
+# CHECK: cf.br ^[[IS_BOOL_BB:.*]](%[[B]] : !py.dynamic)
+# CHECK: ^[[IS_BOOL_BB]](%[[BOOL:.*]]: !py.dynamic loc({{.*}})):
+# CHECK: %[[I1:.*]] = py.bool_toI1 %[[BOOL]]
 # CHECK: cf.cond_br %[[I1]], ^[[BB1:.*]], ^[[BB2:[[:alnum:]]+]]
 
 # CHECK: ^[[BB1]]:

--- a/test/CodeGenNew/ifs.py
+++ b/test/CodeGenNew/ifs.py
@@ -5,8 +5,16 @@
 # CHECK-LABEL: init "__main__"
 
 # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
-# CHECK: %[[B:.*]] = call %[[BOOL]](%{{.*}})
-# CHECK: %[[I1:.*]] = py.bool_toI1 %[[B]]
+# CHECK: %[[TYPE_OF:.*]] = py.typeOf %[[VALUE:[[:alnum:]]+]]
+# CHECK: %[[COND:.*]] = py.is %[[TYPE_OF]], %[[BOOL]]
+# CHECK: cf.cond_br %[[COND]], ^[[IS_BOOL_BB:.*]](%[[VALUE]] : !py.dynamic), ^[[IS_NOT_BOOL:[[:alnum:]]+]]
+
+# CHECK: ^[[IS_NOT_BOOL]]:
+# CHECK: %[[B:.*]] = call %[[BOOL]](%[[VALUE]])
+# CHECK: cf.br ^[[IS_BOOL_BB:.*]](%[[B]] : !py.dynamic)
+
+# CHECK: ^[[IS_BOOL_BB]](%[[BOOL:.*]]: !py.dynamic loc({{.*}})):
+# CHECK: %[[I1:.*]] = py.bool_toI1 %[[BOOL]]
 # CHECK: cf.cond_br %[[I1]], ^[[BB1:.*]], ^[[BB2:[[:alnum:]]+]]
 if 0:
     # CHECK: ^[[BB1]]:
@@ -20,7 +28,9 @@ if 0:
 # CHECK: ^[[BB3]]:
 # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
 # CHECK: %[[B:.*]] = call %[[BOOL]](%{{.*}})
-# CHECK: %[[I1:.*]] = py.bool_toI1 %[[B]]
+# CHECK: cf.br ^[[IS_BOOL_BB:.*]](%[[B]] : !py.dynamic)
+# CHECK: ^[[IS_BOOL_BB]](%[[BOOL:.*]]: !py.dynamic loc({{.*}})):
+# CHECK: %[[I1:.*]] = py.bool_toI1 %[[BOOL]]
 # CHECK: cf.cond_br %[[I1]], ^[[BB4:.*]], ^[[BB5:[[:alnum:]]+]]
 if 0:
     # CHECK: ^[[BB4]]:
@@ -36,7 +46,9 @@ else:
 # CHECK: ^[[BB6]]:
 # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
 # CHECK: %[[B:.*]] = call %[[BOOL]](%{{.*}})
-# CHECK: %[[I1:.*]] = py.bool_toI1 %[[B]]
+# CHECK: cf.br ^[[IS_BOOL_BB:.*]](%[[B]] : !py.dynamic)
+# CHECK: ^[[IS_BOOL_BB]](%[[BOOL:.*]]: !py.dynamic loc({{.*}})):
+# CHECK: %[[I1:.*]] = py.bool_toI1 %[[BOOL]]
 # CHECK: cf.cond_br %[[I1]], ^[[BB7:.*]], ^[[BB8:[[:alnum:]]+]]
 if 0:
     # CHECK: ^[[BB7]]:
@@ -47,7 +59,9 @@ if 0:
     # CHECK: ^[[BB8]]:
     # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
     # CHECK: %[[B:.*]] = call %[[BOOL]](%{{.*}})
-    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[B]]
+    # CHECK: cf.br ^[[IS_BOOL_BB:.*]](%[[B]] : !py.dynamic)
+    # CHECK: ^[[IS_BOOL_BB]](%[[BOOL:.*]]: !py.dynamic loc({{.*}})):
+    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[BOOL]]
     # CHECK: cf.cond_br %[[I1]], ^[[BB9:.*]], ^[[BB10:[[:alnum:]]+]]
 elif 1:
     # CHECK: ^[[BB9]]:
@@ -63,7 +77,9 @@ else:
 # CHECK: ^[[BB11]]:
 # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
 # CHECK: %[[B:.*]] = call %[[BOOL]](%{{.*}})
-# CHECK: %[[I1:.*]] = py.bool_toI1 %[[B]]
+# CHECK: cf.br ^[[IS_BOOL_BB:.*]](%[[B]] : !py.dynamic)
+# CHECK: ^[[IS_BOOL_BB]](%[[BOOL:.*]]: !py.dynamic loc({{.*}})):
+# CHECK: %[[I1:.*]] = py.bool_toI1 %[[BOOL]]
 # CHECK: cf.cond_br %[[I1]], ^[[BB12:.*]], ^[[BB13:[[:alnum:]]+]]
 if 0:
     # CHECK: ^[[BB12]]:
@@ -74,7 +90,9 @@ if 0:
     # CHECK: ^[[BB13]]:
     # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
     # CHECK: %[[B:.*]] = call %[[BOOL]](%{{.*}})
-    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[B]]
+    # CHECK: cf.br ^[[IS_BOOL_BB:.*]](%[[B]] : !py.dynamic)
+    # CHECK: ^[[IS_BOOL_BB]](%[[BOOL:.*]]: !py.dynamic loc({{.*}})):
+    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[BOOL]]
     # CHECK: cf.cond_br %[[I1]], ^[[BB14:.*]], ^[[BB15:[[:alnum:]]+]]
 elif 1:
     # CHECK: ^[[BB14]]:

--- a/test/CodeGenNew/operators.py
+++ b/test/CodeGenNew/operators.py
@@ -47,14 +47,18 @@ def boolean_ops(a, b):
     # CHECK: %[[A_CALL:.*]] = call %[[A]]()
     # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
     # CHECK: %[[TO_BOOL:.*]] = call %[[BOOL]](%[[A_CALL]])
-    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[TO_BOOL]]
+    # CHECK: cf.br ^[[IS_BOOL_BB:.*]](%[[TO_BOOL]] : !py.dynamic)
+    # CHECK: ^[[IS_BOOL_BB]](%[[BOOL:.*]]: !py.dynamic loc({{.*}})):
+    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[BOOL]]
     # CHECK: cf.cond_br %[[I1]], ^[[BB1:.*]], ^[[BB2:.*]](%[[I1]] : i1)
 
     # CHECK: ^[[BB1]]:
     # CHECK: %[[B_CALL:.*]] = call %[[B]]()
     # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
     # CHECK: %[[TO_BOOL:.*]] = call %[[BOOL]](%[[B_CALL]])
-    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[TO_BOOL]]
+    # CHECK: cf.br ^[[IS_BOOL_BB:.*]](%[[TO_BOOL]] : !py.dynamic)
+    # CHECK: ^[[IS_BOOL_BB]](%[[BOOL:.*]]: !py.dynamic loc({{.*}})):
+    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[BOOL]]
     # CHECK: cf.br ^[[BB2]](%[[I1]] : i1)
 
     # CHECK: ^[[BB2]](%[[RES:.*]]: i1 loc({{.*}})):
@@ -64,14 +68,18 @@ def boolean_ops(a, b):
     # CHECK: %[[A_CALL:.*]] = call %[[A]]()
     # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
     # CHECK: %[[TO_BOOL:.*]] = call %[[BOOL]](%[[A_CALL]])
-    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[TO_BOOL]]
+    # CHECK: cf.br ^[[IS_BOOL_BB:.*]](%[[TO_BOOL]] : !py.dynamic)
+    # CHECK: ^[[IS_BOOL_BB]](%[[BOOL:.*]]: !py.dynamic loc({{.*}})):
+    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[BOOL]]
     # CHECK: cf.cond_br %[[I1]], ^[[BB4:.*]](%[[I1]] : i1), ^[[BB3:[[:alnum:]]+]]
 
     # CHECK: ^[[BB3]]:
     # CHECK: %[[B_CALL:.*]] = call %[[B]]()
     # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
     # CHECK: %[[TO_BOOL:.*]] = call %[[BOOL]](%[[B_CALL]])
-    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[TO_BOOL]]
+    # CHECK: cf.br ^[[IS_BOOL_BB:.*]](%[[TO_BOOL]] : !py.dynamic)
+    # CHECK: ^[[IS_BOOL_BB]](%[[BOOL:.*]]: !py.dynamic loc({{.*}})):
+    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[BOOL]]
     # CHECK: cf.br ^[[BB4]](%[[I1]] : i1)
 
     # CHECK: ^[[BB4]](%[[RES:.*]]: i1 loc({{.*}})):
@@ -81,7 +89,9 @@ def boolean_ops(a, b):
     # CHECK: %[[A_CALL:.*]] = call %[[A]]()
     # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
     # CHECK: %[[TO_BOOL:.*]] = call %[[BOOL]](%[[A_CALL]])
-    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[TO_BOOL]]
+    # CHECK: cf.br ^[[IS_BOOL_BB:.*]](%[[TO_BOOL]] : !py.dynamic)
+    # CHECK: ^[[IS_BOOL_BB]](%[[BOOL:.*]]: !py.dynamic loc({{.*}})):
+    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[BOOL]]
     # CHECK: %[[TRUE:.*]] = arith.constant true
     # CHECK: %[[NOT:.*]] = arith.xori %[[I1]], %[[TRUE]]
     # CHECK: py.bool_fromI1 %[[NOT]]

--- a/test/CodeGenNew/while.py
+++ b/test/CodeGenNew/while.py
@@ -8,7 +8,9 @@
 # CHECK: ^[[COND]]:
 # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
 # CHECK: %[[B:.*]] = call %[[BOOL]](%{{.*}})
-# CHECK: %[[I1:.*]] = py.bool_toI1 %[[B]]
+# CHECK: cf.br ^[[IS_BOOL_BB:.*]](%[[B]] : !py.dynamic)
+# CHECK: ^[[IS_BOOL_BB]](%[[BOOL:.*]]: !py.dynamic loc({{.*}})):
+# CHECK: %[[I1:.*]] = py.bool_toI1 %[[BOOL]]
 # CHECK: cf.cond_br %[[I1]], ^[[BODY:.*]], ^[[ELSE:[[:alnum:]]+]]
 while True:
     # CHECK: ^[[BODY]]:
@@ -31,7 +33,9 @@ def foo(a):
     # CHECK: ^[[COND]](%[[A:[[:alnum:]]+]]: !py.dynamic {{.*}}):
     # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
     # CHECK: %[[B:.*]] = call %[[BOOL]](%{{.*}})
-    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[B]]
+    # CHECK: cf.br ^[[IS_BOOL_BB:.*]](%[[B]] : !py.dynamic)
+    # CHECK: ^[[IS_BOOL_BB]](%[[BOOL:.*]]: !py.dynamic loc({{.*}})):
+    # CHECK: %[[I1:.*]] = py.bool_toI1 %[[BOOL]]
     # CHECK: cf.cond_br %[[I1]], ^[[BODY:.*]], ^[[ELSE:[[:alnum:]]+]]
     while False:
         # CHECK: ^[[BODY]]:
@@ -51,7 +55,9 @@ def foo(a):
 # CHECK: ^[[COND]]:
 # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
 # CHECK: %[[B:.*]] = call %[[BOOL]](%{{.*}})
-# CHECK: %[[I1:.*]] = py.bool_toI1 %[[B]]
+# CHECK: cf.br ^[[IS_BOOL_BB:.*]](%[[B]] : !py.dynamic)
+# CHECK: ^[[IS_BOOL_BB]](%[[BOOL:.*]]: !py.dynamic loc({{.*}})):
+# CHECK: %[[I1:.*]] = py.bool_toI1 %[[BOOL]]
 # CHECK: cf.cond_br %[[I1]], ^[[BODY:.*]], ^[[ELSE:[[:alnum:]]+]]
 while True:
     # CHECK: ^[[BODY]]:
@@ -66,7 +72,9 @@ while True:
 # CHECK: ^[[COND]]:
 # CHECK: %[[BOOL:.*]] = py.constant(#[[$BOOL]])
 # CHECK: %[[B:.*]] = call %[[BOOL]](%{{.*}})
-# CHECK: %[[I1:.*]] = py.bool_toI1 %[[B]]
+# CHECK: cf.br ^[[IS_BOOL_BB:.*]](%[[B]] : !py.dynamic)
+# CHECK: ^[[IS_BOOL_BB]](%[[BOOL:.*]]: !py.dynamic loc({{.*}})):
+# CHECK: %[[I1:.*]] = py.bool_toI1 %[[BOOL]]
 # CHECK: cf.cond_br %[[I1]], ^[[BODY:.*]], ^[[ELSE:[[:alnum:]]+]]
 while True:
     # CHECK: ^[[BODY]]:


### PR DESCRIPTION
Any "truthy" evaluation in python unconditionally calls the `bool` constructor in `CodeGenNew`. This is problematic as the implementation of `bool` may also use `if` statements and similar, triggering "truthy" evaluation and therefore an infinite recursion.

Fix this in the same way as in `CodeGen` by creating checks whether the value being evaluated is already a `bool`, only calling `bool` if this is not the case. The only con of this approach is higher complexity in output-ir and potentially larger code-size. A future change may restrict this kind of code-generation to only the builtin module.