### PR TITLE
[ci] Workaround newer Linux kernel version breaking sanitizers

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -87,6 +87,12 @@ runs:
         echo "Adding GNU tar to PATH"
         echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
 
+    - if: ${{ runner.os == 'Linux' && inputs.sanitizers != ''}}
+      name: Workaround ASLR interfering with sanitizers
+      shell: bash
+      # See https://github.com/actions/runner-images/issues/9491.
+      run: sudo sysctl vm.mmap_rnd_bits=28
+
     - name: Calculate ccache key
       id: ccache-key
       shell: pwsh


### PR DESCRIPTION
Due to ASLR consuming more bits than previously, sanitizers such as TSAN or ASAN that allocate large quantities of virtual memory stop working in newer linux kernel versions. Upstream LLVM only adjusted in versions 17 or after, breaking older clang versions.

See https://github.com/actions/runner-images/issues/9491