### PR TITLE
[Py] Add and use `EntryArgsBound` trait

### DIFF
--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
@@ -282,7 +282,7 @@ def PylirHIR_FunctionType : Type<
 
 def PylirHIR_GlobalFuncOp : PylirHIR_Op<"globalFunc",
   [Symbol, FunctionOpInterface, IsolatedFromAbove, OpAsmOpInterface,
-    PylirHIR_FunctionInterface]> {
+    PylirHIR_FunctionInterface, EntryArgsBound]> {
 
   let arguments = (ins StrAttr:$sym_name,
              DenseI32ArrayAttr:$default_values_mapping,
@@ -390,7 +390,7 @@ def PylirHIR_GlobalFuncOp : PylirHIR_Op<"globalFunc",
 }
 
 def PylirHIR_FuncOp : PylirHIR_Op<"func", [OpAsmOpInterface,
-  PylirHIR_FunctionInterface]> {
+  PylirHIR_FunctionInterface, EntryArgsBound]> {
 
   let arguments = (ins StrAttr:$name, Variadic<DynamicType>:$default_values,
              DenseI32ArrayAttr:$default_values_mapping,

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyOps.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyOps.td
@@ -1312,7 +1312,7 @@ def PylirPy_InvokeOp
 
 def PylirPy_FuncOp : PylirPy_Op<"func", [FunctionOpInterface, IsolatedFromAbove,
   OpAsmOpInterface, AutomaticAllocationScope, CallableOpInterface,
-  VerifyAttributesOpTrait]> {
+  EntryArgsBound, VerifyAttributesOpTrait]> {
   let arguments = (ins StrAttr:$sym_name,
            TypeAttrOf<FunctionType>:$function_type,
            OptionalAttr<StrAttr>:$sym_visibility,

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyTraits.hpp
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyTraits.hpp
@@ -33,6 +33,19 @@ class AlwaysBound : public mlir::OpTrait::TraitBase<ConcreteType, AlwaysBound> {
   }
 };
 
+/// Trait used to mark the entry blockarguments of all regions of an op as
+/// always being bound.
+template <class ConcreteType>
+class EntryArgsBound
+    : public mlir::OpTrait::TraitBase<ConcreteType, EntryArgsBound> {
+  static mlir::LogicalResult verifyTrait(mlir::Operation*) {
+    static_assert(
+        !ConcreteType::template hasTrait<mlir::OpTrait::ZeroRegions>(),
+        "'EntryArgsBound' trait is ony applicable to ops with regions");
+    return mlir::success();
+  }
+};
+
 template <class ConcreteType>
 class ReturnsImmutable
     : public mlir::OpTrait::TraitBase<ConcreteType, ReturnsImmutable> {

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyTraits.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyTraits.td
@@ -26,6 +26,10 @@ class PylirPyParamOpTrait<string name, string param>
 /// If such an operation returns an unbound result, it is undefined behaviour.
 def AlwaysBound : PylirPyOpTrait<"AlwaysBound">;
 
+/// Trait used to mark the entry blockarguments of all regions of an op as
+/// always being bound.
+def EntryArgsBound : PylirPyOpTrait<"EntryArgsBound">;
+
 /// Signifies that the results of the operation returns a new immutable object.
 /// It therefore has distinct object identity from every other object marked
 /// 'ReturnsImmutable' or a 'MemAlloc' result.

--- a/test/Optimizer/PylirHIR/IR/entry-args-bound.mlir
+++ b/test/Optimizer/PylirHIR/IR/entry-args-bound.mlir
@@ -1,0 +1,26 @@
+// RUN: pylir-opt %s --canonicalize --split-input-file | FileCheck %s
+
+// CHECK-LABEL: globalFunc @test
+pyHIR.globalFunc @test(%closure, %arg0) {
+  // CHECK: %[[FALSE:.*]] = py.constant(#py.bool<False>)
+  // CHECK: return %[[FALSE]]
+  %0 = py.isUnboundValue %arg0
+  %1 = py.bool_fromI1 %0
+  return %1
+}
+
+// -----
+
+// CHECK-LABEL: init "__main__"
+pyHIR.init "__main__" {
+  // CHECK: %[[FALSE:.*]] = py.constant(#py.bool<False>)
+
+  // CHECK: func "test"
+  %f = func "test"(%arg1) {
+    // CHECK: return %[[FALSE]]
+    %0 = py.isUnboundValue %arg1
+    %1 = py.bool_fromI1 %0
+    return %1
+  }
+  init_return %f
+}


### PR DESCRIPTION
All function ops that we have so far have the semantic of not allowing unbound references to be passed as arguments. Add a proper trait that we can attach to these operations rather on using MLIR's `FunctionOpInterface` to signify these semantics.