### PR TITLE
[Py][PyHIR][PyMem] Workaround missing enums generation filter file

### DIFF
--- a/cmake/AddPylir.cmake
+++ b/cmake/AddPylir.cmake
@@ -57,8 +57,11 @@ function(add_pylir_dialect dialect dialect_namespace)
     -dialect="${dialect_namespace}")
   mlir_tablegen(${dialect}Dialect.cpp.inc -gen-dialect-defs
     -dialect="${dialect_namespace}")
-  mlir_tablegen(${dialect}Enums.h.inc -gen-enum-decls)
-  mlir_tablegen(${dialect}Enums.cpp.inc -gen-enum-defs)
+  if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/${dialect}Enums.td)
+    set(LLVM_TARGET_DEFINITIONS ${dialect}Enums.td)
+    mlir_tablegen(${dialect}Enums.h.inc -gen-enum-decls)
+    mlir_tablegen(${dialect}Enums.cpp.inc -gen-enum-defs)
+  endif ()
   add_public_tablegen_target(${dialect}IncGen)
   
   if (NOT ARG_NO_DOC)

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIREnums.td
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIREnums.td
@@ -1,0 +1,53 @@
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef PYLIR_HIR_ENUMS_TABLEGEN
+#define PYLIR_HIR_ENUMS_TABLEGEN
+
+include "mlir/IR/EnumAttr.td"
+
+def PylirHIR_BinaryOperationAttr : I32EnumAttr<"BinaryOperation",
+  "Binary operations in python", [
+  I32EnumAttrCase<"Eq", 0, "__eq__">,
+  I32EnumAttrCase<"Ne", 1, "__ne__">,
+  I32EnumAttrCase<"Lt", 2, "__lt__">,
+  I32EnumAttrCase<"Le", 3, "__le__">,
+  I32EnumAttrCase<"Gt", 4, "__gt__">,
+  I32EnumAttrCase<"Ge", 5, "__ge__">,
+  I32EnumAttrCase<"Add", 6, "__add__">,
+  I32EnumAttrCase<"Sub", 7, "__sub__">,
+  I32EnumAttrCase<"Or", 8, "__or__">,
+  I32EnumAttrCase<"Xor", 9, "__xor__">,
+  I32EnumAttrCase<"And", 10, "__and__">,
+  I32EnumAttrCase<"LShift", 11, "__lshift__">,
+  I32EnumAttrCase<"RShift", 12, "__rshift__">,
+  I32EnumAttrCase<"Mul", 13, "__mul__">,
+  I32EnumAttrCase<"Div", 14, "__div__">,
+  I32EnumAttrCase<"FloorDiv", 15, "__floordiv__">,
+  I32EnumAttrCase<"Mod", 16, "__mod__">,
+  I32EnumAttrCase<"MatMul", 17, "__matmul__">,
+]> {
+  let cppNamespace = "pylir::HIR";
+}
+
+// Enums values kept in sync with 'PylirHIR_BinaryOperationAttr'.
+def PylirHIR_BinaryAssignmentAttr : I32EnumAttr<"BinaryAssignment",
+  "Binary assignment operations in python", [
+  I32EnumAttrCase<"Add", 6, "__iadd__">,
+  I32EnumAttrCase<"Sub", 7, "__isub__">,
+  I32EnumAttrCase<"Or", 8, "__ior__">,
+  I32EnumAttrCase<"Xor", 9, "__ixor__">,
+  I32EnumAttrCase<"And", 10, "__iand__">,
+  I32EnumAttrCase<"LShift", 11, "__ilshift__">,
+  I32EnumAttrCase<"RShift", 12, "__irshift__">,
+  I32EnumAttrCase<"Mul", 13, "__imul__">,
+  I32EnumAttrCase<"Div", 14, "__idiv__">,
+  I32EnumAttrCase<"FloorDiv", 15, "__ifloordiv__">,
+  I32EnumAttrCase<"Mod", 16, "__imod__">,
+  I32EnumAttrCase<"MatMul", 17, "__imatmul__">,
+]> {
+  let cppNamespace = "pylir::HIR";
+}
+
+#endif

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
@@ -5,7 +5,6 @@
 #ifndef PYLIR_HIR_OPS_TABLEGEN
 #define PYLIR_HIR_OPS_TABLEGEN
 
-include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpBase.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
@@ -15,6 +14,7 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 
 include "pylir/Optimizer/PylirHIR/IR/PylirHIRDialect.td"
+include "pylir/Optimizer/PylirHIR/IR/PylirHIREnums.td"
 include "pylir/Optimizer/PylirHIR/IR/PylirHIRFunctionInterface.td"
 
 include "pylir/Optimizer/PylirPy/IR/PylirPyTypes.td"
