### PR TITLE
[PyHIR] Add support for non-locals in func outlining

### DIFF
--- a/test/Optimizer/PylirHIR/Transform/FuncOutlining.mlir
+++ b/test/Optimizer/PylirHIR/Transform/FuncOutlining.mlir
@@ -72,3 +72,21 @@ pyHIR.init "arg_res_attrs" {
 // CHECK: globalFunc @[[$BASIC1]](
 // CHECK-SAME: "rest" {test.name = 0 : i32}
 // CHECK-SAME: -> {test.name = 1 : i32}
+
+// -----
+
+// CHECK-LABEL: init "non_locals"
+pyHIR.init "non_locals" {
+  // CHECK: %[[LIST:.*]] = py.makeList ()
+  %0 = py.makeList ()
+  // CHECK: py.makeFunc @[[$BASIC1:[[:alnum:]]+]][%[[LIST]] : !py.dynamic]
+  %1 = func "basic"() {
+    return %0
+  }
+  init_return %1
+}
+
+// CHECK: globalFunc @[[$BASIC1]](
+// CHECK-SAME: %[[CLOSURE:[[:alnum:]]+]]
+// CHECK: %[[ARG:.*]] = py.function_closureArg %[[CLOSURE]][0] : [!py.dynamic]
+// CHECK: return %[[ARG]]


### PR DESCRIPTION
Any uses of values that are defined outside the function must be translated to closure arguments when the `pyHIR.func` is translated to `pyHIR.globalFunc`. This is enabled by the previously added closure argument in `globalFunc`.