### PR TITLE
[Runtime] Run "finalizers" before deallocation

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -72,7 +72,6 @@ Checks: >
   clang-analyzer-core.builtin.NoReturnFunctions,
   clang-analyzer-core.DynamicTypePropagation,
   clang-analyzer-core.NonnilStringConstants,
-  clang-analyzer-core.NonNullParamChecker,
   clang-analyzer-core.NullDereference,
   clang-analyzer-core.StackAddrEscapeBase,
   clang-analyzer-core.UndefinedBinaryOperatorResult,

--- a/src/pylir/Runtime/MarkAndSweep/BestFitTree.hpp
+++ b/src/pylir/Runtime/MarkAndSweep/BestFitTree.hpp
@@ -138,7 +138,7 @@ public:
     PYLIR_ASSERT(lowerBlockSizeLimit >= sizeof(Node));
   }
 
-  ~BestFitTree();
+  ~BestFitTree() = default;
   BestFitTree(BestFitTree&&) noexcept = default;
   BestFitTree& operator=(BestFitTree&&) noexcept = default;
   BestFitTree(const BestFitTree&) = delete;
@@ -149,6 +149,8 @@ public:
   void free(PyObject* object);
 
   void sweep();
+
+  void finalize();
 };
 
 } // namespace pylir::rt

--- a/src/pylir/Runtime/MarkAndSweep/MarkAndSweep.cpp
+++ b/src/pylir/Runtime/MarkAndSweep/MarkAndSweep.cpp
@@ -108,6 +108,13 @@ void pylir::rt::MarkAndSweep::collect() {
     });
   }
   mark(stackLower, stackUpper, std::move(roots));
+
+  m_unit2.finalize();
+  m_unit4.finalize();
+  m_unit6.finalize();
+  m_unit8.finalize();
+  m_tree.finalize();
+
   m_unit2.sweep();
   m_unit4.sweep();
   m_unit6.sweep();

