### PR TITLE
[builtins] Add `__dict__` creation

### DIFF
--- a/src/pylir/Optimizer/PylirPy/Transforms/ExpandPyDialect.cpp
+++ b/src/pylir/Optimizer/PylirPy/Transforms/ExpandPyDialect.cpp
@@ -104,6 +104,7 @@ struct TupleExUnrollPattern : mlir::OpRewritePattern<pylir::Py::MakeTupleExOp> {
         op.getLoc(), op.getArguments(), op.getIterExpansionAttr(),
         op.getNormalDestOperands(), op.getUnwindDestOperands(),
         op.getHappyPath(), op.getExceptionPath());
+    rewriter.setInsertionPointToStart(list.getHappyPath());
     rewriter.replaceOpWithNewOp<pylir::Py::ListToTupleOp>(op, list);
   }
 

--- a/test/Execution/classes.py
+++ b/test/Execution/classes.py
@@ -2,9 +2,32 @@
 # RUN: %t | FileCheck %s
 
 class Test:
-    pass
+    x = 3
 
 
 t = Test()
 # CHECK: <__main__.Test object at {{[[:alnum:]]+}}>
 print(t)
+
+# CHECK: True
+print(Test.x == 3)
+# CHECK: True
+print(t.x == 3)
+
+t.x = 5
+# CHECK: True
+print(Test.x == 3)
+# CHECK: True
+print(t.x == 5)
+
+
+class Test:
+    __slots__ = ('x', )
+
+
+t = Test()
+try:
+    t.x = 3
+except AttributeError:
+    # CHECK: Success
+    print('Success')


### PR DESCRIPTION
This PR adds the required code to 1) add `__dict__` to a types instance slots if `__slots__` wasn't present, 2) allocate the `__dict__` if it `__dict__` is in its instance slots and 3) miscellaneous bugs found during the implementation that we don't have a better way of testing.