### PR TITLE
[CodeGenNew][PyHIR] Implement basic `in`

### DIFF
--- a/src/pylir/CodeGenNew/CodeGenNew.cpp
+++ b/src/pylir/CodeGenNew/CodeGenNew.cpp
@@ -1321,7 +1321,8 @@ private:
       }
 
       struct IsTag {};
-      std::variant<HIR::BinaryOperation, IsTag> binaryOperation;
+      struct InTag {};
+      std::variant<HIR::BinaryOperation, IsTag, InTag> binaryOperation;
       switch (op.firstToken.getTokenType()) {
       case TokenType::LessThan:
         binaryOperation = HIR::BinaryOperation::Lt;
@@ -1340,10 +1341,7 @@ private:
         binaryOperation = HIR::BinaryOperation::Ne;
         break;
       case TokenType::IsKeyword: binaryOperation = IsTag{}; break;
-      case TokenType::InKeyword:
-        // TODO:
-        PYLIR_UNREACHABLE;
-        break;
+      case TokenType::InKeyword: binaryOperation = InTag{}; break;
       default: PYLIR_UNREACHABLE;
       }
 
@@ -1356,6 +1354,9 @@ private:
           },
           [&](IsTag) -> Value {
             return create<Py::BoolFromI1Op>(create<Py::IsOp>(current, other));
+          },
+          [&](InTag) -> Value {
+            return create<HIR::ContainsOp>(other, current);
           });
       if (invert) {
         Value i1 = toI1(boolean);

--- a/src/pylir/Optimizer/Conversion/PylirHIRToPylirPy/PylirHIRToPylirPy.cpp
+++ b/src/pylir/Optimizer/Conversion/PylirHIRToPylirPy/PylirHIRToPylirPy.cpp
@@ -244,6 +244,19 @@ struct BinAssignOpConversionPattern
   }
 };
 
+struct ContainsOpConversionPattern
+    : OpExRewritePattern<ContainsOpConversionPattern, ContainsOp> {
+  using Base::Base;
+
+  template <class OpT>
+  LogicalResult matchAndRewrite(OpT op, ExceptionRewriter& rewriter) const {
+    rewriter.replaceOpWithNewOp<Py::CallOp>(
+        op, op.getType(), "pylir__contains__",
+        ValueRange{op.getContainer(), op.getItem()});
+    return success();
+  }
+};
+
 struct GetItemOpConversionPattern
     : OpExRewritePattern<GetItemOpConversionPattern, GetItemOp> {
   using Base::Base;
@@ -968,7 +981,8 @@ void ConvertPylirHIRToPylirPy::runOnOperation() {
                CallOpConversionPattern, BinOpConversionPattern,
                BinAssignOpConversionPattern, InitModuleOpConversionPattern,
                GetItemOpConversionPattern, SetItemOpConversionPattern,
-               DelItemOpConversionPattern>(&getContext());
+               DelItemOpConversionPattern, ContainsOpConversionPattern>(
+      &getContext());
   if (failed(
           applyPartialConversion(getOperation(), target, std::move(patterns))))
     return signalPassFailure();

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
@@ -105,6 +105,42 @@ def PylirHIR_BinAssignOp : PylirHIR_Op<"binAssignOp",
 def PylirHIR_BinAssignExOp
   : CreateExceptionHandlingVariant<PylirHIR_BinAssignOp>;
 
+def PylirHIR_ContainsOp : PylirHIR_Op<"contains",
+  [AddableExceptionHandling<"ContainsExOp">]> {
+  let arguments = (ins DynamicType:$container, DynamicType:$item);
+  let results = (outs DynamicType:$result);
+
+  let description = [{
+    Performs a membership check whether `item` is within `container`.
+
+    This is performed in the following steps:
+    * If the type of `container` implements `__contains__`, calls the method
+      with `item`.
+      Returns true if it returns a truthy value.
+    * Otherwise, if the type of `container` implements `__iter__`, it iterates
+      over `container` and checks whether for any element `z`,
+      `z is item or z == item` is true.
+      Any exceptions raised in the process are propagated as is.
+
+    :::{admonition} TODO
+    :class: note
+
+    * Describe the behaviour of types implementing `__getitem__` in detail.
+    * Implement correctly in lowering: Currently only performs `__contains__`
+      check.
+    :::
+
+    Reference: https://docs.python.org/3.9/reference/expressions.html#membership-test-operations
+  }];
+
+  let assemblyFormat = [{
+    $item `in` $container attr-dict
+  }];
+}
+
+def PylirHIR_ContainsExOp
+  : CreateExceptionHandlingVariant<PylirHIR_ContainsOp>;
+
 //===----------------------------------------------------------------------===//
 // Subscription Operations
 //===----------------------------------------------------------------------===//

--- a/test/CodeGenNew/comparison.py
+++ b/test/CodeGenNew/comparison.py
@@ -28,6 +28,9 @@ def binary_ops(a, b):
     # CHECK: py.bool_fromI1 %[[IS]]
     a is b
 
+    # CHECK: contains %[[ARG0]] in %[[ARG1]]
+    a in b
+
 
 # CHECK-LABEL: func "__main__.chaining"
 # CHECK-SAME: %[[ARG0:[[:alnum:]]+]]

--- a/test/Optimizer/Conversion/PylirHIRToPylirPy/containsOp.mlir
+++ b/test/Optimizer/Conversion/PylirHIRToPylirPy/containsOp.mlir
@@ -1,0 +1,10 @@
+// RUN: pylir-opt %s --convert-pylirHIR-to-pylirPy --split-input-file | FileCheck %s
+
+// CHECK-LABEL: func @test$impl
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+pyHIR.globalFunc @test(%0, %1) {
+  // CHECK: %[[ITEM:.*]] = call @pylir__contains__(%[[ARG0]], %[[ARG1]])
+  %2 = contains %1 in %0
+  return %2
+}

--- a/test/Optimizer/PylirHIR/IR/roundtrip.mlir
+++ b/test/Optimizer/PylirHIR/IR/roundtrip.mlir
@@ -1,4 +1,5 @@
 // RUN: pylir-opt %s | pylir-opt | FileCheck %s
+// RUN: pylir-opt --verify-roundtrip
 
 // CHECK-LABEL: pyHIR.globalFunc @test(
 // CHECK-SAME: %{{[[:alnum:]]+}},
@@ -175,4 +176,13 @@ pyHIR.globalFunc @subscription(%0, %1) {
   // CHECK: delItem %[[ARG1]][%[[ARG0]]]
   delItem %1[%0]
   return %2
+}
+
+// CHECK-LABEL: pyHIR.globalFunc @contains(
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+pyHIR.globalFunc @contains(%container, %item) {
+  // CHECK: contains %[[ARG1]] in %[[ARG0]]
+  %0 = contains %item in %container
+  return %0
 }


### PR DESCRIPTION
Python's `in` keyword lowers to the `__contains__` method in most scenarios. This is represented as a new op in the `pyHIR` dialect called `contains`, lowering to the existing `pylir__contains__` intrinsic use by the old `CodeGen`. 