--- a/src/pylir/Runtime/MarkAndSweep/MarkAndSweep.hpp
+++ b/src/pylir/Runtime/MarkAndSweep/MarkAndSweep.hpp
@@ -22,6 +22,14 @@ class MarkAndSweep {
   BestFitTree m_tree{8 * alignof(MaxAligned)};
 
 public:
+  ~MarkAndSweep() {
+    m_unit2.finalize();
+    m_unit4.finalize();
+    m_unit6.finalize();
+    m_unit8.finalize();
+    m_tree.finalize();
+  }
+
   PyObject* alloc(std::size_t count);
 
   void collect();

--- a/src/pylir/Runtime/MarkAndSweep/SegregatedFreeList.cpp
+++ b/src/pylir/Runtime/MarkAndSweep/SegregatedFreeList.cpp
@@ -47,62 +47,85 @@ pylir::rt::PagePtr pylir::rt::SegregatedFreeList::newPage() const {
   return result;
 }
 
-pylir::rt::SegregatedFreeList::~SegregatedFreeList() {
-  auto iter = m_pages.begin();
-  for (; iter != m_pages.end(); iter++) {
-    auto* end = getEndCell(*iter, m_sizeClass);
-    if (m_head >= iter->get() && m_head < end)
-      break;
-    for (std::byte* begin = iter->get(); begin != end; begin += m_sizeClass)
-      destroyPyObject(*reinterpret_cast<PyObject*>(begin));
-  }
-  for (; iter != m_pages.end(); iter++) {
-    auto* end = getEndCell(*iter, m_sizeClass);
-    for (std::byte* begin = iter->get(); begin != end; begin += m_sizeClass) {
-      if (begin == m_head) {
-        std::memcpy(&m_head, begin, sizeof(std::byte*));
-        continue;
-      }
-      destroyPyObject(*reinterpret_cast<PyObject*>(begin));
-    }
+void pylir::rt::SegregatedFreeList::finalize() {
+  for (PyObject& object : *this) {
+    if (object.getMark<bool>())
+      continue;
+
+    destroyPyObject(object);
   }
 }
 
 void pylir::rt::SegregatedFreeList::sweep() {
-  std::byte* newHead = nullptr;
-  std::byte* lastFree = nullptr;
-  auto iter = m_pages.begin();
-  for (; iter != m_pages.end(); iter++) {
-    auto* end = getEndCell(*iter, m_sizeClass);
-    for (std::byte* begin = iter->get(); begin != end; begin += m_sizeClass) {
-      if (begin == m_head) {
-        if (lastFree)
-          std::memcpy(lastFree, &m_head, sizeof(std::byte*));
-        else
-          newHead = m_head;
-
-        lastFree = m_head;
-        std::memcpy(&m_head, m_head, sizeof(std::byte*));
-        continue;
-      }
-      auto* object = reinterpret_cast<PyObject*>(begin);
-      if (object->getMark<bool>()) {
-        object->clearMarking();
-        continue;
-      }
-      destroyPyObject(*object);
-      if (!newHead) {
-        newHead = reinterpret_cast<std::byte*>(object);
-        lastFree = newHead;
-      } else {
-        std::memcpy(lastFree, &object, sizeof(std::byte*));
-        lastFree = reinterpret_cast<std::byte*>(object);
-      }
+  auto iter = begin();
+  for (; iter != end();) {
+    PyObject& object = *iter;
+    if (object.getMark<bool>()) {
+      object.clearMarking();
+      iter++;
+      continue;
     }
+    iter = erase(iter);
   }
-  if (lastFree) {
-    std::byte* nullPointer = nullptr;
-    std::memcpy(lastFree, &nullPointer, sizeof(std::byte*));
+}
+
+auto pylir::rt::SegregatedFreeList::erase(iterator iter) -> iterator {
+  if (!iter.m_newHead) {
+    // If the free list head wasn't discovered previously, then this slot will
+    // become the new head.
+    m_head = iter.m_newHead = iter.m_byteIter;
+    iter.m_previousFreeList = iter.m_newHead;
+  } else {
+    // Redirect the previous entry in the free list to the new free slot.
+    std::memcpy(iter.m_previousFreeList, &iter.m_byteIter, sizeof(std::byte*));
+    iter.m_previousFreeList = iter.m_byteIter;
   }
-  m_head = newHead;
+  // Link the new free slot to the next free list slot.
+  std::memcpy(iter.m_byteIter, &iter.m_currentFreeList, sizeof(std::byte*));
+
+  PYLIR_ASSERT(!iter.m_currentFreeList ||
+               iter.m_previousFreeList < iter.m_currentFreeList);
+
+  ++iter;
+  return iter;
+}
+
+bool pylir::rt::SegregatedFreeList::iterator::incrementSlot() {
+  m_byteIter += m_freeList->m_sizeClass;
+  if (m_byteIter == getEndCell(*m_pageIter, m_freeList->m_sizeClass)) {
+    m_pageIter++;
+    if (m_pageIter == m_freeList->m_pages.end()) {
+      m_byteIter = nullptr;
+      return true;
+    }
+
+    m_byteIter = m_pageIter->get();
+  }
+  return false;
+}
+
+void pylir::rt::SegregatedFreeList::iterator::skipThroughFreeList() {
+  if (!m_byteIter)
+    return;
+
+  while (m_byteIter == m_currentFreeList) {
+    // If no head has been found previously, set the new head to the
+    // current one.
+    if (!m_newHead)
+      m_newHead = m_currentFreeList;
+
+    m_previousFreeList = m_currentFreeList;
+    // Forward in the linked list.
+    std::memcpy(&m_currentFreeList, m_currentFreeList, sizeof(std::byte*));
+    PYLIR_ASSERT(!m_currentFreeList || m_previousFreeList < m_currentFreeList);
+    if (incrementSlot())
+      return;
+  }
+}
+
+auto pylir::rt::SegregatedFreeList::iterator::operator++() -> iterator& {
+  if (incrementSlot())
+    return *this;
+  skipThroughFreeList();
+  return *this;
 }

--- a/src/pylir/Runtime/MarkAndSweep/SegregatedFreeList.hpp
+++ b/src/pylir/Runtime/MarkAndSweep/SegregatedFreeList.hpp
@@ -23,7 +23,7 @@ class SegregatedFreeList {
 public:
   explicit SegregatedFreeList(std::size_t sizeClass) : m_sizeClass(sizeClass) {}
 
-  ~SegregatedFreeList();
+  ~SegregatedFreeList() = default;
   SegregatedFreeList(SegregatedFreeList&&) noexcept = default;
   SegregatedFreeList& operator=(SegregatedFreeList&&) noexcept = default;
   SegregatedFreeList(const SegregatedFreeList&) = delete;
@@ -31,6 +31,78 @@ public:
 
   PyObject* nextCell();
 
+  void finalize();
+
   void sweep();
+
+  class iterator {
+    SegregatedFreeList* m_freeList = nullptr;
+    decltype(m_pages)::iterator m_pageIter{};
+    std::byte* m_byteIter = nullptr;
+    std::byte* m_currentFreeList = nullptr;
+    std::byte* m_previousFreeList = nullptr;
+    std::byte* m_newHead = nullptr;
+
+    friend class SegregatedFreeList;
+
+    bool incrementSlot();
+
+    void skipThroughFreeList();
+
+  public:
+    iterator() = default;
+
+    iterator(SegregatedFreeList* freeList, decltype(m_pages)::iterator pageIter,
+             std::byte* byteIter)
+        : m_freeList(freeList), m_pageIter(pageIter), m_byteIter(byteIter),
+          m_currentFreeList(freeList->m_head) {
+      skipThroughFreeList();
+    }
+
+    using difference_type = std::ptrdiff_t;
+    using value_type = PyObject;
+    using reference = value_type&;
+    using pointer = value_type*;
+
+    reference operator*() const {
+      return *this->operator->();
+    }
+
+    pointer operator->() const {
+      return reinterpret_cast<PyObject*>(m_byteIter);
+    }
+
+    iterator& operator++();
+
+    iterator operator++(int) {
+      iterator temp = *this;
+      ++*this;
+      return temp;
+    }
+
+    bool operator!=(const iterator& rhs) const {
+      return std::tuple(m_freeList, m_pageIter, m_byteIter) !=
+             std::tuple(rhs.m_freeList, rhs.m_pageIter, rhs.m_byteIter);
+    }
+
+    std::byte* getPreviousHead() const {
+      return m_previousFreeList;
+    }
+
+    std::byte* getNewHead() const {
+      return m_newHead;
+    }
+  };
+
+  iterator begin() {
+    return iterator(this, m_pages.begin(),
+                    m_pages.empty() ? nullptr : m_pages.begin()->get());
+  }
+
+  iterator end() {
+    return iterator(this, m_pages.end(), nullptr);
+  }
+
+  iterator erase(iterator iter);
 };
 } // namespace pylir::rt


### PR DESCRIPTION
A finalizer that accesses other objects' state may crash or read invalid data if that object has already been deallocated. This is commonly the case for type instances where both the type and the instance get garbage collected at once.

This PR fixes that issue by first finalizing all objects before deallocating them. Custom finalizers and resurrection are out of scope for this PR.