### PR TITLE
[PylirPyToPylirMem] Lower `makeFunc` with closure arguments support

### DIFF
--- a/src/pylir/Optimizer/Conversion/PylirPyToPylirMem/PylirPyToPylirMem.td
+++ b/src/pylir/Optimizer/Conversion/PylirPyToPylirMem/PylirPyToPylirMem.td
@@ -81,7 +81,10 @@ def : Pat<(PylirPy_IntToStrOp $integer),
 defvar FunctionRef = ConstantStrAttr<PylirPy_GlobalValueAttr, "builtins.function">;
 
 def : Pat<(PylirPy_MakeFuncOp $symbol, $closure_args),
-  (PylirMem_InitFuncOp GCWithSlots<FunctionRef>.result, $symbol)>;
+  (PylirMem_InitFuncOp (PylirMem_GCAllocFunctionOp (NativeCodeCall<[{
+    $_builder.getTypeArrayAttr($0.getTypes())
+  }]> $closure_args)), $symbol,
+    $closure_args)>;
 
 defvar BoolRef = ConstantStrAttr<PylirPy_GlobalValueAttr, "builtins.bool">;
 

--- a/src/pylir/Optimizer/PylirMem/IR/PylirMemOps.td
+++ b/src/pylir/Optimizer/PylirMem/IR/PylirMemOps.td
@@ -251,10 +251,13 @@ def PylirMem_InitStrFromIntOp : PylirMem_Op<"initStrFromInt",  [AlwaysBound,
 
 def PylirMem_InitFuncOp : PylirMem_Op<"initFunc", [AlwaysBound, NoCaptures]> {
   let arguments = (ins Arg<MemoryType, "", [MemWrite]>:$memory,
-    FlatSymbolRefAttr:$initializer);
+    FlatSymbolRefAttr:$initializer, Variadic<AnyType>:$closure_args);
   let results = (outs DynamicType:$result);
 
-  let assemblyFormat = "$memory `to` $initializer attr-dict";
+  let assemblyFormat = [{
+    $memory `to` $initializer
+      (`[` $closure_args^ `:` type($closure_args) `]`)? attr-dict
+  }];
 }
 
 def PylirMem_InitObjectOp : PylirMem_Op<"initObject", [AlwaysBound,

--- a/test/Optimizer/Conversion/PylirPyToPylirMem/make-ops.mlir
+++ b/test/Optimizer/Conversion/PylirPyToPylirMem/make-ops.mlir
@@ -74,21 +74,19 @@ py.func @make_dict(%arg0 : !py.dynamic, %arg1: index, %arg2 : !py.dynamic) -> !p
 
 // -----
 
-// CHECK: #[[$FUNCTION_TYPE:.*]] = #py.globalValue<builtins.function{{,|>}}
-
 py.func private @test(!py.dynamic,!py.dynamic,!py.dynamic) -> !py.dynamic
 
-py.func @make_function() -> !py.dynamic {
-    %0 = makeFunc @test
+py.func @make_function(%arg0 : i32, %arg1 : !py.dynamic) -> !py.dynamic {
+    %0 = makeFunc @test [%arg0, %arg1 : i32, !py.dynamic]
     return %0 : !py.dynamic
 }
 
 // CHECK-LABEL: @make_function
-// CHECK-NEXT: %[[FUNCTION:.*]] = constant(#[[$FUNCTION_TYPE]])
-// CHECK-NEXT: %[[SLOTS:.*]] = type_slots %[[FUNCTION]]
-// CHECK-NEXT: %[[LEN:.*]] = tuple_len %[[SLOTS]]
-// CHECK-NEXT: %[[MEM:.*]] = pyMem.gcAllocObject %[[FUNCTION]][%[[LEN]]]
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+// CHECK-NEXT: %[[MEM:.*]] = pyMem.gcAllocFunction [i32, !py.dynamic]
 // CHECK-NEXT: %[[RESULT:.*]] = pyMem.initFunc %[[MEM]] to @test
+// CHECK-SAME: [%[[ARG0]], %[[ARG1]] : i32, !py.dynamic]
 // CHECK-NEXT: return %[[RESULT]]
 
 // -----


### PR DESCRIPTION
The lowering now uses the just added `pyMem.gcAllocFunction` op. Additionally, the closure arguments were added to `initFunc`. A lowering of `initFunc` with closure arguments to LLVM will be part of a subsequent PR.