### PR TITLE
[Py] Add `makeType` op and lowering

### DIFF
--- a/src/pylir/Optimizer/Conversion/PylirPyToPylirMem/PylirPyToPylirMem.cpp
+++ b/src/pylir/Optimizer/Conversion/PylirPyToPylirMem/PylirPyToPylirMem.cpp
@@ -69,7 +69,8 @@ void ConvertPylirPyToPylirMem::runOnOperation() {
       pylir::Py::IntFromSignedOp, pylir::Py::IntFromUnsignedOp,
       pylir::Py::StrConcatOp, pylir::Py::IntToStrOp, pylir::Py::StrCopyOp,
       pylir::Py::TupleDropFrontOp, pylir::Py::TuplePrependOp,
-      pylir::Py::IntAddOp, pylir::Py::TupleCopyOp, pylir::Py::FloatFromF64>();
+      pylir::Py::IntAddOp, pylir::Py::TupleCopyOp, pylir::Py::FloatFromF64,
+      pylir::Py::MakeTypeOp>();
 
   mlir::RewritePatternSet patterns(&getContext());
   populateWithGenerated(patterns);

--- a/src/pylir/Optimizer/Conversion/PylirPyToPylirMem/PylirPyToPylirMem.td
+++ b/src/pylir/Optimizer/Conversion/PylirPyToPylirMem/PylirPyToPylirMem.td
@@ -121,4 +121,12 @@ def : Pat<(PylirPy_MakeObjectOp $typeObj),
   (PylirMem_InitObjectOp (PylirMem_GCAllocObjectOp $typeObj,
     (PylirPy_TupleLenOp (PylirPy_TypeSlotsOp $typeObj))))>;
 
+def : Pat<(PylirPy_MakeTypeOp $name, $mro_tuple, $slots_tuple),
+  (PylirMem_InitTypeOp GCWithSlots<TypeRef>.result, $name,
+    (PylirMem_GCAllocObjectOp (PylirPy_ConstantOp TupleRef),
+      (Arith_AddIOp (PylirPy_TupleLenOp $mro_tuple),
+        (Arith_ConstantOp ConstantAttr<IndexAttr, "1">),
+          WrapOverflowFlag)),
+    $mro_tuple, $slots_tuple)>;
+
 #endif

--- a/src/pylir/Optimizer/Conversion/PylirToLLVMIR/CodeGenState.hpp
+++ b/src/pylir/Optimizer/Conversion/PylirToLLVMIR/CodeGenState.hpp
@@ -406,6 +406,12 @@ struct Array : Model<Array<ElementModel>, mlir::LLVM::LLVMArrayType> {
                 this->m_pointer, llvm::ArrayRef<mlir::LLVM::GEPArg>{0, index}),
             this->m_elementType.getElementType(), this->m_codeGenState};
   }
+
+  template <class T>
+  std::enable_if_t<std::is_enum_v<T>, ElementModel> at(mlir::Location loc,
+                                                       T index) const {
+    return at(loc, static_cast<std::underlying_type_t<T>>(index));
+  }
 };
 
 struct PyTypeModel;
@@ -647,6 +653,12 @@ struct PyTypeModel : PyObjectModelBase<PyTypeModel> {
   auto instanceSlotsPtr(mlir::Location loc) const {
     return field<Pointer<PyTupleModel, TbaaAccessType::TypeSlotsMember>>(loc,
                                                                          4);
+  }
+
+  /// Returns a model for accessing the slots of the function.
+  auto slotsArray(mlir::Location loc) const {
+    return field<Array<Pointer<PyObjectModel, TbaaAccessType::TupleElements>>>(
+        loc, 5);
   }
 };
 

--- a/src/pylir/Optimizer/PylirMem/IR/PylirMemOps.td
+++ b/src/pylir/Optimizer/PylirMem/IR/PylirMemOps.td
@@ -249,4 +249,23 @@ def PylirMem_InitObjectOp : PylirMem_Op<"initObject", [AlwaysBound,
   let assemblyFormat = "$memory attr-dict";
 }
 
+def PylirMem_InitTypeOp : PylirMem_Op<"initType", [AlwaysBound]> {
+
+  let arguments = (ins
+    Arg<MemoryType, "", [MemWrite]>:$memory,
+    DynamicType:$name,
+    Arg<MemoryType, "", [MemWrite]>:$mro_tuple_memory,
+    DynamicType:$mro_tuple,
+    DynamicType:$slots_tuple
+  );
+
+  let results = (outs DynamicType:$result);
+
+  let assemblyFormat = [{
+    $memory `(` `name` `=` $name `,`
+                `mro` `=` $mro_tuple_memory `to` $mro_tuple `,`
+                `slots` `=` $slots_tuple `)` attr-dict
+  }];
+}
+
 #endif

