### PR TITLE
[PyHIR] Add ops for reading and writing module attributes

### DIFF
--- a/src/pylir/Optimizer/Conversion/PylirHIRToPylirPy/PylirHIRToPylirPy.cpp
+++ b/src/pylir/Optimizer/Conversion/PylirHIRToPylirPy/PylirHIRToPylirPy.cpp
@@ -1097,12 +1097,13 @@ void ConvertPylirHIRToPylirPy::runOnOperation() {
   target.addIllegalDialect<HIR::PylirHIRDialect>();
 
   RewritePatternSet patterns(&getContext());
-  patterns.add<InitOpConversionPattern, ReturnOpLowering<InitReturnOp>,
-               ReturnOpLowering<HIR::ReturnOp>, GlobalFuncOpConversionPattern,
-               CallOpConversionPattern, BinOpConversionPattern,
-               BinAssignOpConversionPattern, InitModuleOpConversionPattern,
-               GetItemOpConversionPattern, SetItemOpConversionPattern,
-               DelItemOpConversionPattern, ContainsOpConversionPattern,
+  patterns
+      .add<InitOpConversionPattern, ReturnOpLowering<InitReturnOp>,
+           ReturnOpLowering<HIR::ReturnOp>, GlobalFuncOpConversionPattern,
+           CallOpConversionPattern, BinOpConversionPattern,
+           BinAssignOpConversionPattern, InitModuleOpConversionPattern,
+           GetItemOpConversionPattern, SetItemOpConversionPattern,
+           DelItemOpConversionPattern, ContainsOpConversionPattern,
            GetAttributeOpConversionPattern, SetAttrOpConversionPattern,
            ModuleGetAttrOpConversionPattern, ModuleSetAttrOpConversionPattern>(
           &getContext());

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.hpp
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.hpp
@@ -16,6 +16,7 @@
 
 #include <llvm/ADT/iterator.h>
 
+#include <pylir/Optimizer/PylirPy/IR/PylirPyAttributes.hpp>
 #include <pylir/Optimizer/PylirPy/IR/PylirPyTraits.hpp>
 #include <pylir/Optimizer/PylirPy/IR/PylirPyTypes.hpp>
 #include <pylir/Optimizer/PylirPy/Interfaces/ExceptionHandlingInterface.hpp>

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
@@ -17,6 +17,7 @@ include "pylir/Optimizer/PylirHIR/IR/PylirHIRDialect.td"
 include "pylir/Optimizer/PylirHIR/IR/PylirHIREnums.td"
 include "pylir/Optimizer/PylirHIR/IR/PylirHIRFunctionInterface.td"
 
+include "pylir/Optimizer/PylirPy/IR/PylirPyAttributes.td"
 include "pylir/Optimizer/PylirPy/IR/PylirPyTypes.td"
 include "pylir/Optimizer/PylirPy/Interfaces/ExceptionHandlingInterface.td"
 
@@ -558,6 +559,40 @@ def PylirHIR_InitModuleOp : PylirHIR_Op<"initModule",
 def PylirHIR_InitModuleExOp
   : CreateExceptionHandlingVariant<PylirHIR_InitModuleOp> {
   let hasVerifier = 1;
+}
+
+def PylirHIR_ModuleGetAttrOp : PylirHIR_Op<"module_getAttr"> {
+  let arguments = (ins
+    PylirPy_GlobalValueAttr:$module,
+    StrAttr:$attr
+  );
+
+  let description = [{
+    Op used to access an attribute of a module.
+    If the attribute was not previously bound an unbound value is returned.
+  }];
+
+  let results = (outs DynamicType:$result);
+
+  let assemblyFormat = [{
+    $module `[` $attr `]` attr-dict
+  }];
+}
+
+def PylirHIR_ModuleSetAttrOp : PylirHIR_Op<"module_setAttr"> {
+  let arguments = (ins
+    PylirPy_GlobalValueAttr:$module,
+    StrAttr:$attr,
+    DynamicType:$value
+  );
+
+  let description = [{
+    Op used to bind a value to an attribute of a module.
+  }];
+
+  let assemblyFormat = [{
+    $module `[` $attr `]` `to` $value attr-dict
+  }];
 }
 
 #endif

--- a/test/Optimizer/Conversion/PylirHIRToPylirPy/moduleGetAttrOp.mlir
+++ b/test/Optimizer/Conversion/PylirHIRToPylirPy/moduleGetAttrOp.mlir
@@ -1,0 +1,17 @@
+// RUN: pylir-opt %s --convert-pylirHIR-to-pylirPy --split-input-file | FileCheck %s
+
+// CHECK: #[[$MODULE:.*]] = #py.globalValue<module>
+#module = #py.globalValue<module>
+
+// CHECK-LABEL: py.func @test$impl(
+pyHIR.globalFunc @test(%closure) {
+  // CHECK: %[[C:.*]] = constant(#[[$MODULE]])
+  // CHECK: %[[INDEX:.*]] = arith.constant
+  // CHECK: %[[DICT:.*]] = getSlot %[[C]][%[[INDEX]]]
+  // CHECK: %[[KEY:.*]] = constant(#py.str<"foo">)
+  // CHECK: %[[HASH:.*]] = str_hash %[[KEY]]
+  // CHECK: %[[RET:.*]] = dict_tryGetItem %[[DICT]][%[[KEY]] hash(%[[HASH]])]
+  %0 = module_getAttr #module["foo"]
+  // CHECK: return %[[RET]]
+  return %0
+}

--- a/test/Optimizer/Conversion/PylirHIRToPylirPy/moduleSetAttrOp.mlir
+++ b/test/Optimizer/Conversion/PylirHIRToPylirPy/moduleSetAttrOp.mlir
@@ -1,0 +1,17 @@
+// RUN: pylir-opt %s --convert-pylirHIR-to-pylirPy --split-input-file | FileCheck %s
+
+// CHECK: #[[$MODULE:.*]] = #py.globalValue<module>
+#module = #py.globalValue<module>
+
+// CHECK-LABEL: py.func @test$impl(
+// CHECK-SAME: %[[CLOSURE:[[:alnum:]]+]]
+pyHIR.globalFunc @test(%closure) {
+  // CHECK: %[[C:.*]] = constant(#[[$MODULE]])
+  // CHECK: %[[INDEX:.*]] = arith.constant
+  // CHECK: %[[DICT:.*]] = getSlot %[[C]][%[[INDEX]]]
+  // CHECK: %[[KEY:.*]] = constant(#py.str<"foo">)
+  // CHECK: %[[HASH:.*]] = str_hash %[[KEY]]
+  // CHECK: dict_setItem %[[DICT]][%[[KEY]] hash(%[[HASH]])] to %[[CLOSURE]]
+  module_setAttr #module["foo"] to %closure
+  return %closure
+}


### PR DESCRIPTION
These ops are the first step to introducing module objects into the frontend. Of note is that modules attributes are equal to the global dictionary of a module being initialized. These ops are therefore specially designed for this kind of access.

The lowering is currently far from perfect as it makes the assumption of a `__dict__` slot being present and containing a dictionary in the modules object. This creates an undesirable coupling to the frontend. I do not yet have a better idea how to implement this