### PR TITLE
[CodeGenNew] Fix incomplete MRO tuple

### DIFF
--- a/test/CodeGenNew/const-export-class.py
+++ b/test/CodeGenNew/const-export-class.py
@@ -1,10 +1,10 @@
-# RUN: pylir %s -Xnew-codegen -emit-pylir -o - -S | FileCheck %s
+# RUN: pylir %s -Xnew-codegen -emit-pylir -Xno-builtins -o - -S | FileCheck %s
 
 # CHECK: #[[$MAIN_SEQ_ITER_INIT:.*]] = #py.globalValue<__main__.SeqIter.__init__,
 # CHECK: #[[$MAIN_SEQ_ITER:.*]] = #py.globalValue<__main__.SeqIter,
 # CHECK-SAME: const
 # CHECK-SAME: initializer = #py.type<
-# CHECK-SAME: mro_tuple = #py.tuple<(#py.globalValue<__main__.SeqIter>)>
+# CHECK-SAME: mro_tuple = #py.tuple<(#py.globalValue<__main__.SeqIter>, #py.globalValue<builtins.object>)>
 # CHECK-SAME: instance_slots = <(#py.str<"__seq">, #py.str<"__i">)>
 # CHECK-SAME: slots = {__init__ = #py.globalValue<__main__.SeqIter.__init__,
 # CHECK-SAME:          __name__ = #py.str<"SeqIter">}


### PR DESCRIPTION
The MRO tuple must be complete i.e. contain every transitive base class of the original class. Failing to do so leads to failures during MRO lookup.

This PR fixes that property for `const_export` classes by inserting the MRO tuple of any base class as well.