### PR TITLE
[Optimizer] Switch the `O0` pipeline to DCE

### DIFF
--- a/src/pylir/Optimizer/PylirHIR/Transforms/Passes.td
+++ b/src/pylir/Optimizer/PylirHIR/Transforms/Passes.td
@@ -18,7 +18,7 @@ def FuncOutliningPass : Pass<"pylir-func-outlining", "mlir::ModuleOp"> {
   }];
 }
 
-def ClassBodyOutliningPass : Pass<"pylir-class-body-outlining", "mlir::ModuleOp"> {
+def ClassBodyOutliningPass : Pass<"pylir-class-body-outlining"> {
   let dependentDialects = ["::pylir::Py::PylirPyDialect"];
 
   let description = [{


### PR DESCRIPTION
The pipeline previously used canonicalization which did optimization which 1) does not fit the purpose of the O0 pipeline (no optimization) and made us accidentally rely on a canonical form within lowering. One such case was found in the expand-py pass where it failed to legalize operations that usually did not occur due to canonicalizations.

Switching to DCE makes the lowering pass work on unoptimized IR and continues to satisfy the preconditions of dialect conversion; there mustn't be unreachable blocks