### PR TITLE
[Py][CodeGenNew] Add `raiseEx` op for more uniform exception handling

### DIFF
--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyOps.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyOps.td
@@ -1395,7 +1395,8 @@ def PylirPy_UnreachableOp : PylirPy_Op<"unreachable", [Terminator]> {
   let assemblyFormat = "attr-dict";
 }
 
-def PylirPy_RaiseOp : PylirPy_Op<"raise", [Terminator]> {
+def PylirPy_RaiseOp : PylirPy_Op<"raise", [Terminator,
+  AddableExceptionHandling<"RaiseExOp">]> {
   let summary = "raise exception";
 
   let arguments = (ins DynamicType:$exception);
@@ -1405,5 +1406,7 @@ def PylirPy_RaiseOp : PylirPy_Op<"raise", [Terminator]> {
     $exception attr-dict
   }];
 }
+
+def PylirPy_RaiseExOp : CreateExceptionHandlingVariant<PylirPy_RaiseOp>;
 
 #endif

--- a/test/CodeGenNew/raise.py
+++ b/test/CodeGenNew/raise.py
@@ -18,3 +18,10 @@
 # CHECK: ^[[BB2]](%[[EXC:.*]]: !py.dynamic loc({{.*}})):
 # CHECK: py.raise %[[EXC]]
 raise TypeError
+
+try:
+    # CHECK: py.raiseEx %{{.*}}
+    # CHECK-NEXT: label ^{{.*}} unwind ^{{.*}}
+    raise NameError
+except NameError:
+    pass

--- a/test/Optimizer/Conversion/PylirToLLVM/raiseExOp.mlir
+++ b/test/Optimizer/Conversion/PylirToLLVM/raiseExOp.mlir
@@ -1,0 +1,17 @@
+// RUN: pylir-opt %s -convert-pylir-to-llvm --split-input-file | FileCheck %s
+
+// CHECK-LABEL: func @test
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+py.func @test(%arg0 : !py.dynamic, %arg1 : !py.dynamic) -> !py.dynamic {
+  // CHECK: br ^[[BB:.*]](%[[ARG0]], %[[ARG1]] : !{{.*}}, !{{.*}})
+  raiseEx %arg0
+    label ^bb1 unwind ^bb2(%arg1 : !py.dynamic)
+^bb1:
+  unreachable
+
+// CHECK: ^[[BB]](%[[E:.*]]: !{{.*}}, %{{.*}}: !{{.*}}):
+^bb2(%e: !py.dynamic, %arg2 : !py.dynamic):
+  // CHECK: return %[[E]]
+  return %e : !py.dynamic
+}

--- a/test/Optimizer/PylirPy/IR/inliner-interface.mlir
+++ b/test/Optimizer/PylirPy/IR/inliner-interface.mlir
@@ -45,9 +45,9 @@ py.func @__init__() -> !py.dynamic {
 // CHECK-NEXT: ^[[SUCCESS]]
 // CHECK-NEXT: cf.cond_br %[[RANDOM]], ^[[THROW:.*]], ^[[CONTINUE:[[:alnum:]]+]]
 // CHECK-NEXT: ^[[THROW]]:
-// CHECK-NEXT: cf.br ^[[HANDLER:.*]](
-// CHECK-SAME: %[[EX]]
-// CHECK-NEXT: ^[[CONTINUE]]
+// CHECK-NEXT: raiseEx %[[EX]]
+// CHECK-NEXT: unwind ^[[HANDLER:[[:alnum:]]+]]
+// CHECK: ^[[CONTINUE]]:
 // CHECK-NEXT: cf.br ^[[CONTINUE:.*]](
 // CHECK-SAME: %[[EX]]
 // CHECK-NEXT: ^[[CONTINUE]]
@@ -109,9 +109,9 @@ py.func @__init__() -> !py.dynamic {
 // CHECK-NEXT: ^[[SUCCESS]]
 // CHECK-NEXT: cf.cond_br %[[RANDOM]], ^[[THROW:.*]], ^[[CONTINUE:[[:alnum:]]+]]
 // CHECK-NEXT: ^[[THROW]]:
-// CHECK-NEXT: cf.br ^[[HANDLER:.*]](
-// CHECK-SAME: %[[EX]]
-// CHECK-NEXT: ^[[CONTINUE]]
+// CHECK-NEXT: raiseEx %[[EX]]
+// CHECK-NEXT: unwind ^[[HANDLER:.*]]
+// CHECK: ^[[CONTINUE]]:
 // CHECK-NEXT: cf.br ^[[CONTINUE:.*]](
 // CHECK-SAME: %[[EX]]
 // CHECK-NEXT: ^[[CONTINUE]]


### PR DESCRIPTION
The aim of having this op is to make exception handling more uniform and allow creating `raise` ops that jump to an exception handler within the same function. Some code had to be adjusted as they were making assumptions about the operation that exception handling is being added to, not being a terminator.

A redesign of the `cloneWithExceptionHandling` API should be done in the future to make these differences (terminator vs non-terminator op) more transparent.