### PR TITLE
[PyHIR] Add `class` op for representing class definitions

### DIFF
--- a/src/pylir/Optimizer/PylirHIR/IR/CMakeLists.txt
+++ b/src/pylir/Optimizer/PylirHIR/IR/CMakeLists.txt
@@ -4,14 +4,14 @@
 
 add_pylir_dialect(PylirHIR pyHIR)
 
-add_pylir_interface(OP PylirHIRFunctionInterface)
+add_pylir_interface(OP PylirHIRInterfaces)
 
 add_library(PylirHIRDialect
   PylirHIRDialect.cpp
   PylirHIROps.cpp
 )
 add_dependencies(PylirHIRDialect
-  PylirHIRFunctionInterfaceIncGen
+  PylirHIRInterfacesIncGen
   PylirHIRIncGen
 )
 target_link_libraries(PylirHIRDialect

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIRInterfaces.td
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIRInterfaces.td
@@ -105,4 +105,50 @@ def PylirHIR_FunctionInterface : OpInterface<"FunctionInterface",
   }];
 }
 
+def PylirHIR_CallInterface : OpInterface<"CallInterface"> {
+  let cppNamespace = "::pylir::HIR";
+
+  let methods = [
+    InterfaceMethod<[{
+
+    }],
+    "::llvm::ArrayRef<int32_t>", "getKindInternal">,
+    InterfaceMethod<[{
+
+    }],
+    "::mlir::ArrayAttr", "getKeywords">,
+  ];
+
+  let extraSharedClassDeclaration = [{
+
+    enum Kind {
+      Positional = 1,
+      PosExpansion = 2,
+      MapExpansion = 3,
+      Keyword = 0, // zero and any kind of negative value in reality.
+    };
+
+    /// Returns true if the argument at the given index is a positional
+    /// expansion.
+    bool isPosExpansion(std::size_t index) {
+      return $_op.getKindInternal()[index] == Kind::PosExpansion;
+    }
+
+    /// Returns true if the argument at the given index is a map expansion.
+    bool isMapExpansion(std::size_t index) {
+      return $_op.getKindInternal()[index] == Kind::MapExpansion;
+    }
+
+    /// Returns the keyword of the argument at the given index.
+    /// Returns a null attribute if the argument is not a keyword argument.
+    mlir::StringAttr getKeyword(std::size_t index) {
+      if ($_op.getKindInternal()[index] > 0)
+        return nullptr;
+      return mlir::cast<mlir::StringAttr>(
+        $_op.getKeywords()[-$_op.getKindInternal()[index]]);
+    }
+  }];
+}
+
+
 #endif

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.cpp
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.cpp
@@ -19,10 +19,10 @@ using namespace HIR;
 
 /// arg ::= [`*` | `**` | string-attr `=`] value-use
 /// call-arguments ::= <arg> { `,` <arg> }
