### PR TITLE
[PyHIR] Improve builder API for functions

### DIFF
--- a/src/pylir/CodeGenNew/CodeGenNew.cpp
+++ b/src/pylir/CodeGenNew/CodeGenNew.cpp
@@ -574,7 +574,9 @@ private:
         specs.emplace_back(m_builder.getStringAttr(iter.name.getValue()),
                            visit(iter.maybeDefault));
         break;
-      case Syntax::Parameter::PosOnly: specs.emplace_back(); break;
+      case Syntax::Parameter::PosOnly:
+        specs.emplace_back(visit(iter.maybeDefault));
+        break;
       case Syntax::Parameter::KeywordOnly:
         specs.emplace_back(m_builder.getStringAttr(iter.name.getValue()),
                            visit(iter.maybeDefault), true);

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.hpp
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.hpp
@@ -127,48 +127,81 @@ public:
   explicit FunctionParameterRange(FunctionInterface function);
 };
 
-/// Struct used to build functions in the pyHIR dialect.
+/// Class used to specify the parameters of a function in the pyHIR dialect.
 class FunctionParameterSpec {
   mlir::StringAttr m_name;
   mlir::Value m_defaultValue;
   bool m_isPosRest = false;
   bool m_isKeywordRest = false;
   bool m_isKeywordOnly = false;
+  mlir::DictionaryAttr m_parameterAttributes;
 
 public:
   struct PosRest {};
   struct KeywordRest {};
 
-  FunctionParameterSpec() = default;
+  /// Creates a parameter spec for a positional-only parameter with potentially
+  /// a default argument.
+  explicit FunctionParameterSpec(mlir::Value maybeDefaultValue = nullptr)
+      : m_defaultValue(maybeDefaultValue) {}
 
+  /// Creates a parameter spec for a named parameter with potentially a default
+  /// argument. The parameter is a keyword-only parameter if 'keywordOnly' is
+  /// true.
   explicit FunctionParameterSpec(mlir::StringAttr name,
-                                 mlir::Value defaultValue,
+                                 mlir::Value maybeDefaultValue,
                                  bool keywordOnly = false)
-      : m_name(name), m_defaultValue(defaultValue),
+      : m_name(name), m_defaultValue(maybeDefaultValue),
         m_isKeywordOnly(keywordOnly) {}
 
+  /// Creates a parameter receiving all leftover positional arguments.
   explicit FunctionParameterSpec(PosRest) : m_isPosRest(true) {}
 
+  /// Creates a parameter receiving all leftover keyword arguments.
   explicit FunctionParameterSpec(KeywordRest) : m_isKeywordRest(true) {}
 
+  /// Creates a parameter spec from an existing function parameter.
+  explicit FunctionParameterSpec(const FunctionParameter& functionParameter);
+
+  /// Returns the name of the parameter or null if it is a positional-only
+  /// parameter.
   mlir::StringAttr getName() const {
     return m_name;
   }
 
+  /// Returns the default value or null if it has no default value.
   mlir::Value getDefaultValue() const {
     return m_defaultValue;
   }
 
+  /// Returns true if this parameter is positional-only.
+  bool isPosOnly() const {
+    return m_name != nullptr;
+  }
+
+  /// Returns true if this parameter receives all leftover positional arguments.
   bool isPosRest() const {
     return m_isPosRest;
   }
 
+  /// Returns true if this parameter receives all leftover keyword arguments.
   bool isKeywordRest() const {
     return m_isKeywordRest;
   }
 
+  /// Returns true if this parameter can only be called as keyword argument.
   bool isKeywordOnly() const {
     return m_isKeywordOnly;
+  }
+
+  /// Returns the attributes of this parameter.
+  mlir::DictionaryAttr getParameterAttributes() const {
+    return m_parameterAttributes;
+  }
+
+  /// Sets the attributes of this parameter.
+  void setParameterAttributes(mlir::DictionaryAttr parameterAttributes) {
+    m_parameterAttributes = parameterAttributes;
   }
 };
 

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
@@ -273,7 +273,8 @@ def PylirHIR_GlobalFuncOp : PylirHIR_Op<"globalFunc",
 
   let builders = [
     OpBuilder<(ins "llvm::Twine":$symbolName,
-                   "llvm::ArrayRef<FunctionParameterSpec>":$parameters)>
+                   "llvm::ArrayRef<FunctionParameterSpec>":$parameters,
+                   CArg<"mlir::ArrayAttr", "nullptr">:$resAttrs)>
   ];
 
   let description = [{

--- a/src/pylir/Optimizer/PylirHIR/Transforms/FuncOutlining.cpp
+++ b/src/pylir/Optimizer/PylirHIR/Transforms/FuncOutlining.cpp
@@ -44,14 +44,11 @@ void FuncOutlining::runOnOperation() {
       getOperation()->walk<WalkOrder::PostOrder>([&](HIR::FuncOp funcOp) {
         OpBuilder builder(funcOp);
 
+        auto parameters = llvm::to_vector_of<HIR::FunctionParameterSpec>(
+            HIR::FunctionParameterRange(funcOp));
         auto globalFunc = moduleBuilder.create<HIR::GlobalFuncOp>(
-            funcOp.getLoc(), funcOp.getName(),
-            funcOp.getDefaultValuesMappingAttr(), funcOp.getFunctionType(),
-            funcOp.getArgAttrsAttr(), funcOp.getResAttrsAttr(),
-            funcOp.getParameterNamesAttr(),
-            funcOp.getParameterNameMappingAttr(),
-            funcOp.getKeywordOnlyMappingAttr(), funcOp.getPosRestAttr(),
-            funcOp.getKeywordRestAttr());
+            funcOp.getLoc(), funcOp.getName(), parameters,
+            funcOp.getResAttrsAttr());
         // Rename the operation if necessary.
         symbolTable.insert(globalFunc);
 

--- a/test/CodeGenNew/functions.py
+++ b/test/CodeGenNew/functions.py
@@ -15,6 +15,7 @@ def test1():
 def test2(arg, arg2, /):
     def nested():
         pass
+
     pass
 
 
@@ -36,4 +37,11 @@ def test4(*, arg, arg2):
 def test5(arg, arg2, **m):
     pass
 
+
 # CHECK: func "__main__.test5"(%{{.*}} "arg", %{{.*}} "arg2", **%{{.*}})
+
+def test6(arg=3, /):
+    pass
+
+# CHECK: %[[THREE:.*]] = py.constant(#py.int<3>)
+# CHECK: func "__main__.test6"(%{{.*}} = %[[THREE]])

--- a/test/Optimizer/PylirHIR/Transform/FuncOutlining.mlir
+++ b/test/Optimizer/PylirHIR/Transform/FuncOutlining.mlir
@@ -57,3 +57,18 @@ pyHIR.init "func_collision" {
 
 // CHECK: globalFunc @[[$BASIC1]](
 // CHECK: globalFunc @[[$BASIC2]](
+
+// -----
+
+// CHECK-LABEL: init "arg_res_attrs"
+pyHIR.init "arg_res_attrs" {
+  // CHECK: py.makeFunc @[[$BASIC1:.*]]
+  %0 = func "basic"(%ff0 "rest" { test.name = 0 : i32 }) -> {test.name = 1 : i32} {
+    return %ff0
+  }
+  init_return %0
+}
+
+// CHECK: globalFunc @[[$BASIC1]](
+// CHECK-SAME: "rest" {test.name = 0 : i32}
+// CHECK-SAME: -> {test.name = 1 : i32}


### PR DESCRIPTION
The `FunctionParameterSpec` class was previously not well documented and insufficient for some purposes. This PR documents and adds missing features to it such as a dictionary of argument attributes or constructing it from a `FunctionParameter`. This simplifies some code and fixes some other bugs along the way.