### PR TITLE
[CodeGenNew] Implement `nonlocal` variables

### DIFF
--- a/src/pylir/Support/ValueReset.hpp
+++ b/src/pylir/Support/ValueReset.hpp
@@ -42,6 +42,15 @@ public:
     m_valueAfter = std::move(rhs.m_valueAfter);
     return *this;
   }
+
+  /// Returns a reference to the value that will be assigned at destruction.
+  T& getValueAfterReset() {
+    return m_valueAfter;
+  }
+
+  const T& getValueAfterReset() const {
+    return m_valueAfter;
+  }
 };
 
 template <class... Args>

--- a/test/CodeGenNew/non-locals.py
+++ b/test/CodeGenNew/non-locals.py
@@ -1,0 +1,20 @@
+# RUN: pylir %s -Xnew-codegen -emit-pylir -o - -S | FileCheck %s
+
+# CHECK: func "__main__.foo"
+# CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+def foo(x):
+    # CHECK: %[[CELL_TYPE:.*]] = py.constant
+    # CHECK: %[[CELL:.*]] = call %[[CELL_TYPE]]()
+    # CHECK: %[[ZERO:.*]] = arith.constant 0
+    # CHECK: py.setSlot %[[CELL]][%[[ZERO]]] to %[[ARG0]]
+
+    # CHECK: func "__main__.foo.<locals>.bar"
+    # CHECK-SAME: %[[Y:[[:alnum:]]+]]
+    # CHECK: %[[ZERO:.*]] = arith.constant 0
+    # CHECK: %[[X:.*]] = py.getSlot %[[CELL]][%[[ZERO]]]
+    # CHECK: %[[RES:.*]] = binAssignOp %[[X]] __iadd__ %[[Y]]
+    # CHECK: %[[ZERO:.*]] = arith.constant 0
+    # CHECK: py.setSlot %[[CELL]][%[[ZERO]]] to %[[RES]]
+    def bar(y):
+        nonlocal x
+        x += y


### PR DESCRIPTION
`nonlocal` variables in Python are variables that are defined within a parent function or class and captured by the current class. Like normal locals, the variables can be assigned to and the change will be visible to all functions that have access to the variable.

This is implemented using a so-called cell in Python. The function creating the variable that will get captured by sub-functions creates a cell for every captured value. The cell gets captured by sub-functions. Reads and writes of the variable are redirected to the single slot of the cell, creating a single reference everyone has access to.