### PR TITLE
[builtins] Add `type.__new__` and `__build_class` implementations

### DIFF
--- a/src/pylir/Optimizer/Optimizer.cpp
+++ b/src/pylir/Optimizer/Optimizer.cpp
@@ -25,6 +25,7 @@ void pylir::registerOptimizationPipelines() {
       "Minimum pass pipeline to fully lower 'py' dialect, up until (exclusive) "
       "conversion to LLVM",
       [](mlir::OpPassManager& pm) {
+        pm.addPass(HIR::createClassBodyOutliningPass());
         pm.addPass(HIR::createFuncOutliningPass());
         mlir::OpPassManager* nested = &pm.nestAny();
         // This is supposed to be the minimum pipeline, so shouldn't really
@@ -46,6 +47,7 @@ void pylir::registerOptimizationPipelines() {
       "Optimization pipeline used by the compiler with lowering up until "
       "(exclusive) conversion to LLVM",
       [](mlir::OpPassManager& pm) {
+        pm.addPass(HIR::createClassBodyOutliningPass());
         pm.addPass(HIR::createFuncOutliningPass());
         pm.nestAny().addPass(mlir::createCanonicalizerPass());
         pm.addPass(createConvertPylirHIRToPylirPyPass());

--- a/src/pylir/Runtime/MarkAndSweep/MarkAndSweep.cpp
+++ b/src/pylir/Runtime/MarkAndSweep/MarkAndSweep.cpp
@@ -35,6 +35,8 @@ void mark(pylir::rt::PyObject* object) {
 
 template <class F>
 void introspectObject(pylir::rt::PyObject* object, F f) {
+  f(&type(*object));
+
   if (auto* tuple = object->dyn_cast<pylir::rt::PyTuple>()) {
     for (auto* iter : *tuple)
       if (iter)
@@ -52,7 +54,12 @@ void introspectObject(pylir::rt::PyObject* object, F f) {
       if (value)
         f(value);
     }
+  } else if (auto* type = object->dyn_cast<pylir::rt::PyTypeObject>()) {
+    f(&type->getLayoutType());
+    f(&type->getMROTuple());
+    f(&type->getInstanceSlots());
   }
+
   auto& slots = type(*object).getInstanceSlots();
   for (std::size_t i = 0; i < slots.len(); i++)
     if (auto* slot = object->getSlot(i))

--- a/src/pylir/Runtime/Objects/Objects.hpp
+++ b/src/pylir/Runtime/Objects/Objects.hpp
@@ -154,6 +154,10 @@ public:
   [[nodiscard]] PyTuple& getInstanceSlots() const noexcept {
     return *m_instanceSlots;
   }
+
+  [[nodiscard]] PyTypeObject& getLayoutType() const noexcept {
+    return *m_layoutType;
+  }
 };
 
 using PyUniversalCC = PyObject& (*)(PyFunction&, PyTuple&, PyDict&);

--- a/src/python/builtins.py
+++ b/src/python/builtins.py
@@ -45,6 +45,14 @@ def binary_method_call(method, self, other):
 class type:
     __slots__ = pylir.intr.type.__slots__
 
+    def __new__(cls, name, bases, dict, **kwargs):
+        # TODO: Assign instance slots from 'dict', assign slots of instance
+        #  from dict, create instance of metatype not 'type', add '__dict__'
+        #  and '__weakref__' slots by default, allow 0 len 'bases', set
+        #  dictionary, call '__set_name__' of descriptors and
+        #  '__init_subclass__' of 'super()'.
+        return pylir.intr.makeType(name, bases, ())
+
     def __call__(self, *args, **kwargs):
         # I usually try to avoid intrinsics where possible to have as much of a
         # readable and normal python code as possible but due to special
@@ -693,3 +701,14 @@ def next(*args):
         if len(args) == 2:
             return args[1]
         raise e
+
+
+@pylir.intr.const_export
+def __build_class__(func, name, /, *bases, metaclass=type, **kwds):
+    # TODO: Compute MRO order, compute metatype,
+
+    # TODO: Initialize dictionary with __prepare__.
+    d = {}
+    func(d)
+    bases = *bases, object
+    return metaclass(name, bases, d)

--- a/src/python/pylir/intr/__init__.pyi
+++ b/src/python/pylir/intr/__init__.pyi
@@ -22,3 +22,7 @@ def isUnboundValue(obj: object) -> bool:
 
 def mroLookup(mro_tuple, slot: int):
     pass
+
+
+def makeType(name: str, bases: tuple, slots: tuple):
+    pass

--- a/test/Execution/classes.py
+++ b/test/Execution/classes.py
@@ -1,11 +1,3 @@
-#  Licensed under the Apache License v2.0 with LLVM Exceptions.
-#  See https://llvm.org/LICENSE.txt for license information.
-#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-
-#  Licensed under the Apache License v2.0 with LLVM Exceptions.
-#  See https://llvm.org/LICENSE.txt for license information.
-#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-
 # RUN: pylir %s -o %t
 # RUN: %t | FileCheck %s
 

--- a/test/Execution/classes.py
+++ b/test/Execution/classes.py
@@ -1,0 +1,18 @@
+#  Licensed under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#  Licensed under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# RUN: pylir %s -o %t
+# RUN: %t | FileCheck %s
+
+class Test:
+    pass
+
+
+t = Test()
+# CHECK: <__main__.Test object at {{[[:alnum:]]+}}>
+print(t)


### PR DESCRIPTION
These are the most basic implementations necessary to create a new type that does not yet involve saving the namespace or inheritance. Nevertheless, type instances can be created now.