### PR TITLE
[CodeGenNew] Implement lambda expressions

### DIFF
--- a/src/pylir/CodeGenNew/CodeGenNew.cpp
+++ b/src/pylir/CodeGenNew/CodeGenNew.cpp
@@ -1608,9 +1608,11 @@ private:
     return create<Py::ConstantOp>(m_builder.getAttr<Py::UnboundAttr>());
   }
 
-  mlir::Value visitImpl([[maybe_unused]] const Syntax::Lambda& lambda) {
-    // TODO:
-    PYLIR_UNREACHABLE;
+  Value visitImpl(const Syntax::Lambda& lambda) {
+    return visitFunction({}, lambda.parameters, "<lambda>", lambda.scope, [&] {
+      create<HIR::ReturnOp>(visit(lambda.expression));
+      m_builder.clearInsertionPoint();
+    });
   }
 
   mlir::Value visitImpl([[maybe_unused]] const Syntax::Generator& generator) {

--- a/test/CodeGenNew/lambda.py
+++ b/test/CodeGenNew/lambda.py
@@ -1,0 +1,9 @@
+# RUN: pylir %s -Xnew-codegen -emit-pylir -o - -S | FileCheck %s
+
+# CHECK-LABEL: init "__main__"
+# CHECK-DAG: %[[THREE:.*]] = py.constant(#py.int<3>)
+# CHECK-DAG: %[[ONE:.*]] = py.constant(#py.int<1>)
+# CHECK: func "__main__.<lambda>"(%[[ARG0:.*]] "a" = %[[THREE]], %[[ARG1:.*]] only "c" = %[[ONE]]) {
+# CHECK: %[[RET:.*]] = binOp %[[ARG0]] __add__ %[[ARG1]]
+# CHECK: return %[[RET]]
+l = lambda a=3, *, c=1: a + c


### PR DESCRIPTION
Lambda expressions are just anonymous function definitions consisting of an expression. The implementation can reuse the `visitFunction` defined previously to implement them.