### PR TITLE
[Transforms] Add DCE pass

### DIFF
--- a/src/pylir/Optimizer/Optimizer.cpp
+++ b/src/pylir/Optimizer/Optimizer.cpp
@@ -28,11 +28,7 @@ void pylir::registerOptimizationPipelines() {
         pm.addPass(HIR::createClassBodyOutliningPass());
         pm.addPass(HIR::createFuncOutliningPass());
         mlir::OpPassManager* nested = &pm.nestAny();
-        // This is supposed to be the minimum pipeline, so shouldn't really
-        // contain the canonicalizations, but the dialect conversion framework
-        // currently cannot deal with statically known dead code. Running the
-        // canonicalizer eliminates any such occurrences.
-        nested->addPass(mlir::createCanonicalizerPass());
+        nested->addPass(pylir::createDeadCodeEliminationPass());
         pm.addPass(createConvertPylirHIRToPylirPyPass());
 
         nested = &pm.nestAny();

--- a/src/pylir/Optimizer/Transforms/CMakeLists.txt
+++ b/src/pylir/Optimizer/Transforms/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(PylirTransforms
   FixpointPass.cpp
   LoadForwardingPass.cpp
   SROA.cpp
+  DeadCodeElimination.cpp
 )
 add_dependencies(PylirTransforms
   PylirTransformPassIncGen

--- a/src/pylir/Optimizer/Transforms/DeadCodeElimination.cpp
+++ b/src/pylir/Optimizer/Transforms/DeadCodeElimination.cpp
@@ -1,0 +1,60 @@
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <mlir/IR/RegionGraphTraits.h>
+#include <mlir/Pass/Pass.h>
+
+#include <llvm/ADT/DepthFirstIterator.h>
+
+#include <memory>
+
+namespace pylir {
+#define GEN_PASS_DEF_DEADCODEELIMINATIONPASS
+#include "pylir/Optimizer/Transforms/Passes.h.inc"
+} // namespace pylir
+
+using namespace mlir;
+
+namespace {
+class DeadCodeEliminationPass final
+    : public pylir::impl::DeadCodeEliminationPassBase<DeadCodeEliminationPass> {
+public:
+  using Base::Base;
+
+protected:
+  void runOnOperation() override;
+};
+
+} // namespace
+
+void DeadCodeEliminationPass::runOnOperation() {
+  bool changed = false;
+  getOperation()->walk<WalkOrder::PreOrder>([&](Region* region) {
+    if (region->empty())
+      return;
+
+    // Perform a DFS walk from the entry block giving us the set of alive basic
+    // blocks. The set is filled up by simply iterating through the range.
+    llvm::df_iterator_default_set<Block*> reachable;
+    llvm::for_each(llvm::depth_first_ext(&region->front(), reachable),
+                   [](auto&&) {});
+
+    // Any blocks not reachable can be erased without consequences.
+    for (Block& block : llvm::make_early_inc_range(region->getBlocks())) {
+      if (reachable.contains(&block))
+        continue;
+
+      m_blocksRemoved++;
+      block.dropAllDefinedValueUses();
+      block.erase();
+      changed = true;
+    }
+  });
+  if (!changed)
+    markAllAnalysesPreserved();
+}

--- a/src/pylir/Optimizer/Transforms/Passes.td
+++ b/src/pylir/Optimizer/Transforms/Passes.td
@@ -54,4 +54,13 @@ def ConditionalsImplicationsPass : Pass<"pylir-conditionals-implications"> {
   ];
 }
 
+def DeadCodeEliminationPass : Pass<"pylir-dce"> {
+  let summary = "Remove blocks without predecessors";
+
+  let statistics = [
+    Statistic<"m_blocksRemoved", "Number of blocks removed",
+      "Number of blocks that were removed as they no longer had any predecessors">
+  ];
+}
+
 #endif

--- a/test/Optimizer/Transforms/dce.mlir
+++ b/test/Optimizer/Transforms/dce.mlir
@@ -1,0 +1,10 @@
+// RUN: pylir-opt %s --split-input-file -pylir-dce
+
+// CHECK-LABEL: func @test
+// CHECK-NOT: ^{{.*}}:
+py.func @test()  {
+    return
+
+^bb1:
+    cf.br ^bb1
+}


### PR DESCRIPTION
Using MLIR's upstream canonicalization pass for dead code elimination is not always desirable. In a `-O0` pipeline we need DCE to be performed for the dialect conversion framework but do not want optimizations performed by canonicalization. The canonicalizer also performs other region simplifications that are undesirable but cannot be turned off separately from DCE.

A dedicated DCE pass serves both of these use cases.