### PR TITLE
[Main] Fail on invalid MLIR

### DIFF
--- a/test/Main/invalid-mlir.mlir
+++ b/test/Main/invalid-mlir.mlir
@@ -1,0 +1,7 @@
+// RUN: not pylir -o /dev/null %s 2>&1 | FileCheck %s --check-prefix=SYNTAX
+// RUN: not pylir -o /dev/null %t/nonExistent.ll 2>&1 | FileCheck %s --check-prefix=IO
+
+opthatshoulntexit.test
+
+// SYNTAX: Dialect `opthatshoulntexit' not found for custom op 'opthatshoulntexit.test'
+// IO: error: Could not open input file:


### PR DESCRIPTION
Invalid MLIR previously caused segfaults as there was no error handling performed by the caller. This PR adds the failure check to propagate it further to the caller.