### PR TITLE
[CodeGenNew] Implement iterable unpacking

### DIFF
--- a/src/pylir/CodeGenNew/CodeGenNew.cpp
+++ b/src/pylir/CodeGenNew/CodeGenNew.cpp
@@ -1753,23 +1753,29 @@ private:
     PYLIR_UNREACHABLE;
   }
 
-  void
-  visitImpl([[maybe_unused]] llvm::ArrayRef<Syntax::StarredItem> starredItems,
-            [[maybe_unused]] Value value) {
-    // TODO:
-    PYLIR_UNREACHABLE;
+  void visitImpl(ArrayRef<Syntax::StarredItem> starredItems, Value value) {
+    const auto* iter =
+        llvm::find_if(starredItems, [](const Syntax::StarredItem& item) {
+          return item.maybeStar;
+        });
+    std::optional<std::size_t> index;
+    if (iter != starredItems.end())
+      index = iter - starredItems.begin();
+
+    Operation* op = create<Py::UnpackOp>(/*count=*/starredItems.size(),
+                                         /*restIndex=*/index, value);
+    for (auto&& [item, subValue] :
+         llvm::zip_equal(starredItems, op->getResults()))
+      visit(item.expression, subValue);
   }
 
-  void visitImpl([[maybe_unused]] const Syntax::TupleConstruct& tupleConstruct,
-                 [[maybe_unused]] Value value) {
-    // TODO:
-    PYLIR_UNREACHABLE;
+  void visitImpl(const Syntax::TupleConstruct& tupleConstruct, Value value) {
+    visit(tupleConstruct.items, value);
   }
 
-  void visitImpl([[maybe_unused]] const Syntax::ListDisplay& listDisplay,
-                 [[maybe_unused]] Value value) {
-    // TODO:
-    PYLIR_UNREACHABLE;
+  void visitImpl(const Syntax::ListDisplay& listDisplay, Value value) {
+    visit(pylir::get<std::vector<Syntax::StarredItem>>(listDisplay.variant),
+          value);
   }
 
   /// Overload for any construct that is a possible alternative for 'Target' in

--- a/test/CodeGenNew/unpack-assign.py
+++ b/test/CodeGenNew/unpack-assign.py
@@ -1,0 +1,14 @@
+# RUN: pylir %s -Xnew-codegen -emit-pylir -o - -S | FileCheck %s
+
+
+# CHECK-LABEL: func "__main__.test"
+# CHECK-SAME: %[[ITERABLE:[[:alnum:]]+]]
+def test(iterable):
+    # CHECK: %[[AB:[[:alnum:]]+]]:2 = py.unpack %[[ITERABLE]] : (!py.dynamic, !py.dynamic)
+    a, b = iterable
+    # CHECK: %[[A:.*]], %[[B:.*]] = py.unpack %[[AB]]#0 : (), !py.dynamic, (!py.dynamic)
+    *a, b = a
+    # CHECK: %[[A:.*]], %[[B_2:.*]], %[[C:.*]] = py.unpack %[[B]] : (!py.dynamic), !py.dynamic, (!py.dynamic)
+    a, *b, c = b
+    # CHECK: %[[A:.*]], %[[B:.*]] = py.unpack %[[C]] : (!py.dynamic), !py.dynamic
+    a, *b = c


### PR DESCRIPTION
The `py` dialect already contains an existing operation to perform this operation. We will probably want to move this operation to the `HIR` dialect in the future as that is the more fitting abstraction level. Until then, the implementation for iterable packing is the same as in the old CodeGen.