### PR TITLE
[ci] Fix pages deployment

### DIFF
--- a/.github/workflows/build-and-lint.yml
+++ b/.github/workflows/build-and-lint.yml
@@ -346,4 +346,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
We recently upgraded `upload-pages-artifact` to a version that is now incompatible with `deploy-pages`. This PR bumps the version of the latter to allow GitHub pages deployment again.