@@ -26,30 +26,6 @@ class PylirHIR_Op<string mneomic, list<Trait> traits = []>
 //===----------------------------------------------------------------------===//
 // Basic Operations
 //===----------------------------------------------------------------------===//
-
-def PylirHIR_BinaryOperationAttr : I32EnumAttr<"BinaryOperation",
-  "Binary operations in python", [
-  I32EnumAttrCase<"Eq", 0, "__eq__">,
-  I32EnumAttrCase<"Ne", 1, "__ne__">,
-  I32EnumAttrCase<"Lt", 2, "__lt__">,
-  I32EnumAttrCase<"Le", 3, "__le__">,
-  I32EnumAttrCase<"Gt", 4, "__gt__">,
-  I32EnumAttrCase<"Ge", 5, "__ge__">,
-  I32EnumAttrCase<"Add", 6, "__add__">,
-  I32EnumAttrCase<"Sub", 7, "__sub__">,
-  I32EnumAttrCase<"Or", 8, "__or__">,
-  I32EnumAttrCase<"Xor", 9, "__xor__">,
-  I32EnumAttrCase<"And", 10, "__and__">,
-  I32EnumAttrCase<"LShift", 11, "__lshift__">,
-  I32EnumAttrCase<"RShift", 12, "__rshift__">,
-  I32EnumAttrCase<"Mul", 13, "__mul__">,
-  I32EnumAttrCase<"Div", 14, "__div__">,
-  I32EnumAttrCase<"FloorDiv", 15, "__floordiv__">,
-  I32EnumAttrCase<"Mod", 16, "__mod__">,
-  I32EnumAttrCase<"MatMul", 17, "__matmul__">,
-]> {
-  let cppNamespace = "pylir::HIR";
-}
 
 def PylirHIR_BinOp : PylirHIR_Op<"binOp",
   [AddableExceptionHandling<"BinExOp">]> {
@@ -68,24 +44,6 @@ def PylirHIR_BinOp : PylirHIR_Op<"binOp",
 
 def PylirHIR_BinExOp : CreateExceptionHandlingVariant<PylirHIR_BinOp>;
 
-// Enums values kept in sync with 'PylirHIR_BinaryOperationAttr'.
-def PylirHIR_BinaryAssignmentAttr : I32EnumAttr<"BinaryAssignment",
-  "Binary assignment operations in python", [
-  I32EnumAttrCase<"Add", 6, "__iadd__">,
-  I32EnumAttrCase<"Sub", 7, "__isub__">,
-  I32EnumAttrCase<"Or", 8, "__ior__">,
-  I32EnumAttrCase<"Xor", 9, "__ixor__">,
-  I32EnumAttrCase<"And", 10, "__iand__">,
-  I32EnumAttrCase<"LShift", 11, "__ilshift__">,
-  I32EnumAttrCase<"RShift", 12, "__irshift__">,
-  I32EnumAttrCase<"Mul", 13, "__imul__">,
-  I32EnumAttrCase<"Div", 14, "__idiv__">,
-  I32EnumAttrCase<"FloorDiv", 15, "__ifloordiv__">,
-  I32EnumAttrCase<"Mod", 16, "__imod__">,
-  I32EnumAttrCase<"MatMul", 17, "__imatmul__">,
-]> {
-  let cppNamespace = "pylir::HIR";
-}
 
 def PylirHIR_BinAssignOp : PylirHIR_Op<"binAssignOp",
   [AddableExceptionHandling<"BinAssignExOp">]> {

--- a/src/pylir/Optimizer/PylirMem/IR/PylirMemEnums.td
+++ b/src/pylir/Optimizer/PylirMem/IR/PylirMemEnums.td
@@ -1,0 +1,29 @@
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef PYLIR_MEM_ENUMS_TABLEGEN
+#define PYLIR_MEM_ENUMS_TABLEGEN
+
+include "mlir/IR/EnumAttr.td"
+
+/// Object layouts known to the compiler with a static size. May be replaced
+/// with some kind of type descriptors if we ever introduce custom object
+/// layouts as an optimization.
+def PylirMem_LayoutTypeAttr : I32EnumAttr<"LayoutType",
+  "Enum of types with known object layouts", [
+  I32EnumAttrCase<"Object", 0, "object">,
+  I32EnumAttrCase<"Type", 1, "type">,
+  I32EnumAttrCase<"Float", 2, "float">,
+  I32EnumAttrCase<"Function", 3, "function">,
+  I32EnumAttrCase<"Tuple", 4, "tuple">,
+  I32EnumAttrCase<"List", 5, "list">,
+  I32EnumAttrCase<"String", 6, "string">,
+  I32EnumAttrCase<"Dict", 7, "dict">,
+  I32EnumAttrCase<"Int", 8, "int">,
+  I32EnumAttrCase<"BaseException", 9>,
+]> {
+  let cppNamespace = "pylir::Mem";
+}
+
+#endif

--- a/src/pylir/Optimizer/PylirMem/IR/PylirMemOps.td
+++ b/src/pylir/Optimizer/PylirMem/IR/PylirMemOps.td
@@ -6,8 +6,9 @@
 #define PYLIR_OPS_TABLEGEN
 
 include "pylir/Optimizer/Interfaces/CaptureInterface.td"
-include "pylir/Optimizer/PylirMem/IR/PylirMemTypes.td"
 include "pylir/Optimizer/PylirMem/IR/PylirMemAttributes.td"
+include "pylir/Optimizer/PylirMem/IR/PylirMemEnums.td"
+include "pylir/Optimizer/PylirMem/IR/PylirMemTypes.td"
 include "pylir/Optimizer/PylirPy/IR/PylirPyTraits.td"
 include "pylir/Optimizer/PylirPy/IR/PylirPyTypes.td"
 include "pylir/Optimizer/PylirPy/IR/PylirPyAttributes.td"
@@ -17,7 +18,6 @@ include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
-include "mlir/IR/EnumAttr.td"
 
 defvar ObjectAttr = PylirPy_ObjectAttr;
 defvar MemoryType = PylirMem_MemoryType;
@@ -65,25 +65,6 @@ def PylirMem_GCAllocFunctionOp : PylirMem_Op<"gcAllocFunction"> {
   let assemblyFormat = [{
     $closure_args_types attr-dict
   }];
-}
-
-/// Object layouts known to the compiler with a static size. May be replaced
-/// with some kind of type descriptors if we ever introduce custom object
-/// layouts as an optimization.
-def PylirMem_LayoutTypeAttr : I32EnumAttr<"LayoutType",
-  "Enum of types with known object layouts", [
-  I32EnumAttrCase<"Object", 0, "object">,
-  I32EnumAttrCase<"Type", 1, "type">,
-  I32EnumAttrCase<"Float", 2, "float">,
-  I32EnumAttrCase<"Function", 3, "function">,
-  I32EnumAttrCase<"Tuple", 4, "tuple">,
-  I32EnumAttrCase<"List", 5, "list">,
-  I32EnumAttrCase<"String", 6, "string">,
-  I32EnumAttrCase<"Dict", 7, "dict">,
-  I32EnumAttrCase<"Int", 8, "int">,
-  I32EnumAttrCase<"BaseException", 9>,
-]> {
-  let cppNamespace = "pylir::Mem";
 }
 
 def PylirMem_StackAllocObjectOp : PylirMem_Op<"stackAllocObject", [

--- a/src/pylir/Optimizer/PylirPy/IR/CMakeLists.txt
+++ b/src/pylir/Optimizer/PylirPy/IR/CMakeLists.txt
@@ -2,24 +2,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-set(LLVM_TARGET_DEFINITIONS PylirPyOps.td)
-mlir_tablegen(PylirPyOps.h.inc -gen-op-decls)
-mlir_tablegen(PylirPyOps.cpp.inc -gen-op-defs)
-pylir_tablegen(PylirPyOpsExtra.cpp.inc -gen-op-variable-decorators)
-mlir_tablegen(PylirPyTypes.h.inc -gen-typedef-decls --typedefs-dialect="py")
-mlir_tablegen(PylirPyTypes.cpp.inc -gen-typedef-defs --typedefs-dialect="py")
-mlir_tablegen(PylirPyDialect.h.inc -gen-dialect-decls -dialect="py")
-mlir_tablegen(PylirPyDialect.cpp.inc -gen-dialect-defs -dialect="py")
-mlir_tablegen(PylirPyEnums.h.inc -gen-enum-decls)
-mlir_tablegen(PylirPyEnums.cpp.inc -gen-enum-defs)
-mlir_tablegen(PylirPyAttributes.cpp.inc -gen-attrdef-defs
-  --attrdefs-dialect="py")
-set(LLVM_TARGET_DEFINITIONS PylirPyAttributes.td)
-mlir_tablegen(PylirPyAttributes.h.inc -gen-attrdef-decls
-  --attrdefs-dialect="py")
-add_public_tablegen_target(PylirPyIncGen)
-add_pylir_doc(PylirPyOps.td PylirPyDialect Dialect/ -gen-dialect-doc
-  -dialect="py")
+add_pylir_dialect(PylirPy py)
 
 add_pylir_interface(ATTR PylirPyAttrInterfaces)
 add_pylir_rewriter(PylirPyPatterns)

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyEnums.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyEnums.td
@@ -1,0 +1,24 @@
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef PYLIRPY_ENUMS_TABLEGEN
+#define PYLIRPY_ENUMS_TABLEGEN
+
+include "mlir/IR/EnumAttr.td"
+
+def PylirPy_IntCmpEq : I64EnumAttrCase<"eq", 0>;
+def PylirPy_IntCmpNe : I64EnumAttrCase<"ne", 1>;
+def PylirPy_IntCmpLt : I64EnumAttrCase<"lt", 2>;
+def PylirPy_IntCmpLe : I64EnumAttrCase<"le", 3>;
+def PylirPy_IntCmpGt : I64EnumAttrCase<"gt", 4>;
+def PylirPy_IntCmpGe : I64EnumAttrCase<"ge", 5>;
+
+def PylirPy_IntCmpKindAttr : I64EnumAttr<"IntCmpKind", "", [
+  PylirPy_IntCmpEq, PylirPy_IntCmpNe, PylirPy_IntCmpLt, PylirPy_IntCmpLe,
+  PylirPy_IntCmpGt, PylirPy_IntCmpGe
+]> {
+  let cppNamespace = "::pylir::Py";
+}
+
+#endif

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyOps.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyOps.td
@@ -5,10 +5,11 @@
 #ifndef PYLIR_PY_OPS_TABLEGEN
 #define PYLIR_PY_OPS_TABLEGEN
 
-include "pylir/Optimizer/PylirPy/IR/PylirPyBase.td"
-include "pylir/Optimizer/PylirPy/IR/PylirPyTypes.td"
 include "pylir/Optimizer/PylirPy/IR/PylirPyAttributes.td"
+include "pylir/Optimizer/PylirPy/IR/PylirPyBase.td"
+include "pylir/Optimizer/PylirPy/IR/PylirPyEnums.td"
 include "pylir/Optimizer/PylirPy/IR/PylirPyTraits.td"
+include "pylir/Optimizer/PylirPy/IR/PylirPyTypes.td"
 include "pylir/Optimizer/PylirPy/Interfaces/ExceptionHandlingInterface.td"
 include "pylir/Optimizer/PylirPy/Interfaces/CopyObjectInterface.td"
 include "pylir/Optimizer/PylirPy/Interfaces/OnlyReadsValueInterface.td"
@@ -18,7 +19,6 @@ include "pylir/Optimizer/Interfaces/CaptureInterface.td"
 include "pylir/Optimizer/Interfaces/SROAInterfaces.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
-include "mlir/IR/EnumAttr.td"
 include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/FunctionInterfaces.td"
@@ -973,20 +973,6 @@ def PylirPy_IntToIndexOp : PylirPy_Op<"int_toIndex", [NoMemoryEffect,
   }];
 
   let hasFolder = 1;
-}
-
-def PylirPy_IntCmpEq : I64EnumAttrCase<"eq", 0>;
-def PylirPy_IntCmpNe : I64EnumAttrCase<"ne", 1>;
-def PylirPy_IntCmpLt : I64EnumAttrCase<"lt", 2>;
-def PylirPy_IntCmpLe : I64EnumAttrCase<"le", 3>;
-def PylirPy_IntCmpGt : I64EnumAttrCase<"gt", 4>;
-def PylirPy_IntCmpGe : I64EnumAttrCase<"ge", 5>;
-
-def PylirPy_IntCmpKindAttr : I64EnumAttr<"IntCmpKind", "", [
-  PylirPy_IntCmpEq, PylirPy_IntCmpNe, PylirPy_IntCmpLt, PylirPy_IntCmpLe,
-  PylirPy_IntCmpGt, PylirPy_IntCmpGe
-]> {
-  let cppNamespace = "::pylir::Py";
 }
 
 def PylirPy_IntCmpOp : PylirPy_Op<"int_cmp", [NoMemoryEffect, NoCaptures]> {


### PR DESCRIPTION
See the discussion in https://github.com/llvm/llvm-project/pull/89627

Without having a filter for which enums should be generated by a TableGen invocation, it is currently impossible to use `-gen-enum-(decls|defs)` on any TableGen file but a dedicated `*Enums.td` file. Otherwise, `EnumAttr`s that are declared within `*Ops.td`, `*Attrs.td` or `*Types.td` files may be included from multiple dialects and multiple definitions generated.

 This PR therefore moves all `EnumAttrs` to dedicated `*Enums.td` files for each dialect to unblock future changes.