### PR TITLE
[PyHIR] Remove dictionary return from `init_return`

### DIFF
--- a/src/pylir/CodeGen/CodeGen.cpp
+++ b/src/pylir/CodeGen/CodeGen.cpp
@@ -583,9 +583,7 @@ public:
 
     visit(fileInput.input);
 
-    if (m_builder.getInsertionBlock())
-      create<HIR::InitReturnOp>(create<Py::ConstantOp>(m_globalDictionary));
-
+    create<HIR::InitReturnOp>();
     return m_module;
   }
 

--- a/src/pylir/Optimizer/Conversion/PylirHIRToPylirPy/PylirHIRToPylirPy.cpp
+++ b/src/pylir/Optimizer/Conversion/PylirHIRToPylirPy/PylirHIRToPylirPy.cpp
@@ -596,7 +596,7 @@ struct InitOpConversionPattern : OpRewritePattern<InitOp> {
   LogicalResult matchAndRewrite(InitOp op,
                                 PatternRewriter& rewriter) const override {
     std::string functionName = "__init__";
-    // The main init is treate specially as it is the entry point of the whole
+    // The main init is treated specially as it is the entry point of the whole
     // python program by default. It is callable with an `__init__` as that is a
     // valid C identifier.
     if (!op.isMainModule())
@@ -604,8 +604,8 @@ struct InitOpConversionPattern : OpRewritePattern<InitOp> {
 
     auto funcOp = rewriter.create<Py::FuncOp>(
         op->getLoc(), functionName,
-        rewriter.getFunctionType(/*inputs=*/{},
-                                 rewriter.getType<DynamicType>()));
+        rewriter.getFunctionType(/*inputs=*/{}, /*outputs=*/{}));
+
     // The region can be inlined directly without creating a suitable entry
     // block for the function as the function body does not need any block
     // arguments.
@@ -622,8 +622,7 @@ struct InitModuleOpConversionPattern
 
   template <class OpT>
   LogicalResult matchAndRewrite(OpT op, ExceptionRewriter& rewriter) const {
-    rewriter.create<Py::CallOp>(op.getLoc(),
-                                rewriter.getType<Py::DynamicType>(),
+    rewriter.create<Py::CallOp>(op.getLoc(), ValueRange(),
                                 (op.getModule() + ".__init__").str());
     rewriter.eraseOp(op);
     return success();

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
@@ -510,10 +510,6 @@ def PylirHIR_InitOp : PylirHIR_Op<"init", [NoRegionArguments, IsolatedFromAbove,
   let description = [{
     This op represents the initializer body of a module `$name`, or in other
     words, the global scope of a python source file.
-    The region may only be exited by an instruction throwing an exception or via
-    `pyHIR.init_return`.
-    In the latter case, a dictionary must be returned which in python are the
-    global variables of the module and the namespace of the module.
   }];
 
   let extraClassDeclaration = [{
@@ -534,15 +530,13 @@ def PylirHIR_InitOp : PylirHIR_Op<"init", [NoRegionArguments, IsolatedFromAbove,
 
 def PylirHIR_InitReturnOp : PylirHIR_Op<"init_return", [HasParent<"InitOp">,
   Terminator, ReturnLike, Pure]> {
-  let arguments = (ins DynamicType:$global_dict);
+  let arguments = (ins);
 
   let description = [{
     Op used to terminate a `pyHIR.init` body.
-    `$global_dict` are the global variables of the module and the namespace of
-    the module and MUST be a dictionary.
   }];
 
-  let assemblyFormat = "$global_dict attr-dict";
+  let assemblyFormat = "attr-dict";
 }
 
 def PylirHIR_InitModuleOp : PylirHIR_Op<"initModule",

--- a/test/Optimizer/Conversion/PylirHIRToPylirPy/init.mlir
+++ b/test/Optimizer/Conversion/PylirHIRToPylirPy/init.mlir
@@ -1,17 +1,14 @@
 // RUN: pylir-opt %s --convert-pylirHIR-to-pylirPy --split-input-file | FileCheck %s
 
-// CHECK-LABEL: py.func @foo.__init__() -> !py.dynamic
+// CHECK-LABEL: py.func @foo.__init__()
 pyHIR.init "foo" {
-  // CHECK-NEXT: %[[DICT:.*]] = makeDict
-  // CHECK-NEXT: return %[[DICT]]
-  %0 = py.makeDict ()
-  init_return %0
+  // CHECK-NEXT: return
+  init_return
 }
 
-// CHECK-LABEL: py.func @__init__() -> !py.dynamic
+// CHECK-LABEL: py.func @__init__()
 pyHIR.init "__main__" {
-  %0 = py.makeDict ()
-  // CHECK: call @foo.__init__() : () -> !py.dynamic
+  // CHECK: call @foo.__init__() : () -> ()
   initModule @foo
-  init_return %0
+  init_return
 }

--- a/test/Optimizer/PylirHIR/IR/entry-args-bound.mlir
+++ b/test/Optimizer/PylirHIR/IR/entry-args-bound.mlir
@@ -22,5 +22,6 @@ pyHIR.init "__main__" {
     %1 = py.bool_fromI1 %0
     return %1
   }
-  init_return %f
+  test.use(%f) : !py.dynamic
+  init_return
 }

--- a/test/Optimizer/PylirHIR/IR/invalid.mlir
+++ b/test/Optimizer/PylirHIR/IR/invalid.mlir
@@ -48,7 +48,7 @@ pyHIR.init "__main__" {
   %0 = py.constant(#py.dict<{}>)
   // expected-error@below {{cannot initialize '__main__' module}}
   initModule @__main__
-  init_return %0
+  init_return
 }
 
 // -----

--- a/test/Optimizer/PylirHIR/IR/roundtrip.mlir
+++ b/test/Optimizer/PylirHIR/IR/roundtrip.mlir
@@ -31,7 +31,7 @@ pyHIR.init "__main__" {
   %0 = func "foo"(%ff0 "rest") {
       return %ff0
   }
-  init_return %0
+  init_return
 }
 
 // CHECK-LABEL: pyHIR.globalFunc @call(
@@ -154,7 +154,7 @@ pyHIR.globalFunc @binAssignOp(%0, %1) {
 
 pyHIR.init "foo" {
   %0 = py.constant(#py.dict<{}>)
-  init_return %0
+  init_return
 }
 
 // CHECK-LABEL: pyHIR.globalFunc @initModule(

--- a/test/Optimizer/PylirHIR/Transform/FuncOutlining.mlir
+++ b/test/Optimizer/PylirHIR/Transform/FuncOutlining.mlir
@@ -11,11 +11,12 @@ pyHIR.init "__main__" {
   // CHECK: %[[NONE2:.*]] = py.constant(#[[$NONE]])
   // CHECK: py.setSlot %[[FUNC]][%{{.*}}] to %[[NONE1]]
   // CHECK: py.setSlot %[[FUNC]][%{{.*}}] to %[[NONE2]]
-  // CHECK: init_return %[[FUNC]]
+  // CHECK: test.use(%[[FUNC]])
   %0 = func "basic"(%ff0 "rest") {
     return %ff0
   }
-  init_return %0
+  test.use(%0) : !py.dynamic
+  init_return
 }
 
 // CHECK-LABEL: globalFunc @posDefault
@@ -52,7 +53,7 @@ pyHIR.init "func_collision" {
   %1 = func "basic"(%ff0 "rest") {
     return %ff0
   }
-  init_return %0
+  init_return
 }
 
 // CHECK: globalFunc @[[$BASIC1]](
@@ -66,7 +67,7 @@ pyHIR.init "arg_res_attrs" {
   %0 = func "basic"(%ff0 "rest" { test.name = 0 : i32 }) -> {test.name = 1 : i32} {
     return %ff0
   }
-  init_return %0
+  init_return
 }
 
 // CHECK: globalFunc @[[$BASIC1]](
@@ -83,7 +84,7 @@ pyHIR.init "non_locals" {
   %1 = func "basic"() {
     return %0
   }
-  init_return %1
+  init_return
 }
 
 // CHECK: globalFunc @[[$BASIC1]](
@@ -103,7 +104,7 @@ pyHIR.init "constants" {
   %1 = func "basic"() {
     return %0
   }
-  init_return %1
+  init_return
 }
 
 // CHECK: globalFunc @[[BASIC1]](


### PR DESCRIPTION
The argument returning a module's dictionary was a pre-mature design decision with no basis. Remove it for now until modules have actually been implemented.