### PR TITLE
[PyHIR] Add required closure parameter to `globalFunc`

### DIFF
--- a/src/pylir/CodeGenNew/CodeGenNew.cpp
+++ b/src/pylir/CodeGenNew/CodeGenNew.cpp
@@ -625,7 +625,9 @@ private:
     }
 
     // Initialize the parameters by initializing them with the arguments.
-    for (auto&& [param, arg] : llvm::zip(parameterList, region.getArguments()))
+    for (auto&& [param, arg] :
+         llvm::zip_equal(parameterList,
+                         region.getArguments().take_back(parameterList.size())))
       writeToIdentifier(arg, param.name.getValue());
 
     emitFunctionBody();

--- a/src/pylir/Optimizer/Conversion/PylirHIRToPylirPy/PylirHIRToPylirPy.cpp
+++ b/src/pylir/Optimizer/Conversion/PylirHIRToPylirPy/PylirHIRToPylirPy.cpp
@@ -380,9 +380,9 @@ Py::FuncOp buildFunctionCC(OpBuilder& builder, GlobalFuncOp implementation,
   std::size_t positionalDefaultArgsSeen = 0;
   std::optional<std::size_t> positionalRestArgsPos;
   std::optional<std::size_t> kwRestArgsPos;
-  SmallVector<Value> callArguments;
+  SmallVector<Value> callArguments{closure};
   for (HIR::FunctionParameter parameter :
-       HIR::FunctionParameterRange(implementation)) {
+       HIR::FunctionParameterRange(implementation).drop_front()) {
     // There can only be one rest-parameter of each kind. These will be set
     // at the end after all other parameters are converted. The index in the
     // call parameter array with a null-placeholder are set here already.

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.hpp
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.hpp
@@ -125,6 +125,8 @@ class FunctionParameterRange
 public:
   /// Constructor for any function implementing HIR::FunctionInterface.
   explicit FunctionParameterRange(FunctionInterface function);
+
+  using Base::Base;
 };
 
 /// Class used to specify the parameters of a function in the pyHIR dialect.

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
@@ -282,6 +282,11 @@ def PylirHIR_GlobalFuncOp : PylirHIR_Op<"globalFunc",
     Op representing a function in global scope with no use of non-local
     variables or similar.
     This is meant as a more restrictive and more optimized form of `pyHIR.func`.
+    Unlike `pyHIR.func`, `pyHIR.globalFunc` must have a first parameter which
+    acts as the closure parameter used to implement non-local variables after
+    outlining.
+    It may not have a default parameter nor a keyword with which it can be
+    called.
 
     Syntax:
     ```
@@ -292,6 +297,10 @@ def PylirHIR_GlobalFuncOp : PylirHIR_Op<"globalFunc",
   }];
 
   let extraClassDeclaration = [{
+
+    mlir::Value getClosureParameter() {
+      return getBody().getArguments().front();
+    }
 
     //===------------------------------------------------------------------===//
     // FunctionOpInterface implementation
@@ -313,6 +322,11 @@ def PylirHIR_GlobalFuncOp : PylirHIR_Op<"globalFunc",
 
     static llvm::StringRef getDefaultDialect() {
       return pylir::HIR::PylirHIRDialect::getDialectNamespace();
+    }
+
+    void getAsmBlockArgumentNames(mlir::Region& region,
+                                  mlir::OpAsmSetValueNameFn setNameFn) {
+      setNameFn(getClosureParameter(), "closure");
     }
 
     //===------------------------------------------------------------------===//

--- a/src/pylir/Optimizer/PylirHIR/Transforms/FuncOutlining.cpp
+++ b/src/pylir/Optimizer/PylirHIR/Transforms/FuncOutlining.cpp
@@ -137,6 +137,9 @@ void FuncOutlining::runOnOperation() {
             kwDefaults);
 
         globalFunc.getBody().takeBody(funcOp.getBody());
+        // Add argument to entry block acting as the closure parameter.
+        globalFunc.getBody().insertArgument(
+            /*index=*/0u, builder.getType<Py::DynamicType>(), funcOp.getLoc());
         funcOp.replaceAllUsesWith(funcObject);
         funcOp->erase();
 

--- a/test/CodeGenNew/const-export-function.py
+++ b/test/CodeGenNew/const-export-function.py
@@ -14,7 +14,7 @@
 def foo(a=3, *, b=None):
     return a + b
 
-# CHECK: globalFunc @[[$MAIN_FOO_SYMBOL]](%[[ARG0:.*]] "a" has_default, %[[ARG1:.*]] only "b" has_default) {
+# CHECK: globalFunc @[[$MAIN_FOO_SYMBOL]](%{{[[:alnum:]]+}}, %[[ARG0:.*]] "a" has_default, %[[ARG1:.*]] only "b" has_default) {
 # CHECK: binOp %[[ARG0]] __add__ %[[ARG1]]
 
 # CHECK: py.external @__main__.foo, #[[$MAIN_FOO]]

--- a/test/Optimizer/Conversion/PylirHIRToPylirPy/globalFunc.mlir
+++ b/test/Optimizer/Conversion/PylirHIRToPylirPy/globalFunc.mlir
@@ -1,6 +1,6 @@
 // RUN: pylir-opt %s --convert-pylirHIR-to-pylirPy --split-input-file | FileCheck %s
 
-pyHIR.globalFunc @basic(%arg0, %arg1 "first" has_default, *%arg2, %arg3 only "second" has_default, **%arg4) {
+pyHIR.globalFunc @basic(%closure, %arg0, %arg1 "first" has_default, *%arg2, %arg3 only "second" has_default, **%arg4) {
   return %arg0
 }
 
@@ -80,5 +80,5 @@ pyHIR.globalFunc @basic(%arg0, %arg1 "first" has_default, *%arg2, %arg3 only "se
 // CHECK: ^[[BB12]](%[[ARG3:.*]]: !py.dynamic):
 // CHECK: %[[TWO:.*]] = arith.constant 2
 // CHECK: %[[REST:.*]] = tuple_dropFront %[[TWO]], %[[TUPLE]]
-// CHECK: %[[RET:.*]] = call @basic$impl(%[[ARG0]], %[[ARG1]], %[[REST]], %[[ARG3]], %[[DICT]])
+// CHECK: %[[RET:.*]] = call @basic$impl(%[[CLOSURE]], %[[ARG0]], %[[ARG1]], %[[REST]], %[[ARG3]], %[[DICT]])
 // CHECK: return %[[RET]]

--- a/test/Optimizer/PylirHIR/IR/invalid.mlir
+++ b/test/Optimizer/PylirHIR/IR/invalid.mlir
@@ -50,3 +50,28 @@ pyHIR.init "__main__" {
   initModule @__main__
   init_return %0
 }
+
+// -----
+
+// expected-error@below {{expected at least one parameter (the closure parameter) to be present}}
+pyHIR.globalFunc @no_closure_param() {
+  %0 = py.constant(#py.int<3>)
+  return %0
+}
+
+
+// -----
+
+// expected-error@below {{closure parameter must be positional-only with no default}}
+pyHIR.globalFunc @wrong_closure_param_1(%closure "text") {
+  %0 = py.constant(#py.int<3>)
+  return %0
+}
+
+// -----
+
+// expected-error@below {{closure parameter must be positional-only with no default}}
+pyHIR.globalFunc @wrong_closure_param_2(%closure has_default) {
+  %0 = py.constant(#py.int<3>)
+  return %0
+}

--- a/test/Optimizer/PylirHIR/IR/roundtrip.mlir
+++ b/test/Optimizer/PylirHIR/IR/roundtrip.mlir
@@ -15,9 +15,9 @@ pyHIR.globalFunc @test(%arg0, *%arg1, %arg2 "keyword", %arg3 { test.name = 0 : i
   return %0
 }
 
-// CHECK-LABEL: pyHIR.globalFunc @res_attr()
+// CHECK-LABEL: pyHIR.globalFunc @res_attr(%{{[[:alnum:]]+}})
 // CHECK-SAME: -> {test.name = 0 : i32}
-pyHIR.globalFunc @res_attr() -> { test.name = 0 : i32 } {
+pyHIR.globalFunc @res_attr(%closure) -> { test.name = 0 : i32 } {
   %0 = func "foo"(%ff0 "rest") {
       return %ff0
   }
@@ -157,7 +157,7 @@ pyHIR.init "foo" {
 }
 
 // CHECK-LABEL: pyHIR.globalFunc @initModule(
-pyHIR.globalFunc @initModule() {
+pyHIR.globalFunc @initModule(%closure) {
   %0 = py.constant(#py.dict<{}>)
   // CHECK: initModule @foo
   initModule @foo

--- a/test/Optimizer/PylirHIR/Transform/FuncOutlining.mlir
+++ b/test/Optimizer/PylirHIR/Transform/FuncOutlining.mlir
@@ -37,8 +37,8 @@ pyHIR.globalFunc @posDefault(%arg0) {
   return %0
 }
 
-// CHECK: globalFunc @[[$BASIC]](%{{.*}} "rest") {
-// CHECK: globalFunc @[[$POS_DEFAULT_INNER]](%{{.*}} has_default, %{{.*}} only "lol" has_default) {
+// CHECK: globalFunc @[[$BASIC]](%{{[[:alnum:]]+}}, %{{[[:alnum:]]+}} "rest") {
+// CHECK: globalFunc @[[$POS_DEFAULT_INNER]](%{{[[:alnum:]]+}}, %{{[[:alnum:]]+}} has_default, %{{[[:alnum:]]+}} only "lol" has_default) {
 
 // -----
 


### PR DESCRIPTION
After outlining `globalFunc` must use the closure parameter to access any non-local variables that were previously implicitly captured by the `func`. The first step in implementing this is to add a closure parameter to `globalFunc` to which the python `function` will be passed. The lowering of `call` already performed the passing of the closure. Only the CC version had to be adjusted to pass the closure to the implementation.