### PR TITLE
[CodeGenNew] Correctly save and restore `finally` and `try` on function change

### DIFF
--- a/test/CodeGenNew/finally.py
+++ b/test/CodeGenNew/finally.py
@@ -123,3 +123,18 @@ def foo6():
             x = 5
     finally:
         x = 3
+
+
+# CHECK-LABEL: func "__main__.foo7"
+def foo7():
+    try:
+        # CHECK-LABEL: func "__main__.foo7.<locals>.bar"
+        # CHECK-SAME: %[[X:[[:alnum:]]+]]
+        def bar(x):
+            # CHECK: call %[[X]]()
+            x()
+            # CHECK-NEXT: %[[ONE:.*]] = py.constant(#py.int<1>)
+            # CHECK-NEXT: return %[[ONE]]
+            return 1
+    finally:
+        return 0


### PR DESCRIPTION
Prior to this PR the current exception handler and finally stack were not cleared when entering a new function. This leads to invalid code being generated referencing blocks and variables outside the current function.

This PR fixes that issue by introducing a proper `ChangeFunction` class that sets and resets all state associated with function generation.