### PR TITLE
[PyHIR] Prevent capturing of constant operations

### DIFF
--- a/test/Optimizer/PylirHIR/Transform/FuncOutlining.mlir
+++ b/test/Optimizer/PylirHIR/Transform/FuncOutlining.mlir
@@ -90,3 +90,22 @@ pyHIR.init "non_locals" {
 // CHECK-SAME: %[[CLOSURE:[[:alnum:]]+]]
 // CHECK: %[[ARG:.*]] = py.function_closureArg %[[CLOSURE]][0] : [!py.dynamic]
 // CHECK: return %[[ARG]]
+
+// -----
+
+
+// CHECK-LABEL: init "constants"
+pyHIR.init "constants" {
+  %0 = py.constant (#py.str<"text">)
+  // CHECK: py.makeFunc @[[BASIC1:[[:alnum:]]+]]
+  // CHECK-NOT: [
+  // CHECK: {{$}}
+  %1 = func "basic"() {
+    return %0
+  }
+  init_return %1
+}
+
+// CHECK: globalFunc @[[BASIC1]](
+// CHECK-NEXT: %[[ARG:.*]] = py.constant(#py.str
+// CHECK-NEXT: return %[[ARG]]


### PR DESCRIPTION
Constant operations in MLIR are meant as a bridge between compile time constants, attributes, and SSA Value definitions. As such, capturing the results of a constant operation during outlining is unnecessary and any such use should simply be replaced with a local copy of the constant operation within the resulting `globalFunc` operation.