### PR TITLE
[PylirToLLVMIR] Implement GC support for captures in closures

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -217,7 +217,7 @@ CheckOptions:
   readability-identifier-naming.MethodCase: camelBack
   # Ignoring methods from template specializations which obviously have to match, STL style methods, some LLVM style
   # methods etc.
-  readability-identifier-naming.MethodIgnoredRegexp: 'child_begin|child_end|push_back|emplace_back|insert(_.+)?|find(_.+)?|erase(_.+)?|isa(_.+)?|([a-z]+)_cast(_.+)?'
+  readability-identifier-naming.MethodIgnoredRegexp: '.*_begin|.*_end|push_back|emplace_back|insert(_.+)?|find(_.+)?|erase(_.+)?|isa(_.+)?|([a-z]+)_cast(_.+)?'
   readability-identifier-naming.FunctionCase: camelBack
   # Ignoring function overloads where the name obviously has to match.
   readability-identifier-naming.FunctionIgnoredRegexp: 'hash_value|isa(_.+)?|([a-z]+)_cast(_.+)?|LLVMFuzzerTestOneInput'

--- a/src/pylir/Optimizer/Conversion/PylirToLLVMIR/CodeGenState.cpp
+++ b/src/pylir/Optimizer/Conversion/PylirToLLVMIR/CodeGenState.cpp
@@ -284,7 +284,8 @@ void CodeGenState::initializeGlobal(LLVM::GlobalOp global, OpBuilder& builder,
     else
       value = getConstant(global.getLoc(), builder, element);
 
-    undef = builder.create<LLVM::InsertValueOp>(global.getLoc(), undef, value,
+    undef = builder.create<LLVM::InsertValueOp>(
+        global.getLoc(), undef, value,
         ArrayRef<std::int64_t>{slotsInStructIndex,
                                static_cast<std::int64_t>(index)});
   }

--- a/src/pylir/Optimizer/Conversion/PylirToLLVMIR/CodeGenState.hpp
+++ b/src/pylir/Optimizer/Conversion/PylirToLLVMIR/CodeGenState.hpp
@@ -583,15 +583,25 @@ struct PyFunctionModel : PyObjectModelBase<PyFunctionModel> {
     return field<Scalar<TbaaAccessType::FunctionPointer>>(loc, 1);
   }
 
+  // Returns a model for accessing the field denoting the size of all closure
+  // arguments combined as laid out in memory.
+  auto closureSizePtr(mlir::Location loc) const {
+    return field<Scalar<>>(loc, 2);
+  }
+
   /// Returns a model for accessing the slots of the function.
   auto slotsArray(mlir::Location loc) const {
     return field<Array<Pointer<PyObjectModel, TbaaAccessType::TupleElements>>>(
-        loc, 2);
+        loc, 3);
   }
 
   /// Returns a model for accessing the closure argument with the given index.
   auto closureArgument(mlir::Location loc, unsigned index) const {
-    return field<Scalar<>>(loc, 3 + index);
+    return field<Scalar<>>(loc, 4 + index);
+  }
+
+  auto refInClosureBitfield(mlir::Location loc, unsigned numClosureArgs) const {
+    return field<Array<Scalar<>>>(loc, 4 + numClosureArgs);
   }
 };
 

--- a/src/pylir/Optimizer/Conversion/PylirToLLVMIR/PylirTypeConverter.cpp
+++ b/src/pylir/Optimizer/Conversion/PylirToLLVMIR/PylirTypeConverter.cpp
@@ -110,6 +110,18 @@ mlir::LLVM::LLVMStructType pylir::PylirTypeConverter::getPyObjectType(
                             {m_objectPtrType});
 }
 
