### PR TITLE
[Parser] fix error when using a keyword rest parameter after defaults

### DIFF
--- a/src/pylir/Parser/ParserCompounds.cpp
+++ b/src/pylir/Parser/ParserCompounds.cpp
@@ -600,7 +600,8 @@ pylir::Parser::parseParameterList() {
         return std::nullopt;
       maybeDefault = std::move(*defaultVal);
     }
-    if (!maybeDefault && seenDefaultParam) {
+    if (currentKind != Syntax::Parameter::KeywordRest && !maybeDefault &&
+        seenDefaultParam) {
       createError(
           *identifier,
           Diag::

--- a/test/Parser/compounds-verify.py
+++ b/test/Parser/compounds-verify.py
@@ -1,0 +1,5 @@
+# RUN: pylir %s -fsyntax-only -verify
+
+def test(default=5, **kwargs):
+    pass
+


### PR DESCRIPTION
The logic was not considering that keyword rest parameter cannot have defaults and does not need a default, even if previous parameters had defaults.