### PR TITLE
[Py] Add `py.function_closureArg`

### DIFF
--- a/src/pylir/Optimizer/Conversion/PylirPyToPylirMem/PylirPyToPylirMem.td
+++ b/src/pylir/Optimizer/Conversion/PylirPyToPylirMem/PylirPyToPylirMem.td
@@ -80,7 +80,7 @@ def : Pat<(PylirPy_IntToStrOp $integer),
 
 defvar FunctionRef = ConstantStrAttr<PylirPy_GlobalValueAttr, "builtins.function">;
 
-def : Pat<(PylirPy_MakeFuncOp $symbol),
+def : Pat<(PylirPy_MakeFuncOp $symbol, $closure_args),
   (PylirMem_InitFuncOp GCWithSlots<FunctionRef>.result, $symbol)>;
 
 defvar BoolRef = ConstantStrAttr<PylirPy_GlobalValueAttr, "builtins.bool">;

--- a/src/pylir/Optimizer/PylirHIR/Transforms/FuncOutlining.cpp
+++ b/src/pylir/Optimizer/PylirHIR/Transforms/FuncOutlining.cpp
@@ -73,7 +73,7 @@ void FuncOutlining::runOnOperation() {
 
         // TODO: Handle captured values.
         Value funcObject = builder.create<Py::MakeFuncOp>(
-            funcOp.getLoc(), FlatSymbolRefAttr::get(globalFunc));
+            funcOp.getLoc(), FlatSymbolRefAttr::get(globalFunc), ValueRange());
 
         builder.create<Py::SetSlotOp>(
             funcOp.getLoc(), funcObject,

--- a/src/pylir/Optimizer/PylirPy/IR/PyBuilder.hpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PyBuilder.hpp
@@ -408,7 +408,7 @@ public:
   }
 
   Py::MakeFuncOp createMakeFunc(mlir::FlatSymbolRefAttr function) {
-    return create<Py::MakeFuncOp>(function);
+    return create<Py::MakeFuncOp>(function, mlir::ValueRange());
   }
 
   Py::MakeObjectOp createMakeObject(mlir::Value typeObject) {

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyOps.cpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyOps.cpp
@@ -509,6 +509,22 @@ void pylir::Py::FunctionInvokeOp::setCalleeFromCallable(
 }
 
 //===----------------------------------------------------------------------===//
+// FunctionGetClosureArgOp implementations
+//===----------------------------------------------------------------------===//
+
+mlir::LogicalResult pylir::Py::FunctionGetClosureArgOp::inferReturnTypes(
+    mlir::MLIRContext*, std::optional<mlir::Location>, Adaptor adaptor,
+    llvm::SmallVectorImpl<mlir::Type>& inferredReturnTypes) {
+  if (adaptor.getIndex() >= adaptor.getClosureTypes().size())
+    return mlir::failure();
+
+  inferredReturnTypes.push_back(
+      llvm::cast<mlir::TypeAttr>(adaptor.getClosureTypes()[adaptor.getIndex()])
+          .getValue());
+  return mlir::success();
+}
+
+//===----------------------------------------------------------------------===//
 // UnpackOp implementations
 //===----------------------------------------------------------------------===//
 

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyOps.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyOps.td
@@ -727,14 +727,44 @@ def PylirPy_FunctionInvokeOp
 def PylirPy_MakeFuncOp : PylirPy_Op<"makeFunc", [AlwaysBound,
   KnownType<"Function">, DeclareOpInterfaceMethods<SymbolUserOpInterface>,
   DeclareOpInterfaceMethods<SROAAllocOpInterface>]> {
-  let arguments = (ins FlatSymbolRefAttr:$function);
+  let arguments = (ins FlatSymbolRefAttr:$function,
+                       Variadic<AnyType>:$closure_args);
+
+  let description = [{
+    Creates a new instance of a python function that refers to `function`.
+    `closure_args` are extra operands that are stored as part of the function
+    object and can only be read using `py.function_closureArg`, where the index
+    refers to the position within `closure_args`.
+  }];
 
   let results = (outs
     Res<DynamicType, "", [MemAlloc, MemWrite<ObjectResource>]>:$result);
 
   let assemblyFormat = [{
-    $function attr-dict
+    $function (`[` $closure_args^ `:` type($closure_args) `]`)? attr-dict
   }];
+}
+
+def PylirPy_FunctionGetClosureArgOp : PylirPy_Op<"function_closureArg",
+  [NoMemoryEffect, InferTypeOpAdaptor]> {
+  let arguments = (ins DynamicType:$function,
+                       I32Attr:$index,
+                       TypeArrayAttr:$closure_types);
+
+  let results = (outs AnyType:$result);
+
+  let description = [{
+    Returns the closure argument at the given index within `function`.
+    `function` must have been created with closure arguments whose types match
+    `closure_types` or whose type of closure arguments match up until and
+    including `index`.
+  }];
+
+  let assemblyFormat = [{
+    $function `[` $index `]` `:` $closure_types attr-dict
+  }];
+
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyVerifiers.cpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyVerifiers.cpp
@@ -139,8 +139,20 @@ LogicalResult Py::TypeAttr::verifyStructure(Operation* op,
 
 mlir::LogicalResult pylir::Py::MakeFuncOp::verifySymbolUses(
     ::mlir::SymbolTableCollection& symbolTable) {
-  return verifySymbolUse<mlir::FunctionOpInterface>(
-      *this, getFunctionAttr(), symbolTable, "FunctionOpInterface");
+  if (!symbolTable.lookupNearestSymbolFrom(*this, getFunctionAttr()))
+    return emitOpError("Failed to find symbol named '")
+           << getFunctionAttr() << "'";
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// FunctionGetClosureArgOp verification
+//===----------------------------------------------------------------------===//
+
+LogicalResult FunctionGetClosureArgOp::verify() {
+  if (getIndex() >= getClosureTypes().size())
+    return emitOpError("index '") << getIndex() << "' out of bounds";
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Optimizer/PylirPy/IR/invalid.mlir
+++ b/test/Optimizer/PylirPy/IR/invalid.mlir
@@ -83,3 +83,11 @@ py.func @test() {
   call @foo() : () -> ()
   return
 }
+
+// -----
+
+py.func @func_get_closure(%arg0 : !py.dynamic) -> i32 {
+  // expected-error@below {{index '2' out of bounds}}
+  %0 = "py.function_closureArg"(%arg0) <{ index = 2 : i32, closure_types = [i32, i64]}> : (!py.dynamic) -> i32
+  return %0 : i32
+}

--- a/test/Optimizer/PylirPy/IR/roundtrip.mlir
+++ b/test/Optimizer/PylirPy/IR/roundtrip.mlir
@@ -1,56 +1,47 @@
-// RUN: pylir-opt %s | pylir-opt | FileCheck %s
-// RUN: pylir-opt %s --mlir-print-op-generic | pylir-opt | FileCheck %s
+// RUN: pylir-opt %s --verify-roundtrip
 
 py.func @foo(%arg0 : !py.dynamic, %arg1 : !py.dynamic, %arg2 : !py.dynamic) -> !py.dynamic {
     return %arg0 : !py.dynamic
 }
 
-// CHECK-LABEL: test_function
 py.func @test_function() -> !py.dynamic {
   %0 = constant(#py.function<@foo, kw_defaults = #py.dict<{}>>)
   return %0 : !py.dynamic
 }
 
-// CHECK-LABEL: test_constant_integer
 py.func @test_constant_integer() -> !py.dynamic {
     %0 = constant(#py.int<50>)
     return %0 : !py.dynamic
 }
 
-// CHECK-LABEL: test_constant_bool
 py.func @test_constant_bool() -> !py.dynamic {
     %0 = constant(#py.bool<True>)
     %1 = constant(#py.bool<False>)
     return %0 : !py.dynamic
 }
 
-// CHECK-LABEL: test_constant_float
 py.func @test_constant_float() -> !py.dynamic {
     %0 = constant(#py.float<433.4>)
     return %0 : !py.dynamic
 }
 
-// CHECK-LABEL: test_constant_string
 py.func @test_constant_string() -> !py.dynamic {
     %0 = constant(#py.str<"text">)
     return %0 : !py.dynamic
 }
 
-// CHECK-LABEL: test_constant_list
 py.func @test_constant_list() -> !py.dynamic {
     %0 = constant(#py.list<[#py.float<433.4>, #py.int<5>]>)
     %empty = constant(#py.list<[]>)
     return %0 : !py.dynamic
 }
 
-// CHECK-LABEL: test_constant_tuple
 py.func @test_constant_tuple() -> !py.dynamic {
     %0 = constant(#py.tuple<(#py.float<433.4>, #py.int<5>)>)
     %empty = constant(#py.tuple<()>)
     return %0 : !py.dynamic
 }
 
-// CHECK-LABEL: test_constant_dict
 py.func @test_constant_dict() -> !py.dynamic {
     %0 = constant(#py.dict<{#py.float<433.4> to #py.int<5>, #py.str<"__call__"> to #py.int<5>}>)
     %empty = constant(#py.dict<{}>)
@@ -59,9 +50,13 @@ py.func @test_constant_dict() -> !py.dynamic {
 
 #a = #py.globalValue<a, initializer = #py.type>
 
-// CHECK-LABEL: test_objects
 py.func @test_objects() -> !py.dynamic {
     %0 = constant(#py.obj<#a>)
     %1 = constant(#py.obj<#a, {__dict__ = #py.dict<{}>}>)
     return %1 : !py.dynamic
+}
+
+py.func @func_get_closure(%arg0 : !py.dynamic) -> i32 {
+  %0 = function_closureArg %arg0[2] : [i32, i64, i32]
+  return %0 : i32
 }


### PR DESCRIPTION
Closure arguments are used to implement capturing of non-locals within nested functions. This PR adds the necessary support within the `Py` dialect by adding extra operands to `makeFunc`, and a new op called `function_closureArg` to access closure arguments. Closure arguments are immutable, making the op have no memory side effects.

Lowering to PyMem and LLVM will be done in future PRs.