+unsigned
+pylir::PylirTypeConverter::getClosureArgsBytes(TypeRange closureArgsTypes) {
+  // Note that this is the same calculation as for the size of a struct type
+  // except that we do not care about padding at the end of the struct.
+  unsigned byteCount = 0;
+  for (Type type : closureArgsTypes) {
+    byteCount = llvm::alignTo(byteCount, getPlatformABI().getAlignOf(type));
+    byteCount += getPlatformABI().getSizeOf(type);
+  }
+  return byteCount;
+}
+
 mlir::LLVM::LLVMStructType pylir::PylirTypeConverter::getPyFunctionType(
     std::optional<unsigned int> slotSize, TypeRange closureArgsTypes) {
   assert((slotSize || closureArgsTypes.empty()) &&
@@ -129,9 +141,16 @@ mlir::LLVM::LLVMStructType pylir::PylirTypeConverter::getPyFunctionType(
     return type;
 
   SmallVector<Type> body{m_objectPtrType,
-                         mlir::LLVM::LLVMPointerType::get(&getContext())};
+      mlir::LLVM::LLVMPointerType::get(&getContext()),
+      IntegerType::get(&getContext(), 32),
+  };
   body.push_back(getSlotEpilogue(&getContext(), slotSize.value_or(0)));
   llvm::append_range(body, closureArgsTypes);
+  body.push_back(LLVM::LLVMArrayType::get(
+      IntegerType::get(&getContext(), 8),
+      llvm::divideCeil(getClosureArgsBytes(closureArgsTypes),
+                       8 * m_cabi->getSizeOf(m_objectPtrType))));
+
   [[maybe_unused]] LogicalResult result =
       type.setBody(body, /*isPacked=*/false);
   PYLIR_ASSERT(succeeded(result));

--- a/src/pylir/Optimizer/Conversion/PylirToLLVMIR/PylirTypeConverter.cpp
+++ b/src/pylir/Optimizer/Conversion/PylirToLLVMIR/PylirTypeConverter.cpp
@@ -140,7 +140,8 @@ mlir::LLVM::LLVMStructType pylir::PylirTypeConverter::getPyFunctionType(
   if (type.isInitialized())
     return type;
 
-  SmallVector<Type> body{m_objectPtrType,
+  SmallVector<Type> body{
+      m_objectPtrType,
       mlir::LLVM::LLVMPointerType::get(&getContext()),
       IntegerType::get(&getContext(), 32),
   };

--- a/src/pylir/Optimizer/Conversion/PylirToLLVMIR/PylirTypeConverter.hpp
+++ b/src/pylir/Optimizer/Conversion/PylirToLLVMIR/PylirTypeConverter.hpp
@@ -45,6 +45,10 @@ public:
   getPyFunctionType(std::optional<unsigned> slotSize = {},
                     mlir::TypeRange closureArgsTypes = {});
 
+  /// Returns the number of bytes 'closureArgsTypes' occupy within a converted
+  /// 'PyFunction'.
+  unsigned getClosureArgsBytes(mlir::TypeRange closureArgsTypes);
+
   /// Returns the LLVM representation for a 'tuple', optionally of the given
   /// length.
   mlir::LLVM::LLVMStructType

--- a/src/pylir/Runtime/MarkAndSweep/MarkAndSweep.cpp
+++ b/src/pylir/Runtime/MarkAndSweep/MarkAndSweep.cpp
@@ -58,6 +58,11 @@ void introspectObject(pylir::rt::PyObject* object, F f) {
     f(&type->getLayoutType());
     f(&type->getMROTuple());
     f(&type->getInstanceSlots());
+  } else if (auto* function = object->dyn_cast<pylir::rt::PyFunction>()) {
+    for (auto iter = function->closure_ref_begin(),
+              end = function->closure_ref_end();
+         iter != end; iter++)
+      f(*iter);
   }
 
   auto& slots = type(*object).getInstanceSlots();

--- a/test/Optimizer/Conversion/PylirToLLVM/function_getClosureArgOp.mlir
+++ b/test/Optimizer/Conversion/PylirToLLVM/function_getClosureArgOp.mlir
@@ -3,8 +3,8 @@
 // CHECK-LABEL: func @func_get_closure
 // CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
 py.func @func_get_closure(%arg0 : !py.dynamic) -> i32 {
-  // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[ARG0]][0, 5]
-  // CHECK-SAME: struct<{{.*}}, ({{.*}}, {{.*}}, {{.*}}, i32, i64, i32)>
+  // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[ARG0]][0, 6]
+  // CHECK-SAME: struct<{{.*}}, ({{.*}}, {{.*}}, {{.*}}, {{.*}}, i32, i64, i32{{.*}})>
   // CHECK: %[[LOADED:.*]] = llvm.load %[[GEP]]
   // CHECK-SAME: -> i32
   %0 = function_closureArg %arg0[2] : [i32, i64, i32]

--- a/test/Optimizer/Conversion/PylirToLLVM/gcAllocFunctionOp.mlir
+++ b/test/Optimizer/Conversion/PylirToLLVM/gcAllocFunctionOp.mlir
@@ -4,7 +4,7 @@
 py.func @foo(%arg0 : i32, %arg1 : !py.dynamic) -> !pyMem.memory {
   // CHECK: %[[NULL:.*]] = llvm.mlir.zero
   // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[NULL]][1]
-  // CHECK-SAME: !llvm.struct<"{{.*}}", (ptr<{{[0-9]+}}>, ptr, array<{{[0-9]+}} x ptr<{{[0-9]+}}>>, i32, ptr<{{[0-9]+}}>)>
+  // CHECK-SAME: !llvm.struct<"{{.*}}", (ptr<{{[0-9]+}}>, ptr, i32, array<{{[0-9]+}} x ptr<{{[0-9]+}}>>, i32, ptr<{{[0-9]+}}>, array<1 x i8>)>
   // CHECK: %[[SIZE:.*]] = llvm.ptrtoint %[[GEP]]
   // CHECK: %[[MEMORY:.*]] = llvm.call @pylir_gc_alloc(%[[SIZE]])
   // CHECK: "llvm.intr.memset"(%[[MEMORY]], %{{.*}}, %[[SIZE]])

--- a/test/Optimizer/Conversion/PylirToLLVM/globalFunctionObject.mlir
+++ b/test/Optimizer/Conversion/PylirToLLVM/globalFunctionObject.mlir
@@ -26,4 +26,6 @@ py.func @bar(%arg0 : !py.dynamic, %arg1 : !py.dynamic, %arg2 : !py.dynamic) -> !
 // CHECK-NEXT: %[[UNDEF1:.*]] = llvm.insertvalue %[[TYPE]], %[[UNDEF]][0]
 // CHECK-NEXT: %[[ADDRESS:.*]] = llvm.mlir.addressof @bar
 // CHECK-NEXT: %[[UNDEF2:.*]] = llvm.insertvalue %[[ADDRESS]], %[[UNDEF1]][1]
-// CHECK-NEXT: llvm.return %[[UNDEF2]]
+// CHECK-NEXT: %[[CLOSURE_SIZE:.*]] = llvm.mlir.constant(0 : i32)
+// CHECK-NEXT: %[[UNDEF3:.*]] = llvm.insertvalue %[[CLOSURE_SIZE]], %[[UNDEF2]][2]
+// CHECK-NEXT: llvm.return %[[UNDEF3]]

--- a/test/Optimizer/Conversion/PylirToLLVM/initFuncOp.mlir
+++ b/test/Optimizer/Conversion/PylirToLLVM/initFuncOp.mlir
@@ -8,16 +8,23 @@ py.func private @test(%arg0 : !py.dynamic, %arg1 : !py.dynamic, %arg2 : !py.dyna
 // CHECK-SAME: %[[MEM:[[:alnum:]]+]]
 // CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
 // CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
-py.func @make_function(%mem: !pyMem.memory, %arg0: i32, %arg1: !py.dynamic) -> !py.dynamic {
+py.func @make_function(%mem: !pyMem.memory, %arg0: !py.dynamic, %arg1: i32) -> !py.dynamic {
   // CHECK: %[[FUNC:.*]] = llvm.mlir.addressof @test
   // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[MEM]][0, 1]
   // CHECK: store %[[FUNC]], %[[GEP]]
-  // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[MEM]][0, 3]
-  // CHECK-SAME: struct<{{.*}}, ({{.*}}, {{.*}}, {{.*}}, i32, ptr<{{[0-9]+}}>)>
-  // CHECK: store %[[ARG0]], %[[GEP]]
+  // CHECK: %[[CLOSURE_SIZE:.*]] = llvm.mlir.constant({{(12|8)}} : i32)
+  // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[MEM]][0, 2]
+  // CHECK: store %[[CLOSURE_SIZE]], %[[GEP]]
   // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[MEM]][0, 4]
-  // CHECK-SAME: struct<{{.*}}, ({{.*}}, {{.*}}, {{.*}}, i32, ptr<{{[0-9]+}}>)>
+  // CHECK-SAME: struct<{{.*}}, ({{.*}}, {{.*}}, {{.*}}, {{.*}}, ptr<{{[0-9]+}}>, i32, array<1 x i8>)>
+  // CHECK: store %[[ARG0]], %[[GEP]]
+  // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[MEM]][0, 5]
+  // CHECK-SAME: struct<{{.*}}, ({{.*}}, {{.*}}, {{.*}}, {{.*}}, ptr<{{[0-9]+}}>, i32, array<1 x i8>)>
   // CHECK: store %[[ARG1]], %[[GEP]]
-  %1 = pyMem.initFunc %mem to @test[%arg0, %arg1 : i32, !py.dynamic]
+  // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[MEM]][0, 6]
+  // CHECK: %[[MASK:.*]] = llvm.mlir.constant(1 : i8)
+  // CHECK: %[[GEP2:.*]] = llvm.getelementptr %[[GEP]][0, 0]
+  // CHECK: store %[[MASK]], %[[GEP2]]
+  %1 = pyMem.initFunc %mem to @test[%arg0, %arg1 : !py.dynamic, i32]
   return %1 : !py.dynamic
 }


### PR DESCRIPTION
Objects captured by a closure have so far not been accounted for during garbage collection, meaning the GC would delete still reachable objects creating nasty side effects. This PR fixes that issue by adding a "reference mask" bitset at the end of a function object which denotes where references are contained within the closure arguments of a function object.