### PR TITLE
[Main] Remove `-emit-mlir`

### DIFF
--- a/src/pylir/Main/CompilerInvocation.cpp
+++ b/src/pylir/Main/CompilerInvocation.cpp
@@ -322,8 +322,7 @@ mlir::LogicalResult pylir::CompilerInvocation::compilation(
   const auto& args = commandLine.getArgs();
 
   auto shouldOutput = [&args](pylir::cli::ID id) {
-    auto* outputFormatArg =
-        args.getLastArg(OPT_emit_llvm, OPT_emit_mlir, OPT_emit_pylir);
+    auto* outputFormatArg = args.getLastArg(OPT_emit_llvm, OPT_emit_pylir);
     return outputFormatArg && outputFormatArg->getOption().getID() == id;
   };
 
@@ -435,7 +434,7 @@ mlir::LogicalResult pylir::CompilerInvocation::compilation(
               manager)))
         return mlir::failure();
 
-    if (shouldOutput(OPT_emit_mlir) || shouldOutput(OPT_emit_pylir)) {
+    if (shouldOutput(OPT_emit_pylir)) {
       if (mlir::failed(manager.run(*mlirModule)))
         return mlir::failure();
 
@@ -684,7 +683,7 @@ std::string formDefaultOutputName(const llvm::opt::InputArgList& args,
     inputFilename.resize(inputFilename.size() - extension.size());
 
   std::string defaultName;
-  if (args.hasArg(OPT_emit_mlir, OPT_emit_pylir)) {
+  if (args.hasArg(OPT_emit_pylir)) {
     if (action == pylir::CompilerInvocation::ObjectFile)
       defaultName = inputFilename + ".mlirbc";
     else

--- a/src/pylir/Main/Opts.td
+++ b/src/pylir/Main/Opts.td
@@ -34,7 +34,6 @@ def grp_actions : OptionGroup<"Actions">, HelpText<"Action options">;
 
 def c : F<"c", "Emit object file instead of final executable">, Group<grp_actions>;
 def emit_llvm : F<"emit-llvm", "Emit LLVM IR">, Group<grp_actions>;
-def emit_mlir : F<"emit-mlir", "Emit MLIR IR">, Group<grp_actions>;
 def emit_pylir : F<"emit-pylir", "Emit Pylir IR">, Group<grp_actions>;
 def dump_ast : F<"dump-ast", "Dump AST for input file to stdout">, Group<grp_actions>;
 def S : F<"S", "Emit textual assembly file">, Group<grp_actions>;

--- a/src/pylir/Main/PylirMain.cpp
+++ b/src/pylir/Main/PylirMain.cpp
@@ -114,12 +114,10 @@ int pylir::main(int argc, char** argv) {
           .addHighlight(syntaxOnly, Diag::flags::secondaryColour);
     };
 
-    if (auto* lastIR =
-            args.getLastArg(OPT_emit_llvm, OPT_emit_mlir, OPT_emit_pylir)) {
+    if (auto* lastIR = args.getLastArg(OPT_emit_llvm, OPT_emit_pylir)) {
       std::string_view name;
       switch (lastIR->getOption().getID()) {
       case OPT_emit_llvm: name = "LLVM IR"; break;
-      case OPT_emit_mlir: name = "MLIR IR"; break;
       case OPT_emit_pylir: name = "Pylir IR"; break;
       }
       diagActionWithIR(lastIR, name);
@@ -133,13 +131,13 @@ int pylir::main(int argc, char** argv) {
     action = arg->getOption().getID() == OPT_S
                  ? pylir::CompilerInvocation::Assembly
                  : pylir::CompilerInvocation::ObjectFile;
-  } else if (args.hasArg(OPT_emit_llvm, OPT_emit_pylir, OPT_emit_mlir)) {
+  } else if (args.hasArg(OPT_emit_llvm, OPT_emit_pylir)) {
     action = pylir::CompilerInvocation::Assembly;
   }
 
   if (auto* opt = args.getLastArg(OPT_O);
       opt && opt->getValue() == std::string_view{"4"} &&
-      !args.hasArg(OPT_emit_mlir, OPT_emit_pylir, OPT_emit_llvm) &&
+      !args.hasArg(OPT_emit_pylir, OPT_emit_llvm) &&
       (action == pylir::CompilerInvocation::Assembly ||
        action == pylir::CompilerInvocation::ObjectFile) &&
       !args.hasArg(OPT_flto, OPT_fno_lto)) {
@@ -153,7 +151,7 @@ int pylir::main(int argc, char** argv) {
 
   if (auto* opt = args.getLastArg(OPT_flto, OPT_fno_lto);
       opt && opt->getOption().matches(OPT_flto) &&
-      !args.hasArg(OPT_emit_mlir, OPT_emit_pylir, OPT_emit_llvm) &&
+      !args.hasArg(OPT_emit_pylir, OPT_emit_llvm) &&
       (action == pylir::CompilerInvocation::Assembly ||
        action == pylir::CompilerInvocation::ObjectFile)) {
     commandLine

--- a/test/Main/cliDiagnostics.py
+++ b/test/Main/cliDiagnostics.py
@@ -2,10 +2,6 @@
 # RUN: --check-prefix=SYNTAX_ONLY_LLVM
 # SYNTAX_ONLY_LLVM: LLVM IR won't be emitted when only checking syntax
 
-# RUN: pylir -emit-mlir -fsyntax-only %s 2>&1 | FileCheck %s \
-# RUN: --check-prefix=SYNTAX_ONLY_MLIR
-# SYNTAX_ONLY_MLIR: MLIR IR won't be emitted when only checking syntax
-
 # RUN: pylir -emit-pylir -fsyntax-only %s 2>&1 | FileCheck %s \
 # RUN: --check-prefix=SYNTAX_ONLY_PYLIR
 # SYNTAX_ONLY_PYLIR: Pylir IR won't be emitted when only checking syntax

--- a/test/Main/fileProducts.py
+++ b/test/Main/fileProducts.py
@@ -3,14 +3,6 @@
 # RUN: ls %t
 
 # RUN: rm -f %t
-# RUN: pylir %s -emit-mlir -o %t -S
-# RUN: grep "func @__init__()" %t
-
-# RUN: rm -f %t
-# RUN: pylir %s -emit-mlir -o %t -c
-# RUN: od -x -N 4 %t | grep "4c4d *52ef"
-
-# RUN: rm -f %t
 # RUN: pylir %s -emit-pylir -o %t -S
 # RUN: grep "func @__init__()" %t
 
@@ -33,7 +25,7 @@
 
 # Last of the `-emit-*` options is actually used
 # RUN: rm -f %t
-# RUN: pylir %s -emit-mlir -emit-llvm -o %t
+# RUN: pylir %s -emit-pylir -emit-llvm -o %t
 # RUN: grep "define .* void @__init__()" %t
 
 # Writes to stdout instead of a file

--- a/test/Main/lto-output.py
+++ b/test/Main/lto-output.py
@@ -9,7 +9,6 @@
 # LTO_ASSEMBLY: LTO enabled. Compiler will output LLVM IR instead of an Assembly file
 # LTO_OBJECT: LTO enabled. Compiler will output LLVM IR instead of an Object file
 
-# RUN: pylir %s -O4 -emit-mlir -S -o %t 2>%1 | FileCheck %s --check-prefix=NEGATIVE_TEST --allow-empty
 # RUN: pylir %s -O4 -emit-llvm -S -o %t 2>%1 | FileCheck %s --check-prefix=NEGATIVE_TEST --allow-empty
 # RUN: pylir %s -O4 -emit-pylir -S -o %t 2>%1 | FileCheck %s --check-prefix=NEGATIVE_TEST --allow-empty
 # RUN: pylir %s -O4 -o %t -### 2>%1 | FileCheck %s --check-prefix=NEGATIVE_TEST --allow-empty

--- a/test/Main/outputFilenames.py
+++ b/test/Main/outputFilenames.py
@@ -8,14 +8,6 @@
 # RUN: pylir outputFilenames.mlir -c -emit-pylir
 # RUN: ls outputFilenames.mlirbc
 
-# RUN: rm outputFilenames.mlir
-# RUN: pylir outputFilenames.mlirbc -S -emit-mlir
-# RUN: ls outputFilenames.mlir
-
-# RUN: rm outputFilenames.mlirbc
-# RUN: pylir outputFilenames.mlir -c -emit-mlir
-# RUN: ls outputFilenames.mlirbc
-
 # RUN: pylir outputFilenames.mlirbc -c -emit-llvm
 # RUN: ls outputFilenames.bc
 

--- a/test/Main/roundtrip.py
+++ b/test/Main/roundtrip.py
@@ -10,16 +10,6 @@
 # RUN: pylir -c %t1.mlirbc -o /dev/null
 # RUN: pylir-opt %t1.mlirbc -o /dev/null
 
-# RUN: rm -f %t1.mlir %t2.mlir
-# RUN: pylir %s -S -emit-mlir -o %t1.mlir
-# RUN: pylir %t1.mlir -S -emit-mlir -o %t2.mlir
-# RUN: pylir -c %t1.mlir -o /dev/null
-
-# RUN: rm -f %t1.mlirbc %t2.mlirbc
-# RUN: pylir %s -c -emit-mlir -o %t1.mlirbc
-# RUN: pylir %t1.mlirbc -c -emit-mlir -o %t2.mlirbc
-# RUN: pylir -c %t1.mlirbc -o /dev/null
-
 # RUN: rm -f %t1.ll %t2.ll
 # RUN: pylir %s -S -emit-llvm -o %t1.ll
 # RUN: pylir %t1.ll -S -emit-llvm -o %t2.ll


### PR DESCRIPTION
This compiler option is the most arbitrary of all the `-emit` options as it outputs Pylir IR before it is lowered to LLVM IR. Since multiple lowerings have happened at that point in time, the currently defined pipelines will crash on the given operations. The name was arbitrary as well.

Remove the option for now. A more composable pipeline that does input detection (like IREE) can be introduced in the future with finer grained output options to match.