--- a/src/pylir/Optimizer/PylirPy/IR/PylirPyOps.td
+++ b/src/pylir/Optimizer/PylirPy/IR/PylirPyOps.td
@@ -810,6 +810,36 @@ def PylirPy_MakeObjectOp : PylirPy_Op<"makeObject", [AlwaysBound,
 // Type Ops
 //===----------------------------------------------------------------------===//
 
+def PylirPy_MakeTypeOp : PylirPy_Op<"makeType", [AlwaysBound,
+  KnownType<"Type">,
+]> {
+
+  let description = [{
+    Creates a new type object with the given name, MRO tuple and slots tuple.
+    The MRO tuple must be a tuple of type objects.
+    It is not captured, but rather copied with the result of the `makeType`
+    operation prepended.
+    The slots tuple must be a tuple of strings and is captured.
+  }];
+
+  let arguments = (ins
+    DynamicType:$name,
+    DynamicType:$mro_tuple,
+    DynamicType:$slots_tuple
+  );
+
+  let results = (outs
+    Res<DynamicType, "", [MemAlloc,
+      MemWrite<ObjectResource>,
+      MemWrite<ListResource>]>:$result);
+
+  let assemblyFormat = [{
+    `(` `name` `=` $name `,`
+        `mro` `=` $mro_tuple `,`
+        `slots` `=` $slots_tuple `)` attr-dict
+  }];
+}
+
 def PylirPy_TypeMROOp : PylirPy_Op<"type_mro", [NoMemoryEffect, AlwaysBound,
   ReturnsImmutable, KnownType<"Tuple">, NoCaptures]> {
   let arguments = (ins DynamicType:$type_object);

--- a/test/Optimizer/Conversion/PylirPyToPylirMem/make-ops.mlir
+++ b/test/Optimizer/Conversion/PylirPyToPylirMem/make-ops.mlir
@@ -214,3 +214,31 @@ py.func @make_float_fromF64(%arg0 : f64) -> !py.dynamic {
 // CHECK-NEXT: %[[MEM:.*]] = pyMem.gcAllocObject %[[FLOAT]][%[[LEN]]]
 // CHECK-NEXT: %[[RESULT:.*]] = pyMem.initFloat %[[MEM]] to %[[ARG]]
 // CHECK-NEXT: return %[[RESULT]]
+
+// -----
+
+// CHECK-DAG: #[[$TYPE_TYPE:.*]] = #py.globalValue<builtins.type{{,|>}}
+// CHECK-DAG: #[[$TUPLE_TYPE:.*]] = #py.globalValue<builtins.tuple{{,|>}}
+
+py.func @make_type(%name : !py.dynamic,
+                            %mro : !py.dynamic,
+                            %slots : !py.dynamic) -> !py.dynamic {
+  %0 = makeType(name=%name, mro=%mro, slots=%slots)
+  return %0 : !py.dynamic
+}
+
+// CHECK-LABEL: @make_type
+// CHECK-SAME: %[[NAME:[[:alnum:]]+]]
+// CHECK-SAME: %[[MRO:[[:alnum:]]+]]
+// CHECK-SAME: %[[INSTANCE_SLOTS:[[:alnum:]]+]]
+// CHECK-NEXT: %[[TYPE:.*]] = constant(#[[$TYPE_TYPE]])
+// CHECK-NEXT: %[[SLOTS:.*]] = type_slots %[[TYPE]]
+// CHECK-NEXT: %[[LEN:.*]] = tuple_len %[[SLOTS]]
+// CHECK-NEXT: %[[MEM:.*]] = pyMem.gcAllocObject %[[TYPE]][%[[LEN]]]
+// CHECK-NEXT: %[[TUPLE:.*]] = constant(#[[$TUPLE_TYPE]])
+// CHECK-NEXT: %[[MRO_LEN:.*]] = tuple_len %[[MRO]]
+// CHECK-NEXT: %[[ONE:.*]] = arith.constant 1 : index
+// CHECK-NEXT: %[[INC:.*]] = arith.addi %[[MRO_LEN]], %[[ONE]]
+// CHECK-NEXT: %[[MRO_MEM:.*]] = pyMem.gcAllocObject %[[TUPLE]][%[[INC]]]
+// CHECK-NEXT: %[[RESULT:.*]] = pyMem.initType %[[MEM]](name = %[[NAME]], mro = %[[MRO_MEM]] to %[[MRO]], slots = %[[INSTANCE_SLOTS]])
+// CHECK-NEXT: return %[[RESULT]]

--- a/test/Optimizer/Conversion/PylirToLLVM/initTypeOp.mlir
+++ b/test/Optimizer/Conversion/PylirToLLVM/initTypeOp.mlir
@@ -1,0 +1,32 @@
+// RUN: pylir-opt %s -convert-pylir-to-llvm --reconcile-unrealized-casts --split-input-file | FileCheck %s
+
+// CHECK-LABEL: func @test
+// CHECK-SAME: %[[MEMORY:[[:alnum:]]+]]
+// CHECK-SAME: %[[NAME:[[:alnum:]]+]]
+// CHECK-SAME: %[[MRO_MEMORY:[[:alnum:]]+]]
+// CHECK-SAME: %[[MRO:[[:alnum:]]+]]
+// CHECK-SAME: %[[SLOTS:[[:alnum:]]+]]
+py.func @test(%memory: !pyMem.memory,
+              %name : !py.dynamic,
+              %mro_tuple_memory: !pyMem.memory,
+              %mro : !py.dynamic,
+              %slots : !py.dynamic) -> !py.dynamic {
+  // CHECK: %[[TYPE:.*]] = llvm.mlir.addressof @builtins.type
+  // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[MEMORY]][0, 0]
+  // CHECK: llvm.store %[[TYPE]], %[[GEP]]
+
+  // Code prepending the type to MRO is here.
+
+  // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[MEMORY]][0, 3]
+  // CHECK: llvm.store %[[MRO_MEMORY]], %[[GEP]]
+  // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[MEMORY]][0, 4]
+  // CHECK: llvm.store %[[SLOTS]], %[[GEP]]
+
+  // TODO: Layout and offset computation.
+
+  // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[MEMORY]][0, 5]
+  // CHECK: %[[GEP2:.*]] = llvm.getelementptr %[[GEP]][0, 0]
+  // CHECK: llvm.store %[[NAME]], %[[GEP2]]
+  %0 = pyMem.initType %memory(name=%name, mro=%mro_tuple_memory to %mro, slots=%slots)
+  return %0 : !py.dynamic
+}


### PR DESCRIPTION
This op adds the ability to create new types required to implement python class statements. The current basic implementation takes three parameters: The name of the class, the MRO tuple and the instance slots tuple.