### PR TITLE
[PylirToLLVM] Implement closure arguments lowering

### DIFF
--- a/src/pylir/Optimizer/Conversion/PylirToLLVMIR/CodeGenState.hpp
+++ b/src/pylir/Optimizer/Conversion/PylirToLLVMIR/CodeGenState.hpp
@@ -572,14 +572,21 @@ struct PyFloatModel : PyObjectModelBase<PyFloatModel> {
 struct PyFunctionModel : PyObjectModelBase<PyFunctionModel> {
   using PyObjectModelBase::PyObjectModelBase;
 
-  static auto getElementType(PylirTypeConverter& typeConverter) {
-    return typeConverter.getPyFunctionType();
-  }
-
   /// Returns a model for the internal function pointer, using the universal
   /// calling convention.
   auto funcPtr(mlir::Location loc) const {
     return field<Scalar<TbaaAccessType::FunctionPointer>>(loc, 1);
+  }
+
+  /// Returns a model for accessing the slots of the function.
+  auto slotsArray(mlir::Location loc) const {
+    return field<Array<Pointer<PyObjectModel, TbaaAccessType::TupleElements>>>(
+        loc, 2);
+  }
+
+  /// Returns a model for accessing the closure argument with the given index.
+  auto closureArgument(mlir::Location loc, unsigned index) const {
+    return field<Scalar<>>(loc, 3 + index);
   }
 };
 

--- a/test/Optimizer/Conversion/PylirToLLVM/function_getClosureArgOp.mlir
+++ b/test/Optimizer/Conversion/PylirToLLVM/function_getClosureArgOp.mlir
@@ -1,0 +1,13 @@
+// RUN: pylir-opt %s -convert-pylir-to-llvm | FileCheck %s
+
+// CHECK-LABEL: func @func_get_closure
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+py.func @func_get_closure(%arg0 : !py.dynamic) -> i32 {
+  // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[ARG0]][0, 5]
+  // CHECK-SAME: struct<{{.*}}, ({{.*}}, {{.*}}, {{.*}}, i32, i64, i32)>
+  // CHECK: %[[LOADED:.*]] = llvm.load %[[GEP]]
+  // CHECK-SAME: -> i32
+  %0 = function_closureArg %arg0[2] : [i32, i64, i32]
+  // CHECK: return %[[LOADED]]
+  return %0 : i32
+}

--- a/test/Optimizer/Conversion/PylirToLLVM/initFuncOp.mlir
+++ b/test/Optimizer/Conversion/PylirToLLVM/initFuncOp.mlir
@@ -1,0 +1,23 @@
+// RUN: pylir-opt %s -convert-pylir-to-llvm --split-input-file | FileCheck %s
+
+py.func private @test(%arg0 : !py.dynamic, %arg1 : !py.dynamic, %arg2 : !py.dynamic) -> !py.dynamic {
+  return %arg0 : !py.dynamic
+}
+
+// CHECK-LABEL: func @make_function
+// CHECK-SAME: %[[MEM:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+py.func @make_function(%mem: !pyMem.memory, %arg0: i32, %arg1: !py.dynamic) -> !py.dynamic {
+  // CHECK: %[[FUNC:.*]] = llvm.mlir.addressof @test
+  // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[MEM]][0, 1]
+  // CHECK: store %[[FUNC]], %[[GEP]]
+  // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[MEM]][0, 3]
+  // CHECK-SAME: struct<{{.*}}, ({{.*}}, {{.*}}, {{.*}}, i32, ptr<{{[0-9]+}}>)>
+  // CHECK: store %[[ARG0]], %[[GEP]]
+  // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[MEM]][0, 4]
+  // CHECK-SAME: struct<{{.*}}, ({{.*}}, {{.*}}, {{.*}}, i32, ptr<{{[0-9]+}}>)>
+  // CHECK: store %[[ARG1]], %[[GEP]]
+  %1 = pyMem.initFunc %mem to @test[%arg0, %arg1 : i32, !py.dynamic]
+  return %1 : !py.dynamic
+}


### PR DESCRIPTION
The bulk of this change is adjusting `pyFunctionModel` to support closure argument types. That way easy accessors could be created using the familiar model API that are then leveraged in both the exisitng `initFunc` lowering and the new lowering for `function_getClosureArg`.