-ParseResult HIR::parseCallArguments(
-    OpAsmParser& parser, ArrayAttr& keywords,
-    SmallVectorImpl<OpAsmParser::UnresolvedOperand>& arguments,
-    DenseI32ArrayAttr& kindInternal) {
+static ParseResult
+parseCallArguments(OpAsmParser& parser, ArrayAttr& keywords,
+                   SmallVectorImpl<OpAsmParser::UnresolvedOperand>& arguments,
+                   DenseI32ArrayAttr& kindInternal) {
   SmallVector<Attribute> keywordsStorage;
   SmallVector<std::int32_t> kindInternalStorage;
 
@@ -35,9 +35,9 @@ ParseResult HIR::parseCallArguments(
 
     if (succeeded(parser.parseOptionalStar())) {
       if (succeeded(parser.parseOptionalStar())) {
-        kindInternalStorage.push_back(CallOp::MapExpansion);
+        kindInternalStorage.push_back(CallInterface::MapExpansion);
       } else {
-        kindInternalStorage.push_back(CallOp::PosExpansion);
+        kindInternalStorage.push_back(CallInterface::PosExpansion);
       }
     } else {
       StringAttr temp;
@@ -50,7 +50,7 @@ ParseResult HIR::parseCallArguments(
             -static_cast<std::int32_t>(keywordsStorage.size()));
         keywordsStorage.push_back(temp);
       } else {
-        kindInternalStorage.push_back(CallOp::Positional);
+        kindInternalStorage.push_back(CallInterface::Positional);
       }
     }
 
@@ -63,10 +63,9 @@ ParseResult HIR::parseCallArguments(
   return success();
 }
 
-namespace {
 template <class OpT>
-void printCallArguments(OpAsmPrinter& printer, OpT callOp, ArrayAttr,
-                        ValueRange, DenseI32ArrayAttr) {
+static void printCallArguments(OpAsmPrinter& printer, OpT callOp, ArrayAttr,
+                               ValueRange, DenseI32ArrayAttr) {
   llvm::interleaveComma(
       CallArgumentRange(callOp), printer.getStream(),
       [&](const CallArgument& argument) {
@@ -79,10 +78,10 @@ void printCallArguments(OpAsmPrinter& printer, OpT callOp, ArrayAttr,
         printer << argument.value;
       });
 }
-} // namespace
 
-void CallOp::build(OpBuilder& odsBuilder, OperationState& odsState,
-                   Value callable, ArrayRef<CallArgument> arguments) {
+template <class OpT>
+static void buildCallArguments(OpBuilder& odsBuilder, OperationState& odsState,
+                               ArrayRef<CallArgument> arguments) {
   SmallVector<std::int32_t> kindInternal;
   SmallVector<Value> argOperands;
   SmallVector<Attribute> keywords;
@@ -91,13 +90,13 @@ void CallOp::build(OpBuilder& odsBuilder, OperationState& odsState,
     match(
         argument.kind,
         [&](CallArgument::PosExpansionTag) {
-          kindInternal.push_back(PosExpansion);
+          kindInternal.push_back(OpT::PosExpansion);
         },
         [&](CallArgument::MapExpansionTag) {
-          kindInternal.push_back(MapExpansion);
+          kindInternal.push_back(OpT::MapExpansion);
         },
         [&](CallArgument::PositionalTag) {
-          kindInternal.push_back(Positional);
+          kindInternal.push_back(OpT::Positional);
         },
         [&](StringAttr stringAttr) {
           kindInternal.push_back(-static_cast<std::int32_t>(keywords.size()));
@@ -105,13 +104,18 @@ void CallOp::build(OpBuilder& odsBuilder, OperationState& odsState,
         });
   }
 
+  odsState.addOperands(argOperands);
+  odsState.getOrAddProperties<typename OpT::Properties>().keywords =
+      odsBuilder.getArrayAttr(keywords);
+  odsState.getOrAddProperties<typename OpT::Properties>().kind_internal =
+      odsBuilder.getDenseI32ArrayAttr(kindInternal);
+}
+
+void CallOp::build(OpBuilder& odsBuilder, OperationState& odsState,
+                   Value callable, ArrayRef<CallArgument> arguments) {
   odsState.addTypes(odsBuilder.getType<Py::DynamicType>());
   odsState.addOperands(callable);
-  odsState.addOperands(argOperands);
-  odsState.getOrAddProperties<Properties>().keywords =
-      odsBuilder.getArrayAttr(keywords);
-  odsState.getOrAddProperties<Properties>().kind_internal =
-      odsBuilder.getDenseI32ArrayAttr(kindInternal);
+  buildCallArguments<CallOp>(odsBuilder, odsState, arguments);
 }
 
 void CallOp::build(OpBuilder& odsBuilder, OperationState& odsState,
@@ -592,6 +596,43 @@ void FuncOp::print(OpAsmPrinter& p) {
 
   printFunction(p, FunctionParameterRange(*this), resAttrs,
                 (*this)->getAttrDictionary(), getAttributeNames(), getRegion());
+}
+
+//===----------------------------------------------------------------------===//
+// ClassOp
+//===----------------------------------------------------------------------===//
+
+void ClassOp::build(OpBuilder& odsBuilder, OperationState& odsState,
+                    StringRef className, ArrayRef<CallArgument> arguments,
+                    function_ref<void(Block*)> bodyBuilder) {
+  odsState.addTypes(odsBuilder.getType<Py::DynamicType>());
+  buildCallArguments<ClassOp>(odsBuilder, odsState, arguments);
+  odsState.getOrAddProperties<Properties>().setName(
+      odsBuilder.getStringAttr(className));
+  Region* region = odsState.addRegion();
+  Block* entryBlock = &region->emplaceBlock();
+  entryBlock->addArgument(odsBuilder.getType<Py::DynamicType>(),
+                          odsState.location);
+  bodyBuilder(entryBlock);
+}
+
+template <class OpT>
+static LogicalResult verifyClass(OpT op) {
+  if (op.getRegion().empty() || op.getRegion().front().getNumArguments() != 1 ||
+      !isa<Py::DynamicType>(op.getRegion().front().getArgument(0).getType()))
+    return op.emitOpError("expected entry block of ")
+           << op.getOperationName() << " to have exactly one "
+           << Py::DynamicType::name << " argument";
+
+  return success();
+}
+
+LogicalResult ClassOp::verify() {
+  return verifyClass(*this);
+}
+
+LogicalResult ClassExOp::verify() {
+  return verifyClass(*this);
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.hpp
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.hpp
@@ -24,7 +24,7 @@
 #include "PylirHIRAttributes.hpp"
 #include "PylirHIRDialect.hpp"
 
-#include "pylir/Optimizer/PylirHIR/IR/PylirHIRFunctionInterface.h.inc"
+#include "pylir/Optimizer/PylirHIR/IR/PylirHIRInterfaces.h.inc"
 
 namespace pylir::HIR {
 

--- a/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
+++ b/src/pylir/Optimizer/PylirHIR/IR/PylirHIROps.td
@@ -15,7 +15,7 @@ include "mlir/Interfaces/InferTypeOpInterface.td"
 
 include "pylir/Optimizer/PylirHIR/IR/PylirHIRDialect.td"
 include "pylir/Optimizer/PylirHIR/IR/PylirHIREnums.td"
-include "pylir/Optimizer/PylirHIR/IR/PylirHIRFunctionInterface.td"
+include "pylir/Optimizer/PylirHIR/IR/PylirHIRInterfaces.td"
 
 include "pylir/Optimizer/PylirPy/IR/PylirPyAttributes.td"
 include "pylir/Optimizer/PylirPy/IR/PylirPyTypes.td"
@@ -183,7 +183,8 @@ def PylirHIR_SetAttrExOp
 //===----------------------------------------------------------------------===//
 
 def PylirHIR_CallOp : PylirHIR_Op<"call",
-  [AddableExceptionHandling<"CallExOp", ["Single", "Variadic"]>]> {
+  [AddableExceptionHandling<"CallExOp", ["Single", "Variadic"]>,
+   PylirHIR_CallInterface]> {
   let arguments = (ins DynamicType:$callable,
     Variadic<DynamicType>:$arguments,
     DefaultValuedAttr<StrArrayAttr, "{}">:$keywords,
@@ -221,42 +222,6 @@ def PylirHIR_CallOp : PylirHIR_Op<"call",
   let skipDefaultBuilders = 1;
 
   let hasVerifier = 1;
-
-  let extraClassDeclaration = [{
-  private:
-    friend mlir::ParseResult parseCallArguments(mlir::OpAsmParser& parser,
-      mlir::ArrayAttr& keywords,
-      llvm::SmallVectorImpl<mlir::OpAsmParser::UnresolvedOperand>& arguments,
-      mlir::DenseI32ArrayAttr& kindInternal);
-
-    enum Kind {
-      Positional = 1,
-      PosExpansion = 2,
-      MapExpansion = 3,
-      Keyword = 0, // zero and any kind of negative value in reality.
-    };
-
-  public:
-
-    /// Returns true if the argument at the given index is a positional
-    /// expansion.
-    bool isPosExpansion(std::size_t index) {
-      return getKindInternal()[index] == Kind::PosExpansion;
-    }
-
-    /// Returns true if the argument at the given index is a map expansion.
-    bool isMapExpansion(std::size_t index) {
-      return getKindInternal()[index] == Kind::MapExpansion;
-    }
-
-    /// Returns the keyword of the argument at the given index.
-    /// Returns a null attribute if the argument is not a keyword argument.
-    mlir::StringAttr getKeyword(std::size_t index) {
-      if (getKindInternal()[index] > 0)
-        return nullptr;
-      return mlir::cast<mlir::StringAttr>(getKeywords()[-getKindInternal()[index]]);
-    }
-  }];
 }
 
 def PylirHIR_CallExOp : CreateExceptionHandlingVariant<PylirHIR_CallOp>;
@@ -493,6 +458,79 @@ def PylirHIR_ReturnOp : PylirHIR_Op<"return", [Pure, ReturnLike, Terminator,
   }];
 
   let assemblyFormat = "$value attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
+// Classes
+//===----------------------------------------------------------------------===//
+
+def PylirHIR_ClassOp : PylirHIR_Op<"class", [
+    OpAsmOpInterface, PylirHIR_CallInterface,
+    AddableExceptionHandling<"ClassExOp">,
+]> {
+  let arguments = (ins
+    StrAttr:$name,
+    Variadic<DynamicType>:$arguments,
+    DefaultValuedAttr<StrArrayAttr, "{}">:$keywords,
+    DefaultValuedAttr<DenseI32ArrayAttr, "{}">:$kind_internal
+  );
+
+  let results = (outs DynamicType:$result);
+
+  let regions = (region MinSizedRegion<1>:$body);
+
+  let assemblyFormat = [{
+    $name ( `(`
+      custom<CallArguments>($keywords,
+                            $arguments,
+                            $kind_internal)^ `)` )? attr-dict-with-keyword
+    $body
+  }];
+
+  let builders = [
+    OpBuilder<(ins "llvm::StringRef":$className,
+                   "llvm::ArrayRef<CallArgument>":$arguments,
+                   "llvm::function_ref<void(mlir::Block*)>":$bodyBuilder
+    )>
+  ];
+
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+
+    mlir::BlockArgument getDictParameter() {
+      return getBody().front().getArgument(0);
+    }
+
+    //===------------------------------------------------------------------===//
+    // OpAsmOpInterface implementation
+    //===------------------------------------------------------------------===//
+
+    static llvm::StringRef getDefaultDialect() {
+      return pylir::HIR::PylirHIRDialect::getDialectNamespace();
+    }
+
+    void getAsmBlockArgumentNames(mlir::Region& region,
+                                  mlir::OpAsmSetValueNameFn setNameFn) {
+      setNameFn(getDictParameter(), "dict");
+    }
+  }];
+}
+
+def PylirHIR_ClassExOp : CreateExceptionHandlingVariant<PylirHIR_ClassOp,
+  /*name=*/"", /*newline=*/0> {
+  let hasVerifier = 1;
+}
+
+def PylirHIR_ClassReturnOp : PylirHIR_Op<"class_return",
+  [ParentOneOf<["ClassOp", "ClassExOp"]>, Terminator, ReturnLike, Pure]> {
+  let arguments = (ins);
+
+  let description = [{
+    Op used to terminate a `pyHIR.class` body.
+  }];
+
+  let assemblyFormat = "attr-dict";
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/pylir/Optimizer/PylirPy/Interfaces/ExceptionHandlingInterface.td
+++ b/src/pylir/Optimizer/PylirPy/Interfaces/ExceptionHandlingInterface.td
@@ -87,7 +87,7 @@ def AddableExceptionHandlingInterface : OpInterface<"AddableExceptionHandlingInt
 /// automatically.
 /// If 'opName' is empty, its mnemonic is the mnemonic of 'op' with 'Ex' as
 /// suffix.
-class CreateExceptionHandlingVariant<Op op, string opName = "">
+class CreateExceptionHandlingVariant<Op op, string opName = "", bit newline = 1>
   : Op<op.opDialect, !if(!empty(opName), !strconcat(op.opName, "Ex"), opName),
     !listconcat(!filter(x, op.traits, !not(!isa<AddableExceptionHandling>(x))),
       [Terminator, AttrSizedOperandSegments,
@@ -108,8 +108,9 @@ class CreateExceptionHandlingVariant<Op op, string opName = "">
   let successors = (successor AnySuccessor:$happy_path,
                               AnySuccessor:$exception_path);
 
-  let assemblyFormat = !strconcat(op.assemblyFormat, [{
-    `\n` ` ` ` ` `label` $happy_path ( `(` $normal_dest_operands^ `:` type($normal_dest_operands) `)`)?
+  let assemblyFormat = !strconcat(op.assemblyFormat,
+    !if(newline, [{`\n` ` ` ` `}], " ") # [{
+     `label` $happy_path ( `(` $normal_dest_operands^ `:` type($normal_dest_operands) `)`)?
            `unwind` $exception_path ( `(` $unwind_dest_operands^ `:` type($unwind_dest_operands) `)`)?
   }]);
 

--- a/test/Optimizer/PylirHIR/IR/invalid.mlir
+++ b/test/Optimizer/PylirHIR/IR/invalid.mlir
@@ -75,3 +75,13 @@ pyHIR.globalFunc @wrong_closure_param_2(%closure has_default) {
   %0 = py.constant(#py.int<3>)
   return %0
 }
+
+// -----
+
+pyHIR.globalFunc @wrong_block_args1(%closure) {
+  // expected-error@below {{expected entry block of pyHIR.class to have exactly one py.dynamic argument}}
+  %0 = class "test" {
+    class_return
+  }
+  return %0
+}

--- a/test/Optimizer/PylirHIR/IR/roundtrip.mlir
+++ b/test/Optimizer/PylirHIR/IR/roundtrip.mlir
@@ -186,3 +186,24 @@ pyHIR.globalFunc @contains(%container, %item) {
   %0 = contains %item in %container
   return %0
 }
+
+// CHECK-LABEL: pyHIR.globalFunc @class(
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+pyHIR.globalFunc @class(%container, %item) {
+  // CHECK: class "test"(%[[ARG1]], "metaclass"=%[[ARG0]])
+  %0 = class "test"(%item, "metaclass"=%container) {
+  ^bb0(%dict : !py.dynamic):
+    class_return
+  }
+  // CHECK: classEx "test"(%[[ARG1]], "metaclass"=%[[ARG0]]) {
+  // CHECK: } label ^{{[[:alnum:]]+}} unwind ^{{[[:alnum:]]+}}
+  %1 = classEx "test"(%item, "metaclass"=%container) {
+  ^bb0(%dict : !py.dynamic):
+    class_return
+  } label ^bb0 unwind ^bb1
+^bb0:
+  return %0
+^bb1(%e : !py.dynamic):
+  return %e
+}


### PR DESCRIPTION
This op is designed as the lowering target from the Python AST closely mirroring class definitions in Python. The PR does not yet implement a lowering to the py dialect nor the CodeGen from AST to the new op.