### PR TITLE
[CodeGenNew][PyHIR] Implement attribute references

### DIFF
--- a/src/pylir/CodeGenNew/CodeGenNew.cpp
+++ b/src/pylir/CodeGenNew/CodeGenNew.cpp
@@ -1504,10 +1504,10 @@ private:
     }
   }
 
-  mlir::Value
-  visitImpl([[maybe_unused]] const Syntax::AttributeRef& attributeRef) {
-    // TODO:
-    PYLIR_UNREACHABLE;
+  Value visitImpl(const Syntax::AttributeRef& attributeRef) {
+    Value object = visit(attributeRef.object);
+    return create<HIR::GetAttributeOp>(object,
+                                       attributeRef.identifier.getValue());
   }
 
   mlir::Value visitImpl([[maybe_unused]] const Syntax::Slice& slice) {
@@ -1748,10 +1748,9 @@ private:
     PYLIR_UNREACHABLE;
   }
 
-  void visitImpl([[maybe_unused]] const Syntax::AttributeRef& attributeRef,
-                 [[maybe_unused]] Value value) {
-    // TODO:
-    PYLIR_UNREACHABLE;
+  void visitImpl(const Syntax::AttributeRef& attributeRef, Value value) {
+    create<HIR::SetAttrOp>(visit(attributeRef.object),
+                           attributeRef.identifier.getValue(), value);
   }
 
   void

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
@@ -187,6 +187,39 @@ def PylirHIR_DelItemExOp
   : CreateExceptionHandlingVariant<PylirHIR_DelItemOp>;
 
 //===----------------------------------------------------------------------===//
+// Attribute Operations
+//===----------------------------------------------------------------------===//
+
+def PylirHIR_GetAttributeOp : PylirHIR_Op<"getAttribute",
+  [AddableExceptionHandling<"GetAttributeExOp">]> {
+  let arguments = (ins DynamicType:$object, StrAttr:$attribute);
+  let results = (outs DynamicType:$result);
+
+  let assemblyFormat = [{
+    $attribute `of` $object attr-dict
+  }];
+}
+
+def PylirHIR_GetAttributeExOp
+  : CreateExceptionHandlingVariant<PylirHIR_GetAttributeOp>;
+
+def PylirHIR_SetAttrOp : PylirHIR_Op<"setAttr",
+  [AddableExceptionHandling<"SetAttrExOp">]> {
+  let arguments = (ins DynamicType:$object,
+                       StrAttr:$attribute,
+                       DynamicType:$value);
+
+  let results = (outs DynamicType:$result);
+
+  let assemblyFormat = [{
+     $attribute `of` $object `to` $value attr-dict
+  }];
+}
+
+def PylirHIR_SetAttrExOp
+  : CreateExceptionHandlingVariant<PylirHIR_SetAttrOp>;
+
+//===----------------------------------------------------------------------===//
 // Call Operations
 //===----------------------------------------------------------------------===//
 

--- a/test/CodeGenNew/attribute-ref.py
+++ b/test/CodeGenNew/attribute-ref.py
@@ -1,0 +1,11 @@
+# RUN: pylir %s -Xnew-codegen -emit-pylir -o - -c -S | FileCheck %s
+
+# CHECK-LABEL: func "__main__.test"
+# CHECK-SAME: %[[A:[[:alnum:]]+]]
+def test(a):
+    # CHECK: %[[THREE:.*]] = py.constant(#py.int<3>)
+    # CHECK: setAttr "test" of %[[A]] to %[[THREE]]
+    a.test = 3
+    # CHECK: %[[RES:.*]] = getAttribute "test" of %[[A]]
+    # CHECK: return %[[RES]]
+    return a.test

--- a/test/Optimizer/Conversion/PylirHIRToPylirPy/getAttributeOp.mlir
+++ b/test/Optimizer/Conversion/PylirHIRToPylirPy/getAttributeOp.mlir
@@ -1,0 +1,10 @@
+// RUN: pylir-opt %s --convert-pylirHIR-to-pylirPy --split-input-file | FileCheck %s
+
+// CHECK-LABEL: func @test$impl
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+pyHIR.globalFunc @test(%0) {
+  // CHECK: %[[STR:.*]] = constant(#py.str<"test">)
+  // CHECK: %[[ITEM:.*]] = call @pylir__getattribute__(%[[ARG0]], %[[STR]])
+  %2 = getAttribute "test" of %0
+  return %2
+}

--- a/test/Optimizer/Conversion/PylirHIRToPylirPy/setAttrOp.mlir
+++ b/test/Optimizer/Conversion/PylirHIRToPylirPy/setAttrOp.mlir
@@ -1,0 +1,11 @@
+// RUN: pylir-opt %s --convert-pylirHIR-to-pylirPy --split-input-file | FileCheck %s
+
+// CHECK-LABEL: func @test$impl
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+pyHIR.globalFunc @test(%0, %1) {
+  // CHECK: %[[STR:.*]] = constant(#py.str<"test">)
+  // CHECK: call @pylir__setattr__(%[[ARG0]], %[[STR]], %[[ARG1]])
+  setAttr "test" of %0 to %1
+  return %0
+}


### PR DESCRIPTION
Attribute references are the last kind of expressions missing before being able to replace the old `CodeGen`. This PR implements the lowering of attribute refs to HIR ops mirroring the semantics. Most notably, accessing an attribute calls `__getattribute__`, not `__getattr__`. These are then later lowered to the same intrinsic calls that the old `CodeGen` lowers to.